### PR TITLE
ci: allow claude-review to post comments (fix permission_denials)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -38,11 +38,21 @@ jobs:
           # Keep one updating summary comment per PR (visible verdict even when
           # the review is clean — otherwise a clean review looks like a no-op).
           use_sticky_comment: true
+          # The GitHub comment MCP tools are NOT in agent mode's default allow
+          # list, so without this the agent's posting attempts are denied
+          # (permission_denials) and it silently posts nothing. Allow the inline
+          # + sticky comment tools, plus gh as a fallback for the summary.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_comment__update_claude_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
             Review the changes in this pull request as a principal engineer for
             CouchPotatoServer (Python 3.10+ FastAPI media server; see CLAUDE.md
             and AGENTS.md for project rules). Post specific findings as inline PR
-            review comments, grouped by severity.
+            review comments (mcp__github_inline_comment__create_inline_comment),
+            grouped by severity.
 
             Focus on:
             - Correctness and edge cases, especially around the SQLite adapter


### PR DESCRIPTION
Follow-up to #129/#131. The Claude reviewer runs and analyses deeply (34 turns on #131) but **posts nothing** — the job shows `permission_denials_count: 9` and `No buffered inline comments`.

**Root cause** (confirmed against the anthropics/claude-code-action docs): the GitHub comment MCP tools are **not** in agent mode's default allowed-tools set, so the agent's posting calls are denied — independent of the workflow's `issues: write` token scope.

**Fix:**
- `claude_args: --allowedTools "mcp__github_inline_comment__create_inline_comment, mcp__github_comment__update_claude_comment, Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*)"` — lets the agent post inline findings + the sticky summary (with `gh pr comment` as a fallback).
- Pass `REPO` / `PR NUMBER` context in the prompt (recommended by the docs).

**Note on verification:** like all workflow changes here, this only takes effect once it's on `master` (GitHub's workflow-validation rule), so this PR's own review still runs the old config. I'll confirm it works by opening a tiny test PR right after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)