### PR TITLE
fix: enable Jinja2 autoescape for classic UI templates (SEC-002)

### DIFF
--- a/couchpotato/__init__.py
+++ b/couchpotato/__init__.py
@@ -18,7 +18,8 @@ from couchpotato.environment import Env
 from fastapi import FastAPI, Request, Response, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
-from jinja2 import Environment as JinjaEnv, FileSystemLoader
+from jinja2 import Environment as JinjaEnv, FileSystemLoader, select_autoescape
+from markupsafe import Markup
 
 log = CPLog(__name__)
 
@@ -36,10 +37,13 @@ class CPJSONEncoder(json.JSONEncoder):
 
 def _cp_tojson(value):
     """Custom tojson filter that handles bytes values."""
-    return json.dumps(value, cls=CPJSONEncoder)
+    return Markup(json.dumps(value, cls=CPJSONEncoder))
 
 
-_jinja_env = JinjaEnv(loader=FileSystemLoader(_template_dir))
+_jinja_env = JinjaEnv(
+    loader=FileSystemLoader(_template_dir),
+    autoescape=select_autoescape(['html', 'xml']),
+)
 _jinja_env.filters['tojson'] = _cp_tojson
 _jinja_env.policies['json.dumps_kwargs'] = {'cls': CPJSONEncoder}
 

--- a/couchpotato/templates/database.html
+++ b/couchpotato/templates/database.html
@@ -8,7 +8,7 @@
 
         <script>
 
-            var api_base = '{{ Env.get('api_base') }}';
+            var api_base = {{ Env.get('api_base') | tojson }};
 
             var createList = function(name, documents){
                 var list;

--- a/couchpotato/templates/index.html
+++ b/couchpotato/templates/index.html
@@ -99,7 +99,7 @@
 
 			{% if Env.setting('show_wizard') %}
 				if(!window.location.href.contains('wizard'))
-					window.location = '{{ Env.get('web_base') }}wizard/'
+					window.location = {{ (Env.get('web_base') + 'wizard/') | tojson }}
 			{% endif %}
 
 		</script>

--- a/tests/unit/test_jinja_autoescape.py
+++ b/tests/unit/test_jinja_autoescape.py
@@ -1,0 +1,18 @@
+"""Tests for classic UI Jinja2 autoescape behavior."""
+
+from couchpotato import _jinja_env
+
+
+def test_classic_jinja_env_autoescape_enabled_for_html_and_xml():
+    """Classic UI templates should autoescape HTML/XML by extension."""
+    assert callable(_jinja_env.autoescape)
+    assert _jinja_env.autoescape("index.html") is True
+    assert _jinja_env.autoescape("feed.xml") is True
+    assert _jinja_env.autoescape("data.txt") is False
+
+
+def test_classic_jinja_env_escapes_variables_in_rendered_templates():
+    """Raw HTML from variables should be escaped by default."""
+    template = _jinja_env.from_string("{{ value }}")
+    rendered = template.render(value="<script>alert('xss')</script>")
+    assert rendered == "&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;"


### PR DESCRIPTION
## Summary
Resolves CodeQL alert #69 — Reflected XSS in classic UI Jinja2 templates.

### Changes
- **`couchpotato/__init__.py`**: Added `autoescape=select_autoescape(['html', 'xml'])` to `_jinja_env`. Updated `_cp_tojson` filter to return `Markup` so JSON output is correctly marked safe.
- **`couchpotato/templates/database.html`**: Switched `api_base` from string interpolation to `| tojson` to preserve JS correctness with autoescape.
- **`couchpotato/templates/index.html`**: Switched wizard redirect URL to `| tojson` for the same reason.
- **`tests/unit/test_jinja_autoescape.py`**: 2 new tests verifying autoescape is enabled and XSS payloads are escaped.

### Test results
627 passed ✅