### PR TITLE
Codex review isolation for malformed auth cookie commit

### DIFF
--- a/couchpotato/__init__.py
+++ b/couchpotato/__init__.py
@@ -70,7 +70,7 @@ def get_current_user(request: Request):
         if not user:
             return None
         api_key = Env.setting('api_key')
-        if api_key and hmac.compare_digest(str(user), str(api_key)):
+        if api_key and hmac.compare_digest(str(user).encode('utf-8'), str(api_key).encode('utf-8')):
             return user
         return None
     else:

--- a/tests/unit/test_fastapi_web.py
+++ b/tests/unit/test_fastapi_web.py
@@ -6,10 +6,12 @@ and template rendering via FastAPI's TestClient.
 import os
 import json
 import pytest
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 from fastapi.testclient import TestClient
 
+from couchpotato import get_current_user
 from couchpotato.api import addApiView, addNonBlockApiView, api, api_locks, api_nonblock, api_docs, api_docs_missing, callApiHandler
 from couchpotato.environment import Env
 
@@ -210,6 +212,15 @@ class TestAuthentication:
 
         assert resp.status_code in (302, 307)
         assert 'login' in resp.headers.get('location', '')
+
+    def test_auth_rejects_non_ascii_user_cookie(self, app, setup_env):
+        """Malformed user cookies are rejected without raising."""
+        setup_env['username'] = 'admin'
+        setup_env['password'] = 'secret'
+
+        user = get_current_user(SimpleNamespace(cookies={'user': 'é'}))
+
+        assert user is None
 
     def test_auth_accepts_api_key_user_cookie(self, app, setup_env):
         """The login cookie value is accepted only when it matches the API key."""


### PR DESCRIPTION
Temporary diagnostic PR to isolate the latest commit from #109 for Codex review.\n\nBase: 3f011a9894c099f1ccd59cf257fe74a02b0b3703, which Codex reviewed successfully on #109.\nHead: 68fe80b70f66e91b43626e0d28f057c0ca3c0318, where repeated @codex review attempts on #109 returned an unknown error.\n\nThis PR should not be merged; it exists only to test whether Codex can review the small final diff independently.