### PR TITLE
ci(security): add SAST gates — CodeQL/dependency-review/Trivy + ruff-S lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
     # is caught before release. ignore-unfixed keeps un-patchable upstream CVEs
     # from blocking unrelated PRs; .trivyignore suppresses the DS-0002 false +.
     - name: Scan image with Trivy
-      uses: aquasecurity/trivy-action@0.36.0
+      uses: aquasecurity/trivy-action@v0.36.0
       with:
         image-ref: couchpotato:test
         scanners: vuln

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,29 @@ jobs:
     - name: Run ruff
       run: ruff check .
 
+  # Static security lint (ruff's flake8-bandit "S" rules). INFORMATIONAL for now:
+  # the legacy codebase has ~169 S findings, so this does not gate merges yet.
+  # Triage the annotations and ratchet specific S codes into the blocking `lint`
+  # job (pyproject [tool.ruff.lint] select) as they're cleared.
+  security-lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Install ruff
+      run: pip install ruff>=0.15.16
+
+    - name: ruff security lint (bandit S rules)
+      continue-on-error: true
+      run: ruff check --select S --output-format=github couchpotato/ CouchPotato.py
+
   test:
     runs-on: ubuntu-latest
     permissions:
@@ -238,3 +261,18 @@ jobs:
         sleep 15
         curl -sf http://localhost:5050/ || (docker logs cp-test && exit 1)
         docker stop cp-test
+
+    # Image vulnerability scan (the manual pre-release Trivy step, now in CI).
+    # Alpine base targets 0 CVEs; fail on fixable HIGH/CRITICAL so a regression
+    # is caught before release. ignore-unfixed keeps un-patchable upstream CVEs
+    # from blocking unrelated PRs; .trivyignore suppresses the DS-0002 false +.
+    - name: Scan image with Trivy
+      uses: aquasecurity/trivy-action@0.36.0
+      with:
+        image-ref: couchpotato:test
+        scanners: vuln
+        severity: CRITICAL,HIGH
+        ignore-unfixed: true
+        trivyignores: .trivyignore
+        exit-code: '1'
+        format: table

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,28 @@
+name: Dependency Review
+
+# Fails a PR that introduces a dependency with a known vulnerability (or a
+# disallowed licence). Complements Dependabot (which only opens update PRs) and
+# CodeQL (which scans our own code, not our deps). Runs on PRs only — it diffs
+# the dependency graph between base and head, so PRs that touch no deps pass fast.
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v5.0.0
+        with:
+          # Block newly-introduced high/critical vulnerabilities.
+          fail-on-severity: high
+          # Surface a summary in the PR.
+          comment-summary-in-pr: on-failure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,17 @@ make setup → code → make verify → open PR → Claude review + remediate �
   check to pass + conversation resolution. No separate human approval is
   required (solo-maintainer setup), so the agent review *is* the review gate.
 - **Required CI checks:** `lint`, `test-summary`, `ui-unit-tests`,
-  `ui-e2e-tests`, `claude-review`.
+  `ui-e2e-tests`, `claude-review`, `Analyze (python)`, `Analyze (javascript)`,
+  `dependency-review`, `docker`.
+- **SAST / security gates:**
+  - **CodeQL** (`codeql.yml`) — Python + JS static analysis, per-PR + weekly.
+  - **dependency-review** (`dependency-review.yml`) — blocks PRs that add deps
+    with known high/critical vulns.
+  - **Trivy** image scan in the `docker` job — fails on fixable HIGH/CRITICAL
+    CVEs (`ignore-unfixed`, `.trivyignore` for the DS-0002 false positive).
+  - **security-lint** (ruff `S`/bandit) — INFORMATIONAL, non-blocking (~169
+    legacy findings); ratchet S codes into the blocking `lint` as cleared.
+  - Plus the `claude-review` prompt covers security qualitatively.
 - **Note:** GitHub only runs `claude-review` with its token once the workflow
   exists on `master`; the PR that introduces/edits it is a no-op (expected).
 - **Mutation testing** runs nightly + on-demand (*Mutation Testing* workflow),

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Path to production: make setup → code → make verify (auto-enforced on push)
 #                     → PR → Claude review + remediate → merge → release.
 
-.PHONY: help setup verify verify-fast test-py test-ui test-e2e lint mutation mutation-py mutation-js
+.PHONY: help setup verify verify-fast test-py test-ui test-e2e lint security-lint mutation mutation-py mutation-js
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -24,6 +24,9 @@ verify-fast: ## Quick gate — lint + unit only, skips E2E
 
 lint: ## ruff lint only
 	python3 -m ruff check .
+
+security-lint: ## Static security lint (ruff bandit "S" rules — informational)
+	python3 -m ruff check --select S couchpotato/ CouchPotato.py
 
 test-py: ## Python unit tests only
 	PYTHONPATH=libs python3 -m pytest tests/unit/ -q --tb=short

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -66,4 +66,10 @@ else
   step "4/4 E2E tests — SKIPPED (--no-e2e)"
 fi
 
+# ── Informational: static security lint (bandit S rules) ────────────────────
+# Non-blocking — legacy code has many findings; surfaced for awareness only.
+step "info: security lint (ruff S — non-blocking)"
+"$PYTHON" -m ruff check --select S --statistics couchpotato/ CouchPotato.py 2>/dev/null \
+  | tail -5 || true
+
 printf '\n\033[1;32m✔ All checks passed — safe to open a PR.\033[0m\n'


### PR DESCRIPTION
Hardens the pipeline's static security testing. Follow-up to #127.

## Changes
- **Trivy image scan** added to the `docker` CI job — fails on fixable HIGH/CRITICAL CVEs (`ignore-unfixed`, `.trivyignore` for the DS-0002 false positive). Moves the manual pre-release scan into CI.
- **`dependency-review.yml`** — blocks PRs that introduce dependencies with known high/critical vulnerabilities (complements Dependabot + CodeQL).
- **`security-lint` job** + `make security-lint` + a `verify.sh` footer — ruff `S`/flake8-bandit rules. **Informational / non-blocking**: the legacy codebase has ~169 `S` findings, so this surfaces them as annotations rather than gating. Plan: triage and ratchet specific `S` codes into the blocking `lint` job as they're cleared.
- **CodeQL** already existed (Python + JS); this PR + the branch-protection change make it an enforced gate.

## Becoming required checks (branch protection)
`Analyze (python)`, `Analyze (javascript)`, `dependency-review`, `docker` — added on top of the existing `lint, test-summary, ui-unit-tests, ui-e2e-tests, claude-review`.

## Note
`claude-review` will run a **real** review on this PR (the workflow is now on `master` as of #127).

🤖 Generated with [Claude Code](https://claude.com/claude-code)