### PR TITLE
chore: let pydantic manage pydantic-core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ python-multipart==0.0.29
 # Core Infrastructure
 blinker==1.9.0
 pydantic==2.13.4
-pydantic_core==2.46.4
 apscheduler==3.11.2
 tenacity==9.1.4
 


### PR DESCRIPTION
## Summary
- remove the explicit pydantic_core pin from requirements.txt
- let pydantic resolve its required pydantic-core version from package metadata

## Verification
- .venv/bin/python -m pip install -r requirements.txt -r requirements-dev.txt
- .venv/bin/python -m pip check
- .venv/bin/python -m ruff check .
- .venv/bin/python -m pytest tests/unit -q
- git diff --check