### PR TITLE
ci: make claude-review always post a visible verdict

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -35,10 +35,13 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Keep one updating summary comment per PR (visible verdict even when
+          # the review is clean — otherwise a clean review looks like a no-op).
+          use_sticky_comment: true
           prompt: |
             Review the changes in this pull request as a principal engineer for
             CouchPotatoServer (Python 3.10+ FastAPI media server; see CLAUDE.md
-            and AGENTS.md for project rules). Post your findings as inline PR
+            and AGENTS.md for project rules). Post specific findings as inline PR
             review comments, grouped by severity.
 
             Focus on:
@@ -51,5 +54,8 @@ jobs:
             - Adherence to project rules: ruff-clean, conventional commits, no
               committed secrets/test data, E2E specs updated for UI changes.
 
-            Be specific and actionable. If the change looks safe and complete,
-            say so plainly rather than inventing nits.
+            ALWAYS post a brief summary comment with an explicit overall verdict —
+            start it with `✅ LGTM` or `⚠️ Changes requested` — even when there
+            are no issues, so the review is clearly visible. Be specific and
+            actionable; if the change is safe and complete, say so plainly rather
+            than inventing nits.


### PR DESCRIPTION
Small follow-up to #128. On a clean PR the Claude review currently posts nothing (no inline comments + sticky summary off), so a successful review is indistinguishable from a no-op.

- `use_sticky_comment: true` — one updating summary comment per PR.
- Prompt now requires an explicit overall verdict (`✅ LGTM` / `⚠️ Changes requested`) even when there are no issues.

Takes effect on the next PR after this merges (workflow-on-master rule). This PR itself is a good live test — Claude should leave a visible verdict on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)