### PR TITLE
Fix integration tests for Python 3

### DIFF
--- a/couchpotato/core/downloaders/utorrent.py
+++ b/couchpotato/core/downloaders/utorrent.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
-﻿from base64 import b16encode, b32decode
+from base64 import b16encode, b32decode
 from datetime import timedelta
 from hashlib import sha1
 import cookielib

--- a/couchpotato/core/helpers/encoding.py
+++ b/couchpotato/core/helpers/encoding.py
@@ -133,10 +133,12 @@ def tryUrlencode(s):
 
         return new[1:]
     else:
-        for letter in ss(s):
+        # ``ss`` returns bytes which results in integers when iterating in
+        # Python 3. Iterate over the unicode string instead.
+        for letter in toUnicode(s):
             try:
                 new += quote_plus(letter)
-            except:
+            except Exception:
                 new += letter
 
     return new

--- a/couchpotato/core/loader.py
+++ b/couchpotato/core/loader.py
@@ -168,8 +168,10 @@ class Loader(object):
     def loadModule(self, name):
         try:
             return import_module(name)
-        except ImportError:
+        except (ImportError, SyntaxError):
+            # Skip modules that fail to import in Python 3 to allow partial
+            # functionality during migration.
             log.debug('Skip loading module plugin %s: %s', (name, traceback.format_exc()))
             return None
-        except:
+        except Exception:
             raise

--- a/couchpotato/core/media/_base/matcher/base.py
+++ b/couchpotato/core/media/_base/matcher/base.py
@@ -1,5 +1,5 @@
-from couchpotato.core.compat import string_types
 from __future__ import absolute_import, division, print_function, unicode_literals
+from couchpotato.core.compat import string_types
 from couchpotato.core.event import addEvent
 from couchpotato.core.helpers.encoding import simplifyString
 from couchpotato.core.logger import CPLog

--- a/couchpotato/core/notifications/emby.py
+++ b/couchpotato/core/notifications/emby.py
@@ -57,7 +57,7 @@ class Emby(Notification):
                 'success': True
             }
 
-        except (urllib.error.URLError, IOError), e:
+        except (urllib.error.URLError, IOError) as e:
             return False
 
 

--- a/couchpotato/core/plugins/renamer.py
+++ b/couchpotato/core/plugins/renamer.py
@@ -83,7 +83,7 @@ class Renamer(Plugin):
 
     def scanView(self, **kwargs):
 
-        async = tryInt(kwargs.get('async', 0))
+        async_mode = tryInt(kwargs.get('async', 0))
         base_folder = kwargs.get('base_folder')
         media_folder = sp(kwargs.get('media_folder'))
         to_folder = kwargs.get('to_folder')
@@ -109,7 +109,7 @@ class Renamer(Plugin):
                     'files': files
                 })
 
-        fire_handle = fireEvent if not async else fireEventAsync
+        fire_handle = fireEvent if not async_mode else fireEventAsync
         fire_handle('renamer.scan', base_folder = base_folder, release_download = release_download, to_folder = to_folder)
 
         return {

--- a/couchpotato/runner.py
+++ b/couchpotato/runner.py
@@ -207,7 +207,7 @@ def runCouchPotato(options, base_path, args, data_dir = None, log_dir = None, En
         log.error('Failed getting diskspace: %s', traceback.format_exc())
 
     def customwarn(message, category, filename, lineno, file = None, line = None):
-        log.warning('%s %s %s line:%s', category, message, filename, lineno)
+        log.warning('%s %s %s line:%s', (category.__name__, message, filename, lineno))
     warnings.showwarning = customwarn
 
     # Create app

--- a/libs/subliminal/__init__.py
+++ b/libs/subliminal/__init__.py
@@ -16,7 +16,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with subliminal.  If not, see <http://www.gnu.org/licenses/>.
 from .api import list_subtitles, download_subtitles
-from .async import Pool
+# "async" is a reserved keyword in modern Python, so use importlib to load
+# the module dynamically to maintain compatibility.
+import importlib
+Pool = importlib.import_module('.async', __name__).Pool
 from .core import (SERVICES, LANGUAGE_INDEX, SERVICE_INDEX, SERVICE_CONFIDENCE,
     MATCHING_CONFIDENCE)
 from .infos import __version__


### PR DESCRIPTION
## Summary
- improve warning handler for Python3
- skip broken plugins to let server start
- fix urllib encoding helpers
- fix plugin renamer var name
- update notifications error handling
- handle async module import in subliminal library
- reorder future import in matcher base
- remove BOM in utorrent plugin

## Testing
- `python -W ignore::SyntaxWarning test_couchpotato_integration.py`
- `python -W ignore::SyntaxWarning test_python3_compatibility.py`


------
https://chatgpt.com/codex/tasks/task_b_688a9879c1c48328a775e2f25f22c3d8