### PR TITLE
Fix docker compose command in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,19 @@ jobs:
     - name: Test Docker container
       run: |
         docker compose -f docker-compose.test.yml up -d
-        sleep 30
-        curl -f http://localhost:5050/ || exit 1
+        for i in {1..10}; do
+          if curl -fs http://localhost:5050/ > /dev/null; then
+            echo "Container is ready"
+            break
+          fi
+          if [ "$i" -eq 10 ]; then
+            echo "Container failed to start"
+            docker compose -f docker-compose.test.yml logs
+            docker compose -f docker-compose.test.yml down
+            exit 1
+          fi
+          sleep 10
+        done
         docker compose -f docker-compose.test.yml logs
         docker compose -f docker-compose.test.yml down
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,15 +99,15 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: Build Docker image
-      run: docker-compose -f docker-compose.test.yml build
+      run: docker compose -f docker-compose.test.yml build
 
     - name: Test Docker container
       run: |
-        docker-compose -f docker-compose.test.yml up -d
+        docker compose -f docker-compose.test.yml up -d
         sleep 30
         curl -f http://localhost:5050/ || exit 1
-        docker-compose -f docker-compose.test.yml logs
-        docker-compose -f docker-compose.test.yml down
+        docker compose -f docker-compose.test.yml logs
+        docker compose -f docker-compose.test.yml down
 
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- use `docker compose` instead of `docker-compose` in CI workflow

## Testing
- `python -W ignore::SyntaxWarning test_python3_compatibility.py` *(fails: ModuleNotFoundError: No module named 'six')*
- `python -W ignore::SyntaxWarning test_couchpotato_integration.py`

------
https://chatgpt.com/codex/tasks/task_b_688acce501a08328b14fc05b1f192704