### PR TITLE
fix: add explicit permissions to GitHub Actions workflows (SEC-001)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
 
@@ -28,6 +30,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
@@ -73,6 +78,8 @@ jobs:
 
   ui-unit-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
     
@@ -90,6 +97,9 @@ jobs:
 
   ui-e2e-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     needs: [test, ui-unit-tests]
     steps:
     - uses: actions/checkout@v4
@@ -137,6 +147,9 @@ jobs:
 
   accessibility:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     needs: ui-e2e-tests
     steps:
     - uses: actions/checkout@v4
@@ -183,6 +196,9 @@ jobs:
 
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     needs: test
 
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,9 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,10 @@ permissions:
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      actions: write
     env:
       HAS_DOCKER_CREDS: ${{ secrets.DOCKER_USERNAME != '' }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - uses: actions/checkout@v4
@@ -109,6 +111,10 @@ jobs:
 
   docker-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      actions: write
     needs: create-release
     env:
       HAS_DOCKER_CREDS: ${{ secrets.DOCKER_USERNAME != '' }}


### PR DESCRIPTION
## Summary
Resolves CodeQL alerts #47, #49, #51, #52, #53 — missing workflow permissions.

Adds explicit least-privilege `permissions` blocks to every job in:
- `.github/workflows/ci.yml` (lint, test, ui-unit-tests, ui-e2e-tests, accessibility, docker jobs)
- `.github/workflows/release.yml` (create-release, docker-release jobs)  
- `.github/workflows/docker.yml` (docker-build job)
- `.github/workflows/codeql.yml` (analyze job)

Permissions assigned by job role:
- Read-only jobs: `contents: read`
- Cache/artifact jobs: `contents: read`, `actions: write`
- Docker publish: `contents: read`, `packages: write`, `actions: write`
- Release creation: `contents: write`
- CodeQL: `contents: read`, `security-events: write`

No Python code changes.