### PR TITLE
chore: update python dependabot batch

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 -r requirements.txt
 
 pytest==9.0.3
-pytest-cov>=4.0
+pytest-cov>=7.1.0
 coverage==7.13.5
 httpx>=0.28.1
 ruff>=0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # CouchPotatoServer - Python dependencies
 
 # Web Framework
-fastapi==0.135.3
+fastapi==0.136.3
 starlette==1.0.0
 uvicorn==0.47.0
 Jinja2==3.1.6
@@ -9,14 +9,14 @@ python-multipart==0.0.29
 
 # Core Infrastructure
 blinker==1.9.0
-pydantic==2.12.5
-pydantic_core==2.41.5
+pydantic==2.13.4
+pydantic_core==2.46.4
 apscheduler==3.11.2
 tenacity==9.1.4
 
 # Network
 requests==2.33.1
-certifi==2026.2.25
+certifi==2026.5.20
 chardet==7.4.3
 
 # Parsing

--- a/specs/MAINT-2026-05-25-python-dependabot.md
+++ b/specs/MAINT-2026-05-25-python-dependabot.md
@@ -1,0 +1,56 @@
+# MAINT-2026-05-25: Python Dependabot Batch
+
+## Problem
+
+Dependabot opened five new Python dependency PRs after the 2026-05-24 maintenance pass:
+
+- #97 `pytest-cov >=7.1.0`
+- #98 `fastapi 0.136.3`
+- #99 `certifi 2026.5.20`
+- #100 `pydantic 2.13.4`
+- #101 `pydantic-core 2.47.0`
+
+PRs #100 and #101 are failing CI because Dependabot split a coupled dependency pair into incompatible pins:
+
+- `pydantic 2.13.4` requires `pydantic-core == 2.46.4`
+- `pydantic-core 2.47.0` is the newest standalone release, but it is not compatible with the current newest `pydantic` release
+
+## Scope
+
+Update the Python dependency pins in one coherent batch:
+
+- `requirements-dev.txt`: change `pytest-cov>=4.0` to `pytest-cov>=7.1.0`
+- `requirements.txt`: change `fastapi==0.135.3` to `fastapi==0.136.3`
+- `requirements.txt`: change `certifi==2026.2.25` to `certifi==2026.5.20`
+- `requirements.txt`: change `pydantic==2.12.5` to `pydantic==2.13.4`
+- `requirements.txt`: change `pydantic_core==2.41.5` to `pydantic_core==2.46.4`
+
+Do not apply `pydantic-core 2.47.0` unless PyPI metadata shows a matching `pydantic` release requires it.
+
+## Acceptance Criteria
+
+- Dependency installation succeeds without resolver conflicts.
+- Full Python unit tests pass.
+- Ruff passes.
+- UI unit tests still pass.
+- `npm audit --audit-level=moderate` still passes.
+- `git diff --check` passes.
+
+## Verification Commands
+
+Run these before handing back:
+
+```bash
+python3 -m pip install -r requirements.txt -r requirements-dev.txt
+python3 -m ruff check .
+python3 -m pytest tests/unit -q
+npm run test:unit
+npm audit --audit-level=moderate
+git diff --check
+```
+
+If Docker is available and not already validated in this session, also run:
+
+```bash
+./scripts/test-local.sh 3.14
+```


### PR DESCRIPTION
## Summary

Consolidates the 2026-05-25 Python Dependabot batch into one compatible dependency update.

Updates:
- `pytest-cov>=7.1.0`
- `fastapi==0.136.3`
- `certifi==2026.5.20`
- `pydantic==2.13.4`
- `pydantic_core==2.46.4`

Dependabot opened `pydantic` and `pydantic-core` separately, but the split PRs are incompatible. `pydantic 2.13.4` requires `pydantic-core==2.46.4`, so this intentionally does not apply `pydantic-core==2.47.0` yet.

## Verification

- `.venv/bin/python -m pip install -r requirements.txt -r requirements-dev.txt`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m pytest tests/unit -q` (`676 passed`)
- `npm run test:unit` (`19 passed`)
- `npm audit --audit-level=moderate`
- `git diff --check`
- `./scripts/test-local.sh 3.14` (`676 passed` in Docker)
