### PR TITLE
ci(docker): version released images from tag push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: Docker
 on:
   push:
     branches: [ master ]
+    tags: [ 'v*' ]
     paths-ignore:
       - '**.md'
       - 'docs/**'
@@ -58,9 +59,15 @@ jobs:
       id: vars
       run: |
         echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-        # Use nearest tag as base version so containers report a meaningful version
-        # e.g. "3.1.1" even if master is 2 commits ahead of the v3.1.1 tag
-        BASE_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+        # On a tag push (v*), use the tag directly so the released image is
+        # versioned correctly — the tag is created after the merge to master,
+        # so a master-push build would otherwise embed the *previous* version.
+        # On a branch push, fall back to the nearest tag.
+        if [ "${{ github.ref_type }}" = "tag" ]; then
+          BASE_TAG="${{ github.ref_name }}"
+        else
+          BASE_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+        fi
         BASE_TAG="${BASE_TAG#v}"  # strip leading 'v'
         BASE_TAG="${BASE_TAG:-dev}"  # fallback to 'dev' if empty
         echo "base_version=${BASE_TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem
`docker.yml` triggers on push to master and derives the image version from `git describe --tags`. The release tag is created *after* the merge, so the published image embeds the **previous** version until the workflow is manually re-run (this happened with v3.4.0 — the first build labeled the image 3.3.2).

## Fix
- Add a `tags: ['v*']` trigger so a build runs once the release tag exists.
- On tag builds, read the version directly from `github.ref_name` instead of `git describe` (exact, no ambiguity). Branch builds keep the `git describe` fallback.

## Result
Tagging `vX.Y.Z` produces a correctly-versioned image with no manual re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)