### PR TITLE
docs(design-system): add canonical design system + conformance checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,8 @@ Write failing tests first, then code to make them pass. Tests should meet a **pr
 |---|---|---|
 | Database | SQLite via `SQLiteAdapter` | Replaced CodernityDB (unmaintained, Python 3 issues) |
 | Web framework | FastAPI/Uvicorn | Replaced Tornado — modern async, better typing |
-| UI | htmx + Tailwind + Alpine.js | `/` = new UI, `/old/` = classic UI |
+| UI | htmx + Tailwind + Alpine.js | `/` = new UI (the only UI; legacy `/old/` is being retired — see `specs/UI-MIGRATION.md`) |
+| UI design system | `docs/design-system/README.md` is the **visual source of truth** | Tokens, typography, iconography (Heroicons), components, motion, a11y — extracted from `base.html`. Conform new UI against `docs/design-system/CONFORMANCE.md`. |
 | Container base | `python:3.14-alpine` + `su-exec` | Debian base carried ~119 OS-package CVEs (many HIGH/CRITICAL, no upstream fix); Alpine ships **0**. Healthcheck uses Python `urllib` so no `curl`/`libcurl` in the image. |
 
 ### Database Patterns

--- a/docs/design-system/CONFORMANCE.md
+++ b/docs/design-system/CONFORMANCE.md
@@ -5,10 +5,12 @@ and partial must satisfy these. Each conformance PR should tick the relevant
 boxes and add tests (vitest unit for extracted logic, Playwright e2e, axe a11y).
 
 ## Tokens & theme
-- [ ] Tailwind `cp.*` colors match the README config exactly (accent `#35c5f4`, hover `#4dd4ff`, success/warning/danger fixed).
-- [ ] CSS custom properties on `:root` / `:root.light` match the dark/light table.
-- [ ] Light-mode `.text-cp-accent` override to `#0e7490` is present (AA contrast).
-- [ ] Translucent layers invert correctly in light mode (`white/[0.0x]` → black-based).
+Exact values live in [`README.md`](./README.md) (source of truth) — this checklist
+deliberately does not repeat hex values, so it can't drift out of sync.
+- [ ] Tailwind `cp.*` colors match the README config exactly (accent, hover, and the fixed success/warning/danger).
+- [ ] CSS custom properties match the README dark/light table: **`:root` holds the DARK values (the default)** and **`:root.light` holds the LIGHT values** — not inverted.
+- [ ] Light-mode `.text-cp-accent` contrast override is present (the AA value in the README tokens section).
+- [ ] Translucent layers invert correctly in light mode (`white/[0.0x]` → black-based, per README).
 - [ ] Theme toggle flips `.light` on `<html>`, persists `localStorage['cp-theme']`, respects `prefers-color-scheme` on first load.
 
 ## Typography
@@ -39,7 +41,7 @@ boxes and add tests (vitest unit for extracted logic, Playwright e2e, axe a11y).
 - [ ] `prefers-reduced-motion: reduce` collapses animation to ~0ms.
 
 ## Accessibility (axe-clean)
-- [ ] `:focus-visible` → `2px solid #35c5f4`, `outline-offset: 2px`; suppressed on mouse.
+- [ ] `:focus-visible` → `2px solid` accent ring + `outline-offset: 2px` (accent value per README); suppressed on mouse.
 - [ ] Skip link ("Skip to main content"), first tab stop, off-screen until focused.
 - [ ] `aria-current` on active nav; `aria-label` on every icon-only button; `aria-hidden` on decorative SVGs.
 - [ ] `role` + `aria-live` on toasts/status; `aria-modal` + focus trap on dialogs; `sr-only` for hidden labels.

--- a/docs/design-system/CONFORMANCE.md
+++ b/docs/design-system/CONFORMANCE.md
@@ -1,0 +1,51 @@
+# Design System Conformance Checklist
+
+Derived from [`README.md`](./README.md) (the source of truth). Every new-UI page
+and partial must satisfy these. Each conformance PR should tick the relevant
+boxes and add tests (vitest unit for extracted logic, Playwright e2e, axe a11y).
+
+## Tokens & theme
+- [ ] Tailwind `cp.*` colors match the README config exactly (accent `#35c5f4`, hover `#4dd4ff`, success/warning/danger fixed).
+- [ ] CSS custom properties on `:root` / `:root.light` match the dark/light table.
+- [ ] Light-mode `.text-cp-accent` override to `#0e7490` is present (AA contrast).
+- [ ] Translucent layers invert correctly in light mode (`white/[0.0x]` → black-based).
+- [ ] Theme toggle flips `.light` on `<html>`, persists `localStorage['cp-theme']`, respects `prefers-color-scheme` on first load.
+
+## Typography
+- [ ] Single family **Inter** (300/400/500/600/700); no Open Sans / Lobster.
+- [ ] Global `letter-spacing: -0.01em`; headings `tracking-tight`; hero `-0.03em`.
+- [ ] Scale used as specified (hero `text-5xl/600`, h2 `text-3xl/600`, body `text-sm–base`, labels `text-[13px]/500`, captions `text-xs`/`text-[10px]`).
+
+## Iconography
+- [ ] All icons are inline **Heroicons (outline)**, 24×24, `stroke-width="1.5"`, `stroke="currentColor"`, `fill="none"`.
+- [ ] No legacy icon-font glyphs remain (map per README table). Decorative icons get `aria-hidden="true"`.
+- [ ] `sunglasses` / `coffee` drawn fresh as 24×24 stroke-1.5 to match.
+
+## Components
+- [ ] **Buttons** — primary / ghost / danger variants with hover + focus states.
+- [ ] **Inputs** — the 10 field types (`string`, `int`/`float`, `password`, `dropdown`, `bool`, `directory`, `directories`, `combined`, `button`) follow the field grammar; helper text + `<details>` learn-more.
+- [ ] **Toggle switch** — `role="switch"` + `:aria-checked`, correct track/knob classes.
+- [ ] **Status & quality badges** — pill classes per status (wanted/done/snatched/quality).
+- [ ] **Toasts** — Alpine `toast(msg,type,duration)` queue, `aria-live="polite"`, auto-dismiss + manual close.
+- [ ] **Poster card** — structure, lazy img + gradient fallback, badges, hover checkbox + refresh, hover glow.
+- [ ] **Release table** — header/data row styles, mono numerics, seed color by health.
+- [ ] **Modals** — `role="dialog" aria-modal="true"`, scrim, header/body/footer; Escape closes, scrim-click dismisses, Tab trapped; restart banner; directory browser.
+
+## States
+- [ ] Spinner (`animate-spin`), skeleton (pulse), empty (icon + message), error (`exclamation-triangle` + message), htmx indicator.
+
+## Motion
+- [ ] `fade-in` for swapped content; 150ms hover / 200ms fade / 300ms sidebar.
+- [ ] `prefers-reduced-motion: reduce` collapses animation to ~0ms.
+
+## Accessibility (axe-clean)
+- [ ] `:focus-visible` → `2px solid #35c5f4`, `outline-offset: 2px`; suppressed on mouse.
+- [ ] Skip link ("Skip to main content"), first tab stop, off-screen until focused.
+- [ ] `aria-current` on active nav; `aria-label` on every icon-only button; `aria-hidden` on decorative SVGs.
+- [ ] `role` + `aria-live` on toasts/status; `aria-modal` + focus trap on dialogs; `sr-only` for hidden labels.
+
+## Coding standards (every PR)
+- **Security:** no secrets/XSS (`x-html` only on trusted/escaped content), input validation preserved.
+- **Accessibility:** axe suite green; keyboard reachable.
+- **Supportability/Maintainability:** pure logic extracted into tested `couchpotato/static/scripts/ui/` modules; no new framework/CSS-in-JS/component lib.
+- **TDD:** failing test first → implement → green; principal-dev standard.

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -1,0 +1,182 @@
+# Handoff: CouchPotato Design System (v3 / htmx UI)
+
+## Overview
+This package documents the **canonical design system for the modern CouchPotato web UI** — the htmx + Alpine + Tailwind interface under `couchpotato/ui/`. It defines colour, typography, spacing, iconography, components, motion, and accessibility so the modern UI can be built/extended consistently and the legacy MooTools UI (`/old/`, `couchpotato/static/style/*.scss`) can be retired.
+
+The system was **extracted directly from the existing codebase** (`couchpotato/ui/templates/base.html` and the `partials/`), so most tokens below already exist in the app. Treat this README as the source of truth when adding new screens or refactoring old ones.
+
+## About the Design Files
+The `*.dc.html` files in this bundle are **design references** — interactive HTML prototypes showing the intended look and behaviour. They are **not** production code to copy verbatim.
+
+Your target environment already exists: **Jinja2 templates + htmx 2 + Alpine 3 + Tailwind (CDN) + Inter**. Recreate anything from these references using that stack and the conventions already in `couchpotato/ui/templates/` — Tailwind utility classes, Alpine `x-data` components, htmx attributes, and the `cp.*` colour tokens. Do not introduce a new framework, CSS-in-JS, or a component library.
+
+## Fidelity
+**High-fidelity.** Colours, type, spacing, radii, and states are final and exact. Match them precisely; they mirror values already in `base.html`.
+
+---
+
+## Design Tokens
+
+### Tailwind config (already in `base.html` — keep as-is)
+```js
+tailwind.config = {
+  darkMode: 'class',
+  theme: { extend: {
+    fontFamily: { sans: ['Inter', 'sans-serif'] },
+    colors: { cp: {
+      bg: 'var(--cp-bg)', card: 'var(--cp-card)', surface: 'var(--cp-surface)',
+      border: 'var(--cp-border)', text: 'var(--cp-text)', muted: 'var(--cp-muted)',
+      accent: '#35c5f4', accentHover: '#4dd4ff',
+      success: '#3ddc84', warning: '#e5a00d', danger: '#f04848', blue: '#35c5f4',
+    } }
+  } }
+}
+```
+
+### Theme variables (CSS custom properties on `:root` / `:root.light`)
+Dark is the default; `<html class="light">` switches the theme. Persist the choice to `localStorage['cp-theme']`.
+
+| Token | Role | Dark | Light |
+|---|---|---|---|
+| `--cp-bg` | app background | `#0d0d0d` | `#f5f5f7` |
+| `--cp-surface` | inset / inputs | `#111113` | `#fafafa` |
+| `--cp-card` | card surface | `#161618` | `#ffffff` |
+| `--cp-border` | dividers, borders | `#1e1e22` | `#e0e0e4` |
+| `--cp-text` | primary text | `#e0e0e4` | `#1a1a1a` |
+| `--cp-muted` | secondary text | `#9b9ba8` | `#666666` |
+
+**Accent (brand):** `#35c5f4` cyan. Hover `#4dd4ff`.
+**Accent-as-text contrast rule:** cyan text fails AA on light tints, so in light mode `.text-cp-accent` is overridden to **`#0e7490`** (same hue, sufficient contrast). Keep this override.
+
+**Semantic (fixed across themes):** success `#3ddc84` · warning `#e5a00d` · danger `#f04848`.
+
+**Translucent layers** (borders/fills, used heavily as `white/[0.0x]` in dark): in light mode invert to black-based — e.g. `border-white/[0.04]` → `rgba(0,0,0,0.08)`, `bg-white/[0.03]` → `rgba(0,0,0,0.04)`. These overrides already exist in `base.html`.
+
+### Typography
+- **Family:** `Inter` (Google Fonts, weights 300/400/500/600/700). Single family — no secondary face. (The legacy Open Sans + Lobster pairing is retired.)
+- **Global tracking:** `letter-spacing: -0.01em` on `*`; headings tighten further (`tracking-tight`, ~`-0.02em`; hero `-0.03em`).
+- **Scale (as used):** hero `text-5xl/600`, section h2 `text-3xl/600`, body `text-sm–base/300`, labels `text-[13px]/500`, captions `text-xs`/`text-[10px]` muted, mono captions in JetBrains Mono (docs only — app uses Inter).
+
+### Spacing & radius
+- **Spacing:** Tailwind 4px scale. Common: `gap-2`(8) `gap-3`(12) `p-2.5`(10) `p-4`(16) `px-3 py-2` for controls.
+- **Radius:** `rounded`(4px) for nav items, `rounded-md`(6px) inputs/buttons, `rounded-lg`(8px) toasts, `rounded-xl`(12px) modals/cards.
+- **Layout:** sidebar `w-56` (224px), collapses to `w-16` (64px); mobile top bar `h-12`, bottom nav.
+
+### Surfaces & elevation
+Depth = three near-black layers (`bg` → `surface` → `card`) + translucent borders. Floating chrome (sidebar, top bar) uses `bg-black/80 backdrop-blur-xl` (light: `bg-white/85`). Cards sit flat; only the poster card gets an accent glow on hover (`box-shadow: 0 0 20px rgba(53,197,244,0.06)`).
+
+---
+
+## Iconography
+The app uses **Heroicons (outline)** inline as SVG — 24×24, `stroke-width="1.5"`, `stroke="currentColor"`, `fill="none"`, decorative ones get `aria-hidden="true"`. No icon font.
+
+The legacy UI's 30-glyph icon font maps to these Heroicons. When porting old screens, swap each glyph for its equivalent:
+
+| Legacy glyph | Heroicon (outline) |
+|---|---|
+| `icon-home` | home |
+| `icon-movie` | film |
+| `icon-search` | magnifying-glass |
+| `icon-settings` | cog-6-tooth |
+| `icon-menu` | bars-3 |
+| `icon-handle` | bars-2 |
+| `icon-dots` | ellipsis-horizontal |
+| `icon-dropdown` | chevron-down |
+| `icon-left-arrow` | arrow-left |
+| `icon-plus` | plus |
+| `icon-download` | arrow-down-tray |
+| `icon-refresh` | arrow-path |
+| `icon-redo` | arrow-uturn-right |
+| `icon-delete` | trash |
+| `icon-cancel` | x-mark |
+| `icon-ok` | check |
+| `icon-play` | play |
+| `icon-eye` | eye |
+| `icon-donate` | heart |
+| `icon-notifications` | bell |
+| `icon-info` | information-circle |
+| `icon-error` | exclamation-triangle |
+| `icon-thumb` | squares-2x2 (grid view) |
+| `icon-list` | list-bullet |
+| `icon-filter` | funnel |
+| `icon-star` / `star-empty` / `star-half` | star (outline; fill with accent; half via 50% linear-gradient fill) |
+| `icon-emo-cry` | face-frown (empty states) |
+| `icon-emo-sunglasses` | face-smile, or a custom sunglasses glyph in the same line style |
+| `icon-emo-coffee` | custom coffee-cup glyph in the same line style |
+
+The two glyphs with no Heroicon (`sunglasses`, `coffee`) should be drawn fresh as 24×24 / stroke-1.5 paths to match. Exact path data for every icon is in the reference file's `iconGroups` array.
+
+---
+
+## Components
+
+All examples use existing Tailwind/`cp.*` tokens. Hover/focus states are required.
+
+### Buttons
+- **Primary:** `bg-cp-accent text-cp-bg rounded-lg px-4 py-2 text-sm font-semibold hover:bg-cp-accentHover`
+- **Ghost (secondary):** `border border-cp-border text-cp-text rounded-lg px-4 py-2 hover:bg-white/[0.03]`
+- **Danger:** `border border-cp-danger/30 text-cp-danger hover:bg-cp-danger/10`
+
+### Inputs (settings field grammar)
+`w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30`. Helper text `text-[10px] text-cp-muted mt-1.5`. Optional `<details>` "Learn more" disclosure (`summary` in `text-cp-accent`).
+
+**10 field types** (from `partials/settings/field_types.html`): `string` · `int`/`float` (number) · `password` · `dropdown` (select) · `bool` (checkbox, `text-cp-accent` accent) · `directory` (input + Browse button → folder modal) · `directories` (repeatable rows with remove + "+ Add folder") · `combined` (multi-column rows: a `use` toggle switch + text inputs, headers, "+ Add") · `button` (async action: spinner + inline success/error result).
+
+**Toggle switch:** `w-8 h-4 rounded-full` track (`bg-cp-accent` on / `bg-white/[0.08]` off), `role="switch" :aria-checked`, knob `w-3 h-3 bg-white` translating `translate-x-4` / `translate-x-0.5`.
+
+**Settings row layout:** label + hint on the left, control right-aligned; rows divided by `border-white/[0.04]`.
+
+### Status & quality badges
+Pill `px-1.5 py-0.5 rounded text-[9px] font-medium`: wanted `bg-cp-blue/20 text-cp-blue` · done `bg-cp-success/20 text-cp-success` · snatched `bg-cp-warning/20 text-cp-warning` · quality `bg-white/10 text-white/80 backdrop-blur-sm`.
+
+### Toasts
+Global Alpine `toast(msg, type, duration)` queue, top-right, `aria-live="polite"`. `bg-green-600`/`bg-red-600`/`bg-cp-accent text-cp-bg` for success/error/info. Auto-dismiss (default 3000ms) + manual close.
+
+### Poster card (`partials/movie_cards.html`)
+`poster-card rounded-md overflow-hidden bg-cp-card border border-white/[0.05] group`. `aspect-[2/3]` poster with lazy `<img>` + gradient fallback; status badge top-right, quality badge over a bottom `from-black/90` gradient; title `text-xs font-medium truncate`, year `text-[10px] text-cp-muted`. Hover reveals a bulk-select checkbox (top-left) and a refresh button (bottom-right). Hover glow on `.poster-card`.
+
+### Release table
+Header row `font-medium text-xs text-cp-muted border-b border-cp-border`; data rows `border-white/[0.04]`, numerics (size/seeds) in mono; seed colour by health (success / muted / warning).
+
+### Modals & overlays (`partials/settings/modals.html`)
+`role="dialog" aria-modal="true"` on a `bg-black/60` scrim, centered, `bg-cp-card rounded-xl border border-white/[0.05] w-full max-w-lg`. **Header** (title + close X) / **scrollable body** (`max-h-[80vh]` or `max-h-[400px]`) / **footer** (right-aligned Cancel + primary). Required behaviours: Escape closes, scrim-click dismisses, Tab is trapped within. Also: **restart banner** (`bg-cp-warning/20 border-cp-warning/30`, fixed bottom-center) and the **directory browser** modal (Up button + mono path + folder list).
+
+### States
+- **Spinner:** shared SVG circle, `animate-spin`, `text-cp-accent` / `text-cp-muted`.
+- **Skeleton:** `bg-cp-border` blocks, pulse animation, while posters load.
+- **Empty:** centered muted icon + message ("No movies found", "No results found", "No notifications (yet)", "Empty folder").
+- **Error:** `exclamation-triangle` in `text-cp-danger` + message.
+- **htmx indicator:** `.htmx-indicator` hidden until `.htmx-request`.
+
+---
+
+## Interactions & Behaviour
+- **Theme toggle:** toggles `.light` on `<html>`, persists `localStorage['cp-theme']`, respects `prefers-color-scheme` on first load.
+- **Sidebar:** collapsible (`w-56`↔`w-16`, 300ms); active link gets `bg-cp-accent/10 text-cp-accent` + `aria-current="page"`.
+- **htmx:** content swaps in place; global `htmx:afterRequest` listener fires toasts for `movie.add`, `media.delete`, `movie.searcher.single`, `movie.refresh`.
+- **Search → add:** result card opens a movie-info modal; profile `<select>` lazy-loads via `hx-get`; Add button shows adding/added state.
+
+## Motion
+Restrained and fast. `fade-in` (opacity 0→1, translateY 4px→0, 0.2s ease-out) for swapped content. Transitions: **150ms** colour/hover, **200ms** fades, **300ms** sidebar collapse. Honour `prefers-reduced-motion: reduce` — collapse all animation/scroll to ~0ms (already in `base.html`).
+
+## Accessibility
+Built-in, with a Playwright + axe suite. Rules every component follows:
+- `:focus-visible` → `2px solid #35c5f4`, `outline-offset: 2px`; suppress on mouse (`:focus:not(:focus-visible)`).
+- **Skip link** ("Skip to main content") — off-screen until focused, first tab stop.
+- `aria-current` on active nav; `aria-label` on every icon-only button; `aria-hidden` on decorative SVGs.
+- `role` + `aria-live` on toasts/status regions; `aria-modal` + focus trap on dialogs; `sr-only` for visually-hidden labels.
+- Light-mode accent contrast override (`#0e7490`) — see tokens.
+
+## Migration: legacy → modern
+**Carry over:** poster grid + status badges, release table, quality profiles, star ratings (half-star), dark/light theming concept.
+**Leave behind:** Lobster wordmark, Open Sans, the `#ac0000` red accent, the custom icon font, and the MooTools + Uniform + ripple stack (replaced by htmx + Alpine + inline Heroicons).
+
+## Files
+- `CouchPotato Design System.dc.html` — the full interactive reference (all tokens, icon paths, components, live theme toggle). Open in a browser. Icon path data lives in its `iconGroups` array.
+- `CouchPotato Design System (Classic).dc.html` — the legacy red/Open Sans/Lobster system, for reference only (being retired).
+
+### Source files in the repo to align with
+- `couchpotato/ui/templates/base.html` — Tailwind config, CSS variables, sidebar/chrome, toasts, theme toggle, a11y scaffolding.
+- `couchpotato/ui/templates/partials/settings/field_types.html` — the 10 form field types.
+- `couchpotato/ui/templates/partials/settings/modals.html` — dialog, restart banner, directory browser.
+- `couchpotato/ui/templates/partials/movie_cards.html` · `search_results.html` — poster cards & states.

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -6,7 +6,12 @@ This package documents the **canonical design system for the modern CouchPotato 
 The system was **extracted directly from the existing codebase** (`couchpotato/ui/templates/base.html` and the `partials/`), so most tokens below already exist in the app. Treat this README as the source of truth when adding new screens or refactoring old ones.
 
 ## About the Design Files
-The `*.dc.html` files in this bundle are **design references** — interactive HTML prototypes showing the intended look and behaviour. They are **not** production code to copy verbatim.
+The `*.dc.html` files in this bundle are **static design-canvas exports** — raw reference snapshots and a data source (notably the `iconGroups` SVG path data). They are **not** production code to copy verbatim, and **not** standalone browsable pages: they were authored against a design-tool runtime (`support.js`) that is **not** part of this handoff, so the `{{ … }}` template bindings will not render. **This `README.md` is the authoritative spec;** use the `.dc.html` only as raw reference/data.
+
+### Precedence when sources disagree
+Where a `.dc.html` export diverges from this README or the live `couchpotato/ui/templates/base.html`, **base.html + this README win.** Known divergences in the exports:
+- **Poster-card hover glow:** production is `rgba(53,197,244,0.06)` → `0.15` (see `base.html`), *not* the brighter `.10`/`.25` shown in the export.
+- **Ghost button:** transparent by default (`hover:bg-white/[0.03]`, per Components below), *not* the opaque `bg-cp-surface` fill an export caption may show.
 
 Your target environment already exists: **Jinja2 templates + htmx 2 + Alpine 3 + Tailwind (CDN) + Inter**. Recreate anything from these references using that stack and the conventions already in `couchpotato/ui/templates/` — Tailwind utility classes, Alpine `x-data` components, htmx attributes, and the `cp.*` colour tokens. Do not introduce a new framework, CSS-in-JS, or a component library.
 
@@ -172,8 +177,8 @@ Built-in, with a Playwright + axe suite. Rules every component follows:
 **Leave behind:** Lobster wordmark, Open Sans, the `#ac0000` red accent, the custom icon font, and the MooTools + Uniform + ripple stack (replaced by htmx + Alpine + inline Heroicons).
 
 ## Files
-- `CouchPotato Design System.dc.html` — the full interactive reference (all tokens, icon paths, components, live theme toggle). Open in a browser. Icon path data lives in its `iconGroups` array.
-- `CouchPotato Design System (Classic).dc.html` — the legacy red/Open Sans/Lobster system, for reference only (being retired).
+- `couchpotato-design-system.dc.html` — static design-canvas export (tokens, components, and the **icon path data** in its `iconGroups` array). Reference/data only — not a browsable page (see "About the Design Files"); this README is authoritative.
+- `couchpotato-design-system-classic.dc.html` — the legacy red/Open Sans/Lobster system, for reference only (being retired).
 
 ### Source files in the repo to align with
 - `couchpotato/ui/templates/base.html` — Tailwind config, CSS variables, sidebar/chrome, toasts, theme toggle, a11y scaffolding.

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -10,7 +10,7 @@ The `*.dc.html` files in this bundle are **static design-canvas exports** — ra
 
 ### Precedence when sources disagree
 Where a `.dc.html` export diverges from this README or the live `couchpotato/ui/templates/base.html`, **base.html + this README win.** Known divergences in the exports:
-- **Poster-card hover glow:** production is `rgba(53,197,244,0.06)` → `0.15` (see `base.html`), *not* the brighter `.10`/`.25` shown in the export.
+- **Poster-card hover:** production (dark) is `border-color: rgba(53,197,244,0.15)` + `box-shadow: …rgba(53,197,244,0.06)` (see Surfaces below and `base.html`), *not* the brighter values shown in the export.
 - **Ghost button:** transparent by default (`hover:bg-white/[0.03]`, per Components below), *not* the opaque `bg-cp-surface` fill an export caption may show.
 
 Your target environment already exists: **Jinja2 templates + htmx 2 + Alpine 3 + Tailwind (CDN) + Inter**. Recreate anything from these references using that stack and the conventions already in `couchpotato/ui/templates/` — Tailwind utility classes, Alpine `x-data` components, htmx attributes, and the `cp.*` colour tokens. Do not introduce a new framework, CSS-in-JS, or a component library.
@@ -64,11 +64,16 @@ Dark is the default; `<html class="light">` switches the theme. Persist the choi
 
 ### Spacing & radius
 - **Spacing:** Tailwind 4px scale. Common: `gap-2`(8) `gap-3`(12) `p-2.5`(10) `p-4`(16) `px-3 py-2` for controls.
-- **Radius:** `rounded`(4px) for nav items, `rounded-md`(6px) inputs/buttons, `rounded-lg`(8px) toasts, `rounded-xl`(12px) modals/cards.
+- **Radius:** `rounded`(4px) nav items · `rounded-md`(6px) inputs · `rounded-lg`(8px) **buttons** and toasts · `rounded-xl`(12px) modals/cards. (Buttons are `rounded-lg`, per Components below.)
 - **Layout:** sidebar `w-56` (224px), collapses to `w-16` (64px); mobile top bar `h-12`, bottom nav.
 
 ### Surfaces & elevation
-Depth = three near-black layers (`bg` → `surface` → `card`) + translucent borders. Floating chrome (sidebar, top bar) uses `bg-black/80 backdrop-blur-xl` (light: `bg-white/85`). Cards sit flat; only the poster card gets an accent glow on hover (`box-shadow: 0 0 20px rgba(53,197,244,0.06)`).
+Depth = three near-black layers (`bg` → `surface` → `card`) + translucent borders. Floating chrome (sidebar, top bar) uses `bg-black/80 backdrop-blur-xl` (light: `bg-white/85`). Cards sit flat; only the poster card gets an accent border + glow on hover (transition `0.2s`). Exact values (from `base.html`):
+
+| | `border-color` | `box-shadow` glow |
+|---|---|---|
+| **Dark** (`.poster-card:hover`) | `rgba(53,197,244,0.15)` | `0 0 20px rgba(53,197,244,0.06)` |
+| **Light** (`:root.light .poster-card:hover`) | `rgba(53,197,244,0.3)` | `0 0 20px rgba(53,197,244,0.1)` |
 
 ---
 

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -111,7 +111,7 @@ The legacy UI's 30-glyph icon font maps to these Heroicons. When porting old scr
 | `icon-filter` | funnel |
 | `icon-star` / `star-empty` / `star-half` | star (outline; fill with accent; half via 50% linear-gradient fill) |
 | `icon-emo-cry` | face-frown (empty states) |
-| `icon-emo-sunglasses` | face-smile, or a custom sunglasses glyph in the same line style |
+| `icon-emo-sunglasses` | custom sunglasses glyph in the same line style (no exact Heroicon; `face-smile` only as a rough placeholder) |
 | `icon-emo-coffee` | custom coffee-cup glyph in the same line style |
 
 The two glyphs with no Heroicon (`sunglasses`, `coffee`) should be drawn fresh as 24×24 / stroke-1.5 paths to match. Exact path data for every icon is in the reference file's `iconGroups` array.
@@ -189,4 +189,4 @@ Built-in, with a Playwright + axe suite. Rules every component follows:
 - `couchpotato/ui/templates/base.html` — Tailwind config, CSS variables, sidebar/chrome, toasts, theme toggle, a11y scaffolding.
 - `couchpotato/ui/templates/partials/settings/field_types.html` — the 10 form field types.
 - `couchpotato/ui/templates/partials/settings/modals.html` — dialog, restart banner, directory browser.
-- `couchpotato/ui/templates/partials/movie_cards.html` · `search_results.html` — poster cards & states.
+- `couchpotato/ui/templates/partials/movie_cards.html` · `couchpotato/ui/templates/partials/search_results.html` — poster cards & states.

--- a/docs/design-system/couchpotato-design-system-classic.dc.html
+++ b/docs/design-system/couchpotato-design-system-classic.dc.html
@@ -1,0 +1,345 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Lobster&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  *{margin:0;padding:0;box-sizing:border-box;}
+  body{background:#111;}
+  ::selection{background:#ac0000;color:#fff;}
+  .cp-scroll::-webkit-scrollbar{width:10px;height:10px;}
+  .cp-scroll::-webkit-scrollbar-thumb{background:#444;border-radius:5px;}
+  .cp-scroll::-webkit-scrollbar-track{background:transparent;}
+</style>
+</helmet>
+
+<div style="display:flex; min-height:100vh; font-family:'Open Sans','Helvetica Neue',Helvetica,Arial,sans-serif; font-weight:300; color:#1a1a1a; background:#111;">
+
+  <!-- Sidebar — mirrors CouchPotato's real 132px dark header -->
+  <aside style="width:132px; flex:0 0 132px; background:#111; position:sticky; top:0; height:100vh; z-index:10; display:flex; flex-direction:column;">
+    <div style="background:#ac0000; height:80px; display:flex; align-items:center; justify-content:center; font-family:'Lobster',serif; color:#fff; font-size:34px; letter-spacing:1px;">CouchPotato</div>
+    <nav style="flex:1; padding-top:8px;">
+      <sc-for list="{{ navItems }}" as="item" hint-placeholder-count="6">
+        <a href="{{ item.href }}" onClick="{{ item.onClick }}" style="display:block; color:#fff; letter-spacing:1px; padding:10px 20px; font-size:14px; opacity:.78; cursor:pointer; transition:background 150ms,opacity 150ms; text-decoration:none;" style-hover="{ background:'#2e2e2e', opacity:1 }">{{ item.label }}</a>
+      </sc-for>
+    </nav>
+    <div style="padding:14px 20px; font-size:11px; color:#666; letter-spacing:.5px;">v · master</div>
+  </aside>
+
+  <!-- Content -->
+  <main class="cp-scroll" style="flex:1; background:#fff; border-radius:3px 0 0 3px; min-width:0;">
+
+    <!-- Hero -->
+    <header id="overview" style="position:relative; padding:64px 56px 52px; background:#fff; border-bottom:1px solid #ebebeb; overflow:hidden;">
+      <span style="position:absolute; top:0; left:0; width:10px; height:10px; background:#ac0000;"></span>
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:#ac0000; text-transform:uppercase; margin-bottom:18px;">Design System · extracted from source</div>
+      <h1 style="font-size:54px; font-weight:300; line-height:1.05; letter-spacing:-.5px; max-width:760px;">The visual language of <span style="font-family:'Lobster',serif; color:#ac0000; font-weight:400;">CouchPotato</span></h1>
+      <p style="margin-top:22px; max-width:620px; font-size:17px; line-height:1.6; color:#555;">A reference for the automated movie download manager's web interface — colours, type, spacing and components pulled directly from the project's SCSS. Light and dark themes, one red.</p>
+      <div style="display:flex; gap:32px; margin-top:40px; flex-wrap:wrap;">
+        <sc-for list="{{ heroStats }}" as="s" hint-placeholder-count="4">
+          <div style="border-left:2px solid #ebebeb; padding-left:16px;">
+            <div style="font-size:30px; font-weight:300; color:#1a1a1a;">{{ s.value }}</div>
+            <div style="font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:1px; color:#999; text-transform:uppercase; margin-top:4px;">{{ s.label }}</div>
+          </div>
+        </sc-for>
+      </div>
+    </header>
+
+    <!-- Foundations -->
+    <section id="color" style="padding:56px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:#ac0000; text-transform:uppercase; margin-bottom:8px;">01 — Foundations</div>
+      <h2 style="font-size:32px; font-weight:300; margin-bottom:8px;">Colour</h2>
+      <p style="color:#666; max-width:560px; font-size:15px; line-height:1.6; margin-bottom:32px;">Six named theme variables, each mapped to a light and a dark value. A single saturated red (light) / orange (dark) carries every accent — buttons, badges, ripples, toasts.</p>
+
+      <!-- Theme pair -->
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:28px; margin-bottom:40px;">
+        <sc-for list="{{ themes }}" as="theme" hint-placeholder-count="2">
+          <div style="border:1px solid #ebebeb; border-radius:3px; overflow:hidden;">
+            <div style="padding:14px 18px; display:flex; align-items:center; gap:10px; border-bottom:1px solid #ebebeb;">
+              <span style="width:10px; height:10px; border-radius:50%; background:{{ theme.dot }};"></span>
+              <span style="font-weight:600; font-size:14px;">{{ theme.name }}</span>
+              <span style="font-family:'JetBrains Mono',monospace; font-size:11px; color:#999; margin-left:auto;">{{ theme.css }}</span>
+            </div>
+            <sc-for list="{{ theme.swatches }}" as="sw" hint-placeholder-count="6">
+              <div style="display:flex; align-items:center; gap:14px; padding:12px 18px; border-bottom:1px solid #f4f4f4;">
+                <span style="width:46px; height:46px; border-radius:3px; flex:0 0 46px; background:{{ sw.hex }}; border:1px solid rgba(0,0,0,.08);"></span>
+                <div style="min-width:0;">
+                  <div style="font-weight:600; font-size:14px;">{{ sw.name }}</div>
+                  <div style="font-size:12px; color:#888;">{{ sw.role }}</div>
+                </div>
+                <span style="font-family:'JetBrains Mono',monospace; font-size:12px; color:#aaa; margin-left:auto;">{{ sw.hex }}</span>
+              </div>
+            </sc-for>
+          </div>
+        </sc-for>
+      </div>
+    </section>
+
+    <!-- Typography -->
+    <section id="type" style="padding:0 56px 56px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:#ac0000; text-transform:uppercase; margin-bottom:8px;">02 — Foundations</div>
+      <h2 style="font-size:32px; font-weight:300; margin-bottom:8px;">Typography</h2>
+      <p style="color:#666; max-width:560px; font-size:15px; line-height:1.6; margin-bottom:32px;">Two families: <strong style="font-weight:600;">Open Sans</strong> at a light 300 default for all UI text, and <strong style="font-weight:600;">Lobster</strong> reserved exclusively for the wordmark. Base size 14px, line-height 1.5.</p>
+
+      <div style="border:1px solid #ebebeb; border-radius:3px;">
+        <div style="display:flex; align-items:baseline; justify-content:space-between; padding:22px 24px; border-bottom:1px solid #f4f4f4;">
+          <span style="font-family:'Lobster',serif; font-size:44px; color:#ac0000;">CouchPotato</span>
+          <span style="font-family:'JetBrains Mono',monospace; font-size:11px; color:#aaa;">Lobster · wordmark only</span>
+        </div>
+        <sc-for list="{{ typeSamples }}" as="t" hint-placeholder-count="5">
+          <div style="display:flex; align-items:baseline; gap:24px; padding:18px 24px; border-bottom:1px solid #f4f4f4;">
+            <span style="font-family:'JetBrains Mono',monospace; font-size:11px; color:#aaa; width:120px; flex:0 0 120px;">{{ t.meta }}</span>
+            <span style="font-size:{{ t.size }}; font-weight:{{ t.weight }}; font-style:{{ t.style }}; flex:1; min-width:0;">{{ t.text }}</span>
+          </div>
+        </sc-for>
+      </div>
+    </section>
+
+    <!-- Spacing & radius -->
+    <section id="space" style="padding:0 56px 56px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:#ac0000; text-transform:uppercase; margin-bottom:8px;">03 — Foundations</div>
+      <h2 style="font-size:32px; font-weight:300; margin-bottom:8px;">Space, radius &amp; metrics</h2>
+      <p style="color:#666; max-width:560px; font-size:15px; line-height:1.6; margin-bottom:32px;">A single 20px padding unit, scaled by division (½, ⅓, ¼), drives the whole layout. Corners are a tight 3px.</p>
+      <div style="display:grid; grid-template-columns:repeat(auto-fill,minmax(150px,1fr)); gap:16px;">
+        <sc-for list="{{ metrics }}" as="m" hint-placeholder-count="6">
+          <div style="border:1px solid #ebebeb; border-radius:3px; padding:18px; display:flex; flex-direction:column; gap:12px;">
+            <div style="height:46px; display:flex; align-items:center;">
+              <span style="display:block; background:#ac0000; height:{{ m.barH }}; width:{{ m.barW }}; border-radius:{{ m.barR }};"></span>
+            </div>
+            <div>
+              <div style="font-family:'JetBrains Mono',monospace; font-size:15px; color:#1a1a1a;">{{ m.value }}</div>
+              <div style="font-size:12px; color:#888; margin-top:2px;">{{ m.label }}</div>
+            </div>
+          </div>
+        </sc-for>
+      </div>
+    </section>
+
+    <!-- Components -->
+    <section id="components" style="padding:0 56px 16px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:#ac0000; text-transform:uppercase; margin-bottom:8px;">04 — Components</div>
+      <h2 style="font-size:32px; font-weight:300;">Components</h2>
+    </section>
+
+    <!-- Buttons & inputs -->
+    <section style="padding:0 56px 48px;">
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:28px;">
+
+        <div style="border:1px solid #ebebeb; border-radius:3px; padding:26px;">
+          <h3 style="font-size:13px; font-weight:600; letter-spacing:1px; text-transform:uppercase; color:#999; margin-bottom:20px;">Buttons</h3>
+          <div style="display:flex; flex-wrap:wrap; gap:14px; align-items:center;">
+            <a style="color:#ac0000; font-weight:300; padding:5px 14px; border:1px solid #ac0000; border-radius:3px; cursor:pointer; transition:all 150ms; font-size:14px;" style-hover="{ background:'#ac0000', color:'#fff' }">Add movie</a>
+            <a style="color:#fff; font-weight:300; padding:5px 14px; border:1px solid #ac0000; background:#ac0000; border-radius:3px; cursor:pointer; font-size:14px;">Refresh</a>
+            <a style="color:#bbb; font-weight:300; padding:5px 14px; border:1px solid #e2e2e2; border-radius:3px; font-size:14px; cursor:not-allowed;">Disabled</a>
+          </div>
+          <div style="margin-top:20px; font-size:12px; color:#999; line-height:1.6;">Ghost by default — outlined in primary, filling on hover with a 150ms transition.</div>
+        </div>
+
+        <div style="border:1px solid #ebebeb; border-radius:3px; padding:26px;">
+          <h3 style="font-size:13px; font-weight:600; letter-spacing:1px; text-transform:uppercase; color:#999; margin-bottom:20px;">Inputs</h3>
+          <div style="display:flex; flex-direction:column; gap:14px;">
+            <input value="The Grand Budapest Hotel" style="font-size:14px; font-weight:300; padding:7px 9px; border-radius:0; border:1px solid #ccc; background:#ebebeb; color:#000; width:100%;" />
+            <select style="font-size:14px; font-weight:300; padding:7px 9px; border-radius:0; border:1px solid #ccc; background:#ebebeb; color:#000; width:100%;"><option>1080p · BluRay</option><option>720p · WEB-DL</option></select>
+            <textarea rows="2" style="font-size:14px; font-weight:300; padding:7px 9px; border-radius:0; border:1px solid #ccc; background:#ebebeb; color:#000; width:100%; resize:none; font-family:inherit;">Custom search title…</textarea>
+          </div>
+          <div style="margin-top:18px; font-size:12px; color:#999; line-height:1.6;">Square corners, light grey <code style="font-family:'JetBrains Mono',monospace;">off</code> fill, 1px border.</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Badges, toast, menu -->
+    <section style="padding:0 56px 48px;">
+      <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:28px;">
+
+        <div style="border:1px solid #ebebeb; border-radius:3px; padding:26px;">
+          <h3 style="font-size:13px; font-weight:600; letter-spacing:1px; text-transform:uppercase; color:#999; margin-bottom:20px;">Badge &amp; status</h3>
+          <div style="display:flex; align-items:center; gap:18px; margin-bottom:18px;">
+            <div style="position:relative; width:44px; height:44px; background:#111; border-radius:3px; display:flex; align-items:center; justify-content:center; color:#fff; font-size:20px;">🔔
+              <span style="position:absolute; top:3px; right:0; background:#ac0000; color:#fff; border-radius:50%; width:18px; height:18px; line-height:18px; text-align:center; font-size:10px; font-weight:400;">3</span>
+            </div>
+            <div style="display:flex; flex-direction:column; gap:8px;">
+              <span style="display:inline-flex; align-items:center; gap:6px; font-size:12px; color:#1a8a3a;"><span style="width:8px;height:8px;border-radius:50%;background:#1a8a3a;"></span>Snatched</span>
+              <span style="display:inline-flex; align-items:center; gap:6px; font-size:12px; color:#ac0000;"><span style="width:8px;height:8px;border-radius:50%;background:#ac0000;"></span>Wanted</span>
+              <span style="display:inline-flex; align-items:center; gap:6px; font-size:12px; color:#999;"><span style="width:8px;height:8px;border-radius:50%;background:#999;"></span>Done</span>
+            </div>
+          </div>
+        </div>
+
+        <div style="border:1px solid #ebebeb; border-radius:3px; padding:26px;">
+          <h3 style="font-size:13px; font-weight:600; letter-spacing:1px; text-transform:uppercase; color:#999; margin-bottom:20px;">Toast message</h3>
+          <div style="background:#ac0000; border-radius:3px; box-shadow:0 0 15px 2px rgba(0,0,0,.15); overflow:hidden;">
+            <div style="background:#fff; border-radius:3px; padding:14px 28px 14px 18px; margin-bottom:4px; font-size:15px; position:relative;">Movie added to wanted list
+              <span style="position:absolute; right:8px; top:10px; color:#ac0000; cursor:pointer;">✕</span>
+            </div>
+          </div>
+          <div style="margin-top:16px; font-size:12px; color:#999; line-height:1.6;">A primary-filled shell wrapping a white card, bottom-right, cubic-bezier slide.</div>
+        </div>
+
+        <div style="border:1px solid #ebebeb; border-radius:3px; padding:26px;">
+          <h3 style="font-size:13px; font-weight:600; letter-spacing:1px; text-transform:uppercase; color:#999; margin-bottom:20px;">Dropdown menu</h3>
+          <div style="background:#ac0000; border-radius:3px 0 0 3px; box-shadow:0 0 15px 2px rgba(0,0,0,.15); display:inline-block; min-width:170px;">
+            <ul style="background:#fff; border-radius:3px 0 0 3px; overflow:hidden; list-style:none;">
+              <sc-for list="{{ menuItems }}" as="mi" hint-placeholder-count="4">
+                <li style="border-top:1px solid #ebebeb; font-size:14px;"><a style="display:block; color:#1a1a1a; padding:6px 10px; line-height:22px; cursor:pointer;" style-hover="{ background:'#ebebeb' }">{{ mi }}</a></li>
+              </sc-for>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Movie card + table -->
+    <section style="padding:0 56px 48px;">
+      <div style="display:grid; grid-template-columns:300px 1fr; gap:28px; align-items:start;">
+
+        <div style="border:1px solid #ebebeb; border-radius:3px; padding:26px;">
+          <h3 style="font-size:13px; font-weight:600; letter-spacing:1px; text-transform:uppercase; color:#999; margin-bottom:20px;">Movie card</h3>
+          <div style="border-radius:3px; overflow:hidden; box-shadow:0 1px 6px rgba(0,0,0,.12);">
+            <div style="position:relative; aspect-ratio:2/3; background:repeating-linear-gradient(135deg,#1c1c1c,#1c1c1c 12px,#232323 12px,#232323 24px); display:flex; align-items:flex-end;">
+              <span style="position:absolute; top:10px; left:10px; font-family:'JetBrains Mono',monospace; font-size:10px; color:#777; letter-spacing:1px;">POSTER 2:3</span>
+              <span style="position:absolute; top:8px; right:8px; background:#ac0000; color:#fff; font-size:11px; padding:3px 8px; border-radius:3px;">1080p</span>
+              <div style="width:100%; padding:14px 12px 12px; background:linear-gradient(transparent,rgba(0,0,0,.85));">
+                <div style="color:#fff; font-size:16px; line-height:1.2;">Arrival</div>
+                <div style="color:#bbb; font-size:12px; margin-top:3px;">2016 · ★ 8.0</div>
+              </div>
+            </div>
+            <div style="display:flex; background:#fff;">
+              <a style="flex:1; text-align:center; padding:9px 0; font-size:13px; color:#ac0000; cursor:pointer;" style-hover="{ background:'#ebebeb' }">Refresh</a>
+              <a style="flex:1; text-align:center; padding:9px 0; font-size:13px; color:#ac0000; border-left:1px solid #ebebeb; cursor:pointer;" style-hover="{ background:'#ebebeb' }">Delete</a>
+            </div>
+          </div>
+        </div>
+
+        <div style="border:1px solid #ebebeb; border-radius:3px; padding:26px;">
+          <h3 style="font-size:13px; font-weight:600; letter-spacing:1px; text-transform:uppercase; color:#999; margin-bottom:20px;">Release table</h3>
+          <div>
+            <div style="display:flex; font-weight:700; font-size:13px; border-bottom:1px solid rgba(0,0,0,.2); padding-bottom:6px;">
+              <span style="flex:3;">Release</span><span style="flex:1;">Source</span><span style="flex:1; text-align:right;">Size</span><span style="flex:1; text-align:right;">Seeds</span>
+            </div>
+            <sc-for list="{{ releases }}" as="r" hint-placeholder-count="4">
+              <div style="display:flex; font-size:13px; padding:9px 0; border-bottom:1px solid rgba(0,0,0,.12); color:#333;">
+                <span style="flex:3; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">{{ r.name }}</span>
+                <span style="flex:1; color:#777;">{{ r.source }}</span>
+                <span style="flex:1; text-align:right; font-family:'JetBrains Mono',monospace; font-size:12px;">{{ r.size }}</span>
+                <span style="flex:1; text-align:right; font-family:'JetBrains Mono',monospace; font-size:12px; color:{{ r.seedColor }};">{{ r.seeds }}</span>
+              </div>
+            </sc-for>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Dark theme preview -->
+    <section id="dark" style="margin:0 56px 56px; border-radius:3px; overflow:hidden;">
+      <div style="display:flex; min-height:240px;">
+        <div style="width:88px; flex:0 0 88px; background:#111; display:flex; flex-direction:column;">
+          <div style="background:#f85c22; height:60px; display:flex; align-items:center; justify-content:center; font-family:'Lobster',serif; color:#fff; font-size:22px;">CP</div>
+          <div style="flex:1; padding-top:10px;">
+            <sc-for list="{{ darkNav }}" as="d" hint-placeholder-count="3">
+              <div style="color:#fff; opacity:.7; padding:8px 16px; font-size:13px;">{{ d }}</div>
+            </sc-for>
+          </div>
+        </div>
+        <div style="flex:1; background:#2d2d2d; color:#fff; padding:30px 34px; position:relative;">
+          <span style="position:absolute; top:0; left:0; width:10px; height:10px; background:#f85c22;"></span>
+          <div style="font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:2px; color:#f85c22; text-transform:uppercase;">Dark theme</div>
+          <h3 style="font-size:26px; font-weight:300; margin:10px 0 8px;">Same system, inverted</h3>
+          <p style="color:#bbb; font-size:14px; max-width:440px; line-height:1.6;">Background drops to <code style="font-family:'JetBrains Mono',monospace; color:#f85c22;">#2d2d2d</code>, text flips to white, and the accent warms from red to <code style="font-family:'JetBrains Mono',monospace; color:#f85c22;">#f85c22</code>.</p>
+          <div style="display:flex; gap:12px; margin-top:20px;">
+            <a style="color:#f85c22; padding:5px 14px; border:1px solid #f85c22; border-radius:3px; font-size:14px; cursor:pointer;" style-hover="{ background:'#f85c22', color:'#fff' }">Add movie</a>
+            <a style="color:#fff; padding:5px 14px; border:1px solid #f85c22; background:#f85c22; border-radius:3px; font-size:14px; cursor:pointer;">Refresh</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <footer style="padding:24px 56px 40px; border-top:1px solid #ebebeb; color:#999; font-size:12px; display:flex; justify-content:space-between; flex-wrap:wrap; gap:8px;">
+      <span style="font-family:'JetBrains Mono',monospace;">Tokens extracted from couchpotato/static/style/_mixins.scss</span>
+      <span>bassings/CouchPotatoServer</span>
+    </footer>
+
+  </main>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script>
+class Component extends DCLogic {
+  scrollTo(id){
+    const el = document.getElementById(id);
+    if (el) el.scrollIntoView ? window.scrollTo({ top: el.offsetTop, behavior:'smooth' }) : null;
+  }
+  renderVals(){
+    const jump = (id) => (e) => {
+      e.preventDefault();
+      const el = document.getElementById(id);
+      if (el) el.scrollIntoView({ behavior:'smooth', block:'start' });
+    };
+    return {
+      navItems: [
+        { label:'Overview',   href:'#overview',   onClick: jump('overview') },
+        { label:'Colour',     href:'#color',      onClick: jump('color') },
+        { label:'Type',       href:'#type',       onClick: jump('type') },
+        { label:'Spacing',    href:'#space',      onClick: jump('space') },
+        { label:'Components', href:'#components',  onClick: jump('components') },
+        { label:'Dark',       href:'#dark',       onClick: jump('dark') },
+      ],
+      heroStats: [
+        { value:'6',   label:'theme vars' },
+        { value:'2',   label:'themes' },
+        { value:'2',   label:'typefaces' },
+        { value:'3px', label:'radius' },
+      ],
+      themes: [
+        { name:'Light', css:'$theme_light', dot:'#ac0000', swatches:[
+          { name:'primary',  role:'accent · buttons, badges', hex:'#ac0000' },
+          { name:'background', role:'content surface', hex:'#ffffff' },
+          { name:'off',      role:'inputs, dividers', hex:'#ebebeb' },
+          { name:'text',     role:'body copy', hex:'#000000' },
+          { name:'menu',     role:'sidebar', hex:'#111111' },
+          { name:'menu_off', role:'sidebar hover', hex:'#2e2e2e' },
+        ]},
+        { name:'Dark', css:'$theme_dark', dot:'#f85c22', swatches:[
+          { name:'primary',  role:'accent · buttons, badges', hex:'#f85c22' },
+          { name:'background', role:'content surface', hex:'#2d2d2d' },
+          { name:'off',      role:'inputs, dividers', hex:'#343434' },
+          { name:'text',     role:'body copy', hex:'#ffffff' },
+          { name:'menu',     role:'sidebar', hex:'#111111' },
+          { name:'menu_off', role:'sidebar hover', hex:'#2e2e2e' },
+        ]},
+      ],
+      typeSamples: [
+        { meta:'h1 · 54 / 300',     size:'40px', weight:'300', style:'normal', text:'Now downloading' },
+        { meta:'h2 · 24 / 300',     size:'24px', weight:'300', style:'normal', text:'Wanted movies' },
+        { meta:'body · 14 / 300',   size:'15px', weight:'300', style:'normal', text:'CouchPotato automatically finds and downloads the best quality release for the movies on your list.' },
+        { meta:'bold · 14 / 700',   size:'15px', weight:'700', style:'normal', text:'42 releases found' },
+        { meta:'italic · 14 / 400', size:'15px', weight:'400', style:'italic', text:'No notifications (yet)' },
+      ],
+      metrics: [
+        { value:'20px', label:'$padding base',  barH:'20px', barW:'20px', barR:'0' },
+        { value:'10px', label:'½ · gutters',    barH:'10px', barW:'10px', barR:'0' },
+        { value:'6.6px',label:'⅓ · field pad',  barH:'7px',  barW:'7px',  barR:'0' },
+        { value:'5px',  label:'¼ · button pad',  barH:'5px',  barW:'5px',  barR:'0' },
+        { value:'3px',  label:'$border_radius', barH:'30px', barW:'46px', barR:'3px' },
+        { value:'132px',label:'header width',   barH:'12px', barW:'66px', barR:'0' },
+      ],
+      menuItems: ['Mark as done','Refresh info','Change quality','Delete'],
+      releases: [
+        { name:'Arrival.2016.1080p.BluRay.x264', source:'Torrent', size:'8.4 GB', seeds:'214', seedColor:'#1a8a3a' },
+        { name:'Arrival.2016.720p.WEB-DL.DD5.1', source:'Usenet',  size:'4.1 GB', seeds:'—',   seedColor:'#999' },
+        { name:'Arrival.2016.2160p.UHD.HDR.x265', source:'Torrent', size:'22 GB',  seeds:'37',  seedColor:'#1a8a3a' },
+        { name:'Arrival.2016.1080p.WEBRip.x264', source:'Torrent', size:'2.0 GB', seeds:'6',   seedColor:'#ac0000' },
+      ],
+      darkNav: ['Movies','Wanted','Settings'],
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design-system/couchpotato-design-system-classic.dc.html
+++ b/docs/design-system/couchpotato-design-system-classic.dc.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<script src="./support.js"></script>
 </head>
 <body>
 <x-dc>

--- a/docs/design-system/couchpotato-design-system-classic.dc.html
+++ b/docs/design-system/couchpotato-design-system-classic.dc.html
@@ -7,9 +7,6 @@
 <body>
 <x-dc>
 <helmet>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Lobster&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
   *{margin:0;padding:0;box-sizing:border-box;}
   body{background:#111;}

--- a/docs/design-system/couchpotato-design-system.dc.html
+++ b/docs/design-system/couchpotato-design-system.dc.html
@@ -7,9 +7,6 @@
 <body>
 <x-dc>
 <helmet>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <style>
   *{margin:0;padding:0;box-sizing:border-box;letter-spacing:-.01em;}
   :root{

--- a/docs/design-system/couchpotato-design-system.dc.html
+++ b/docs/design-system/couchpotato-design-system.dc.html
@@ -1,0 +1,888 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  *{margin:0;padding:0;box-sizing:border-box;letter-spacing:-.01em;}
+  :root{
+    --cp-bg:#0d0d0d; --cp-surface:#111113; --cp-card:#161618; --cp-border:#1e1e22;
+    --cp-text:#e0e0e4; --cp-muted:#9b9ba8; --cp-faint:#6a6a78;
+    --cp-accent-ink:#35c5f4; --cp-accent-tint:rgba(53,197,244,.1); --cp-chrome:rgba(0,0,0,.8);
+    --cp-h02:rgba(255,255,255,.02); --cp-h03:rgba(255,255,255,.03); --cp-h04:rgba(255,255,255,.04);
+    --cp-h05:rgba(255,255,255,.05); --cp-h06:rgba(255,255,255,.06); --cp-h08:rgba(255,255,255,.08); --cp-h12:rgba(255,255,255,.12);
+  }
+  :root.light{
+    --cp-bg:#f5f5f7; --cp-surface:#fafafa; --cp-card:#ffffff; --cp-border:#e0e0e4;
+    --cp-text:#1a1a1a; --cp-muted:#666666; --cp-faint:#999999;
+    --cp-accent-ink:#0e7490; --cp-accent-tint:rgba(53,197,244,.14); --cp-chrome:rgba(255,255,255,.85);
+    --cp-h02:rgba(0,0,0,.03); --cp-h03:rgba(0,0,0,.04); --cp-h04:rgba(0,0,0,.06);
+    --cp-h05:rgba(0,0,0,.07); --cp-h06:rgba(0,0,0,.1); --cp-h08:rgba(0,0,0,.1); --cp-h12:rgba(0,0,0,.14);
+  }
+  html{transition:background .25s ease;}
+  body{background:var(--cp-bg); transition:background .25s ease;}
+  ::selection{background:#35c5f4;color:#0d0d0d;}
+  .cp-scroll::-webkit-scrollbar{width:8px;height:8px;}
+  .cp-scroll::-webkit-scrollbar-thumb{background:#2a2a30;border-radius:4px;}
+  .cp-scroll::-webkit-scrollbar-track{background:transparent;}
+  .icon-cell:hover{border-color:rgba(53,197,244,.35)!important;background:rgba(53,197,244,.04)!important;}
+  .icon-cell:hover svg{color:#4dd4ff!important;}
+  .poster-card{transition:border-color .2s ease,box-shadow .2s ease;}
+  .poster-card:hover{border-color:rgba(53,197,244,.25)!important;box-shadow:0 0 24px rgba(53,197,244,.10);}
+  @keyframes cpSpin{to{transform:rotate(360deg);}}
+  @keyframes cpPulse{0%,100%{opacity:1;}50%{opacity:.4;}}
+  @keyframes cpFade{from{opacity:0;transform:translateY(4px);}to{opacity:1;transform:translateY(0);}}
+  .cp-spin{animation:cpSpin .8s linear infinite;}
+  .cp-pulse{animation:cpPulse 1.6s ease-in-out infinite;}
+  .cp-fade{animation:cpFade .2s ease-out;}
+  .settings-row:hover{background:rgba(255,255,255,.015);}
+  .dlg-row:hover{background:var(--cp-h04)!important;}
+  @media (prefers-reduced-motion: reduce){.cp-spin,.cp-pulse,.cp-fade{animation:none!important;}}
+</style>
+</helmet>
+
+<svg width="0" height="0" style="position:absolute;" aria-hidden="true"><defs><linearGradient id="halfFill"><stop offset="50%" stop-color="#35c5f4"></stop><stop offset="50%" stop-color="transparent"></stop></linearGradient></defs></svg>
+
+<div style="display:flex; min-height:100vh; font-family:'Inter',sans-serif; color:var(--cp-text); background:var(--cp-bg);">
+
+  <!-- Sidebar — mirrors the modern UI's collapsed-capable nav -->
+  <aside style="width:224px; flex:0 0 224px; background:var(--cp-chrome); backdrop-filter:blur(20px); border-right:1px solid var(--cp-h04); position:sticky; top:0; height:100vh; z-index:10; display:flex; flex-direction:column;">
+    <div style="display:flex; align-items:center; gap:12px; padding:0 16px; height:56px; border-bottom:1px solid var(--cp-h04);">
+      <div style="width:28px; height:28px; border-radius:6px; background:linear-gradient(135deg,#35c5f4,#1f8fbf); display:flex; align-items:center; justify-content:center; font-size:15px;">🛋️</div>
+      <span style="font-weight:600; font-size:14px; letter-spacing:-.02em;">CouchPotato</span>
+    </div>
+    <nav style="flex:1; padding:12px 8px; display:flex; flex-direction:column; gap:2px;">
+      <sc-for list="{{ navItems }}" as="item" hint-placeholder-count="6">
+        <a href="{{ item.href }}" onClick="{{ item.onClick }}" style="display:flex; align-items:center; gap:12px; padding:8px 12px; border-radius:6px; cursor:pointer; color:{{ item.color }}; background:{{ item.bg }}; transition:background 150ms,color 150ms; text-decoration:none; font-size:13px; font-weight:500;" style-hover="{ background:'var(--cp-h03)', color:'var(--cp-text)' }">
+          <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" style="flex:0 0 16px;"><path stroke-linecap="round" stroke-linejoin="round" d="{{ item.icon }}"></path></svg>
+          <span>{{ item.label }}</span>
+        </a>
+      </sc-for>
+      <div style="margin-top:8px; padding-top:8px; border-top:1px solid var(--cp-h04);">
+        <div style="display:flex; align-items:center; gap:8px; padding:8px 12px; font-size:11px; color:var(--cp-faint);">
+          <span style="width:6px; height:6px; border-radius:50%; background:#f04848;"></span>Classic UI · retired
+        </div>
+      </div>
+    </nav>
+    <button onClick="{{ toggleTheme }}" style="display:flex; align-items:center; gap:10px; width:100%; padding:11px 16px; border:none; border-top:1px solid var(--cp-h04); background:none; color:var(--cp-muted); cursor:pointer; font-family:inherit; font-size:13px; font-weight:500; text-align:left; transition:color .15s;" style-hover="{ color:'var(--cp-text)' }">
+      <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" style="flex:0 0 16px;"><path stroke-linecap="round" stroke-linejoin="round" d="{{ themeIcon }}"></path></svg>
+      <span>{{ themeLabel }}</span>
+    </button>
+    <div style="padding:12px 16px; font-size:10px; color:var(--cp-faint); border-top:1px solid var(--cp-h04);">htmx · Alpine · Tailwind</div>
+  </aside>
+
+  <!-- Content -->
+  <main class="cp-scroll" style="flex:1; min-width:0;">
+
+    <!-- Hero -->
+    <header id="overview" style="position:relative; padding:64px 56px 52px; border-bottom:1px solid var(--cp-border); background:radial-gradient(120% 90% at 0% 0%, rgba(53,197,244,.08), transparent 60%);">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:var(--cp-accent-ink); text-transform:uppercase; margin-bottom:18px;">Design System · v3 · htmx UI</div>
+      <h1 style="font-size:52px; font-weight:600; line-height:1.04; letter-spacing:-.03em; max-width:780px;">The visual language of <span style="color:#35c5f4;">CouchPotato</span></h1>
+      <p style="margin-top:22px; max-width:640px; font-size:17px; line-height:1.6; color:var(--cp-muted); font-weight:300;">The system of record for the modernised movie manager — Inter, a single cyan accent, dark-first theming and a Heroicons set. The classic MooTools interface is being retired; everything worth keeping lives here.</p>
+      <p style="margin-top:14px; font-family:'JetBrains Mono',monospace; font-size:12px; color:var(--cp-faint); line-height:1.7;">Jump via the sidebar — it tracks your scroll position. Toggle dark / light at the bottom-left to flip every token live.</p>
+      <div style="display:flex; gap:30px; margin-top:40px; flex-wrap:wrap;">
+        <sc-for list="{{ heroStats }}" as="s" hint-placeholder-count="4">
+          <div style="border-left:2px solid var(--cp-border); padding-left:16px;">
+            <div style="font-size:30px; font-weight:600; color:var(--cp-text); letter-spacing:-.02em;">{{ s.value }}</div>
+            <div style="font-family:'JetBrains Mono',monospace; font-size:11px; letter-spacing:1px; color:var(--cp-faint); text-transform:uppercase; margin-top:4px;">{{ s.label }}</div>
+          </div>
+        </sc-for>
+      </div>
+    </header>
+
+    <!-- Colour -->
+    <section id="color" style="padding:56px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:var(--cp-accent-ink); text-transform:uppercase; margin-bottom:8px;">01 — Foundations</div>
+      <h2 style="font-size:30px; font-weight:600; margin-bottom:8px; letter-spacing:-.02em;">Colour</h2>
+      <p style="color:var(--cp-muted); max-width:580px; font-size:15px; line-height:1.6; margin-bottom:32px; font-weight:300;">Tokens are CSS variables that flip between dark and light. One cyan accent — <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">#35c5f4</code> — replaces the classic red. Semantic colours stay fixed across themes.</p>
+
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:24px; margin-bottom:36px;">
+        <sc-for list="{{ themes }}" as="theme" hint-placeholder-count="2">
+          <div style="border:1px solid var(--cp-border); border-radius:12px; overflow:hidden; background:var(--cp-card);">
+            <div style="padding:14px 18px; display:flex; align-items:center; gap:10px; border-bottom:1px solid var(--cp-border);">
+              <span style="width:10px; height:10px; border-radius:50%; background:{{ theme.dot }};"></span>
+              <span style="font-weight:600; font-size:14px;">{{ theme.name }}</span>
+              <span style="font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--cp-faint); margin-left:auto;">{{ theme.css }}</span>
+            </div>
+            <sc-for list="{{ theme.swatches }}" as="sw" hint-placeholder-count="6">
+              <div style="display:flex; align-items:center; gap:14px; padding:11px 18px; border-bottom:1px solid var(--cp-h03);">
+                <span style="width:42px; height:42px; border-radius:8px; flex:0 0 42px; background:{{ sw.hex }}; border:1px solid var(--cp-h08);"></span>
+                <div style="min-width:0;">
+                  <div style="font-weight:500; font-size:13px;">{{ sw.name }}</div>
+                  <div style="font-size:12px; color:var(--cp-faint);">{{ sw.role }}</div>
+                </div>
+                <span style="font-family:'JetBrains Mono',monospace; font-size:12px; color:var(--cp-faint); margin-left:auto;">{{ sw.hex }}</span>
+              </div>
+            </sc-for>
+          </div>
+        </sc-for>
+      </div>
+
+      <div style="font-size:12px; color:var(--cp-faint); margin-bottom:14px; font-family:'JetBrains Mono',monospace; letter-spacing:1px; text-transform:uppercase;">Accent &amp; semantic</div>
+      <div style="display:grid; grid-template-columns:repeat(auto-fill,minmax(150px,1fr)); gap:14px;">
+        <sc-for list="{{ semantic }}" as="c" hint-placeholder-count="5">
+          <div style="border:1px solid var(--cp-border); border-radius:10px; overflow:hidden; background:var(--cp-card);">
+            <div style="height:54px; background:{{ c.hex }};"></div>
+            <div style="padding:10px 12px;">
+              <div style="font-weight:500; font-size:13px;">{{ c.name }}</div>
+              <div style="font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--cp-faint); margin-top:2px;">{{ c.hex }}</div>
+            </div>
+          </div>
+        </sc-for>
+      </div>
+    </section>
+
+    <!-- Typography -->
+    <section id="type" style="padding:0 56px 56px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:var(--cp-accent-ink); text-transform:uppercase; margin-bottom:8px;">02 — Foundations</div>
+      <h2 style="font-size:30px; font-weight:600; margin-bottom:8px; letter-spacing:-.02em;">Typography</h2>
+      <p style="color:var(--cp-muted); max-width:580px; font-size:15px; line-height:1.6; margin-bottom:32px; font-weight:300;">One family — <strong style="font-weight:600;">Inter</strong>, weights 300–700, with a global <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">-0.01em</code> tracking and tighter headings. Replaces the classic Open Sans + Lobster pairing.</p>
+      <div style="border:1px solid var(--cp-border); border-radius:12px; background:var(--cp-card);">
+        <sc-for list="{{ typeSamples }}" as="t" hint-placeholder-count="5">
+          <div style="display:flex; align-items:baseline; gap:24px; padding:18px 24px; border-bottom:1px solid var(--cp-h03);">
+            <span style="font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--cp-faint); width:140px; flex:0 0 140px;">{{ t.meta }}</span>
+            <span style="font-size:{{ t.size }}; font-weight:{{ t.weight }}; letter-spacing:{{ t.tracking }}; color:{{ t.color }}; flex:1; min-width:0;">{{ t.text }}</span>
+          </div>
+        </sc-for>
+      </div>
+    </section>
+
+    <!-- Spacing / radius -->
+    <section id="metrics" style="padding:0 56px 56px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:var(--cp-accent-ink); text-transform:uppercase; margin-bottom:8px;">03 — Foundations</div>
+      <h2 style="font-size:30px; font-weight:600; margin-bottom:8px; letter-spacing:-.02em;">Radius &amp; metrics</h2>
+      <p style="color:var(--cp-muted); max-width:580px; font-size:15px; line-height:1.6; margin-bottom:32px; font-weight:300;">Tailwind's scale, softened from the classic 3px corners. Sidebar is 224px (collapses to 64px); focus rings are a 2px accent outline.</p>
+      <div style="display:grid; grid-template-columns:repeat(auto-fill,minmax(150px,1fr)); gap:14px;">
+        <sc-for list="{{ metrics }}" as="m" hint-placeholder-count="6">
+          <div style="border:1px solid var(--cp-border); border-radius:10px; padding:18px; background:var(--cp-card); display:flex; flex-direction:column; gap:14px;">
+            <div style="height:44px; display:flex; align-items:center;">
+              <span style="display:block; background:#35c5f4; height:{{ m.barH }}; width:{{ m.barW }}; border-radius:{{ m.barR }};"></span>
+            </div>
+            <div>
+              <div style="font-family:'JetBrains Mono',monospace; font-size:14px; color:var(--cp-text);">{{ m.value }}</div>
+              <div style="font-size:12px; color:var(--cp-faint); margin-top:2px;">{{ m.label }}</div>
+            </div>
+          </div>
+        </sc-for>
+      </div>
+    </section>
+
+    <!-- Icon inventory -->
+    <section id="icons" style="padding:0 56px 56px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:var(--cp-accent-ink); text-transform:uppercase; margin-bottom:8px;">04 — Iconography</div>
+      <h2 style="font-size:30px; font-weight:600; margin-bottom:8px; letter-spacing:-.02em;">Icon inventory</h2>
+      <p style="color:var(--cp-muted); max-width:640px; font-size:15px; line-height:1.6; margin-bottom:8px; font-weight:300;">The classic UI shipped a 30-glyph icon font. Every glyph is remapped here to a <strong style="font-weight:600;">Heroicons</strong> outline equivalent — 24×24, <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">stroke-width 1.5</code>, <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">currentColor</code>. Glyphs with no Heroicon match (sunglasses, coffee) are drawn fresh in the same line style.</p>
+      <p style="color:var(--cp-faint); font-size:12px; margin-bottom:28px; font-family:'JetBrains Mono',monospace;">caption shows: new name · legacy glyph</p>
+
+      <sc-for list="{{ iconGroups }}" as="group" hint-placeholder-count="4">
+        <div style="margin-bottom:30px;">
+          <div style="font-size:13px; font-weight:600; color:var(--cp-muted); margin-bottom:14px; display:flex; align-items:center; gap:10px;">{{ group.title }}<span style="flex:1; height:1px; background:var(--cp-border);"></span></div>
+          <div style="display:grid; grid-template-columns:repeat(auto-fill,minmax(132px,1fr)); gap:12px;">
+            <sc-for list="{{ group.items }}" as="ic" hint-placeholder-count="6">
+              <div class="icon-cell" style="border:1px solid var(--cp-border); border-radius:10px; background:var(--cp-card); padding:18px 12px 12px; display:flex; flex-direction:column; align-items:center; gap:12px; text-align:center; transition:border-color .15s,background .15s;">
+                <svg width="26" height="26" fill="{{ ic.fill }}" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" style="color:var(--cp-text); transition:color .15s;"><path stroke-linecap="round" stroke-linejoin="round" d="{{ ic.path }}"></path></svg>
+                <div>
+                  <div style="font-size:12px; font-weight:500; color:var(--cp-text);">{{ ic.name }}</div>
+                  <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); margin-top:3px;">{{ ic.legacy }}</div>
+                </div>
+              </div>
+            </sc-for>
+          </div>
+        </div>
+      </sc-for>
+    </section>
+
+    <!-- Components -->
+    <section id="components" style="padding:0 56px 16px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:var(--cp-accent-ink); text-transform:uppercase; margin-bottom:8px;">05 — Components</div>
+      <h2 style="font-size:30px; font-weight:600; letter-spacing:-.02em;">Components</h2>
+    </section>
+
+    <section style="padding:24px 56px 40px;">
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:24px;">
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:26px; background:var(--cp-card);">
+          <h3 style="font-size:12px; font-weight:600; letter-spacing:1px; text-transform:uppercase; color:var(--cp-faint); margin-bottom:20px;">Buttons</h3>
+          <div style="display:flex; flex-wrap:wrap; gap:12px; align-items:center;">
+            <a style="background:#35c5f4; color:#0d0d0d; font-weight:600; padding:8px 16px; border-radius:8px; cursor:pointer; font-size:13px;" style-hover="{ background:'#4dd4ff' }">Add movie</a>
+            <a style="color:var(--cp-text); font-weight:500; padding:8px 16px; border:1px solid var(--cp-border); border-radius:8px; cursor:pointer; font-size:13px;" style-hover="{ background:'var(--cp-h03)' }">Refresh</a>
+            <a style="color:#f04848; font-weight:500; padding:8px 16px; border:1px solid rgba(240,72,72,.3); border-radius:8px; cursor:pointer; font-size:13px;" style-hover="{ background:'rgba(240,72,72,.1)' }">Delete</a>
+          </div>
+          <div style="margin-top:18px; font-size:12px; color:var(--cp-faint); line-height:1.6;">Solid accent for primary, ghost for secondary, danger outline for destructive.</div>
+          <div style="margin-top:8px; font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-accent-ink);">bg-cp-accent · text-cp-bg · rounded-lg</div>
+        </div>
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:26px; background:var(--cp-card);">
+          <h3 style="font-size:12px; font-weight:600; letter-spacing:1px; text-transform:uppercase; color:var(--cp-faint); margin-bottom:20px;">Inputs</h3>
+          <div style="display:flex; flex-direction:column; gap:12px;">
+            <input value="The Grand Budapest Hotel" style="font-size:13px; padding:9px 12px; border-radius:8px; border:1px solid var(--cp-border); background:var(--cp-surface); color:var(--cp-text); width:100%; font-family:inherit;" />
+            <select style="font-size:13px; padding:9px 12px; border-radius:8px; border:1px solid var(--cp-border); background:var(--cp-surface); color:var(--cp-text); width:100%; font-family:inherit;"><option>1080p · BluRay</option><option>720p · WEB-DL</option></select>
+          </div>
+          <div style="margin-top:16px; font-size:12px; color:var(--cp-faint); line-height:1.6;">Surface fill, 8px radius, 2px accent focus ring.</div>
+          <div style="margin-top:8px; font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-accent-ink);">bg-cp-surface · border-cp-border · rounded-lg</div>
+        </div>
+      </div>
+    </section>
+
+    <section style="padding:0 56px 40px;">
+      <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:24px;">
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:26px; background:var(--cp-card);">
+          <h3 style="font-size:12px; font-weight:600; letter-spacing:1px; text-transform:uppercase; color:var(--cp-faint); margin-bottom:20px;">Status badges</h3>
+          <div style="display:flex; flex-direction:column; gap:10px; align-items:flex-start;">
+            <span style="padding:3px 10px; border-radius:5px; font-size:11px; font-weight:500; background:rgba(53,197,244,.2); color:#35c5f4;">wanted</span>
+            <span style="padding:3px 10px; border-radius:5px; font-size:11px; font-weight:500; background:rgba(61,220,132,.2); color:#3ddc84;">done</span>
+            <span style="padding:3px 10px; border-radius:5px; font-size:11px; font-weight:500; background:rgba(229,160,13,.2); color:#e5a00d;">snatched</span>
+            <span style="padding:3px 10px; border-radius:5px; font-size:11px; font-weight:500; background:var(--cp-h08); color:var(--cp-muted);">1080p</span>
+          </div>
+        </div>
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:26px; background:var(--cp-card);">
+          <h3 style="font-size:12px; font-weight:600; letter-spacing:1px; text-transform:uppercase; color:var(--cp-faint); margin-bottom:20px;">Toasts</h3>
+          <div style="display:flex; flex-direction:column; gap:8px;">
+            <div style="display:flex; align-items:center; gap:10px; padding:10px 12px; border-radius:8px; background:#16a34a; color:#fff; font-size:13px; font-weight:500;">Movie added to wanted list</div>
+            <div style="display:flex; align-items:center; gap:10px; padding:10px 12px; border-radius:8px; background:#dc2626; color:#fff; font-size:13px; font-weight:500;">Failed to add movie</div>
+            <div style="display:flex; align-items:center; gap:10px; padding:10px 12px; border-radius:8px; background:#35c5f4; color:#0d0d0d; font-size:13px; font-weight:500;">Search started</div>
+          </div>
+          <div style="margin-top:10px; font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-accent-ink);">toast(msg, 'success' | 'error' | 'info')</div>
+        </div>
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:26px; background:var(--cp-card);">
+          <h3 style="font-size:12px; font-weight:600; letter-spacing:1px; text-transform:uppercase; color:var(--cp-faint); margin-bottom:20px;">Rating</h3>
+          <div style="display:flex; align-items:center; gap:4px;">
+            <sc-for list="{{ ratingStars }}" as="st" hint-placeholder-count="5">
+              <svg width="22" height="22" fill="{{ st.fill }}" viewBox="0 0 24 24" stroke="#35c5f4" stroke-width="1.2"><path stroke-linecap="round" stroke-linejoin="round" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z"></path></svg>
+            </sc-for>
+            <span style="margin-left:8px; font-size:13px; color:var(--cp-muted);">8.0</span>
+          </div>
+          <div style="margin-top:18px; font-size:12px; color:var(--cp-faint); line-height:1.6;">star · star-half · star-empty, filled with accent.</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Poster card + table -->
+    <section style="padding:0 56px 40px;">
+      <div style="display:grid; grid-template-columns:260px 1fr; gap:24px; align-items:start;">
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:26px; background:var(--cp-card);">
+          <h3 style="font-size:12px; font-weight:600; letter-spacing:1px; text-transform:uppercase; color:var(--cp-faint); margin-bottom:20px;">Poster card</h3>
+          <div class="poster-card" style="border-radius:8px; overflow:hidden; background:var(--cp-card); border:1px solid var(--cp-h05);">
+            <div style="position:relative; aspect-ratio:2/3; background:linear-gradient(135deg,#1c1c20,#141417,#0d0d0d); display:flex; align-items:flex-end;">
+              <span style="position:absolute; top:8px; left:8px; font-family:'JetBrains Mono',monospace; font-size:9px; color:#4a4a55; letter-spacing:1px;">POSTER 2:3</span>
+              <span style="position:absolute; top:8px; right:8px; padding:2px 6px; border-radius:4px; font-size:9px; font-weight:500; background:rgba(53,197,244,.2); color:#35c5f4; backdrop-filter:blur(4px);">wanted</span>
+              <div style="width:100%; padding:24px 10px 8px; background:linear-gradient(transparent,rgba(0,0,0,.9));">
+                <span style="padding:2px 6px; border-radius:4px; font-size:9px; font-weight:500; background:rgba(255,255,255,.1); color:rgba(255,255,255,.8);">1080p</span>
+              </div>
+            </div>
+            <div style="padding:10px;">
+              <div style="font-size:12px; font-weight:500; color:var(--cp-text); white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">Arrival</div>
+              <div style="font-size:10px; color:var(--cp-faint); margin-top:2px;">2016</div>
+            </div>
+          </div>
+        </div>
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:26px; background:var(--cp-card);">
+          <h3 style="font-size:12px; font-weight:600; letter-spacing:1px; text-transform:uppercase; color:var(--cp-faint); margin-bottom:20px;">Release table</h3>
+          <div>
+            <div style="display:flex; font-weight:600; font-size:12px; color:var(--cp-muted); border-bottom:1px solid var(--cp-border); padding-bottom:8px;">
+              <span style="flex:3;">Release</span><span style="flex:1;">Source</span><span style="flex:1; text-align:right;">Size</span><span style="flex:1; text-align:right;">Seeds</span>
+            </div>
+            <sc-for list="{{ releases }}" as="r" hint-placeholder-count="4">
+              <div style="display:flex; font-size:13px; padding:10px 0; border-bottom:1px solid var(--cp-h04); color:var(--cp-text);">
+                <span style="flex:3; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">{{ r.name }}</span>
+                <span style="flex:1; color:var(--cp-faint);">{{ r.source }}</span>
+                <span style="flex:1; text-align:right; font-family:'JetBrains Mono',monospace; font-size:12px; color:var(--cp-muted);">{{ r.size }}</span>
+                <span style="flex:1; text-align:right; font-family:'JetBrains Mono',monospace; font-size:12px; color:{{ r.seedColor }};">{{ r.seeds }}</span>
+              </div>
+            </sc-for>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Forms & settings -->
+    <section id="forms" style="padding:0 56px 16px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:var(--cp-accent-ink); text-transform:uppercase; margin-bottom:8px;">06 — Components</div>
+      <h2 style="font-size:30px; font-weight:600; letter-spacing:-.02em;">Forms &amp; settings</h2>
+      <p style="color:var(--cp-muted); max-width:640px; font-size:15px; line-height:1.6; margin-top:8px; font-weight:300;">The settings screen drives every field from a typed schema. Ten field types share one visual grammar — <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">bg-white/[0.03]</code> fill, <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">white/[0.06]</code> border, 6px radius, 10px muted helper text, and an optional "Learn more" disclosure.</p>
+    </section>
+
+    <section style="padding:24px 56px 24px;">
+      <div style="display:grid; grid-template-columns:repeat(auto-fill,minmax(280px,1fr)); gap:18px;">
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card);">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:12px;">string · int · float</div>
+          <input value="movies, downloads" style="font-size:12px; padding:8px 12px; border-radius:6px; border:1px solid var(--cp-h06); background:var(--cp-h03); color:var(--cp-text); width:100%; font-family:inherit;" />
+          <p style="font-size:10px; color:var(--cp-faint); margin-top:6px; line-height:1.5;">Comma-separated genres to ignore.</p>
+        </div>
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card);">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:12px;">password</div>
+          <input type="password" value="supersecret" style="font-size:12px; padding:8px 12px; border-radius:6px; border:1px solid var(--cp-h06); background:var(--cp-h03); color:var(--cp-text); width:100%; font-family:inherit; letter-spacing:.15em;" />
+          <p style="font-size:10px; color:var(--cp-faint); margin-top:6px; line-height:1.5;">API key — never echoed back in logs.</p>
+        </div>
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card);">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:12px;">dropdown</div>
+          <select style="font-size:12px; padding:8px 12px; border-radius:6px; border:1px solid var(--cp-h06); background:var(--cp-h03); color:var(--cp-text); width:100%; font-family:inherit;"><option>SABnzbd</option><option>NZBGet</option><option>Transmission</option></select>
+          <p style="font-size:10px; color:var(--cp-faint); margin-top:6px; line-height:1.5;">Active download client.</p>
+        </div>
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card);">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:12px;">bool · checkbox</div>
+          <label style="display:flex; align-items:center; gap:8px; cursor:pointer; font-size:11px; color:var(--cp-muted);">
+            <span style="width:15px; height:15px; border-radius:4px; border:1px solid var(--cp-h12); background:#35c5f4; display:flex; align-items:center; justify-content:center;"><svg width="11" height="11" fill="none" viewBox="0 0 24 24" stroke="#0d0d0d" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"></path></svg></span>
+            Send a test notification on startup
+          </label>
+          <details style="margin-top:10px; font-size:10px;"><summary style="color:#35c5f4; cursor:pointer;">Learn more</summary><div style="margin-top:6px; padding:8px; border-radius:6px; background:var(--cp-h02); border:1px solid var(--cp-h04); color:var(--cp-muted); line-height:1.5;">Verifies your notifier credentials whenever the server boots.</div></details>
+        </div>
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card);">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:12px;">toggle (combined 'use')</div>
+          <div style="display:flex; align-items:center; gap:12px;">
+            <button onClick="{{ toggleSwitch }}" style="position:relative; width:32px; height:16px; border-radius:9999px; border:none; cursor:pointer; transition:background .15s; background:{{ toggleBg }};">
+              <span style="display:block; width:12px; height:12px; background:#fff; border-radius:50%; position:absolute; top:2px; transition:transform .15s; transform:translateX({{ toggleX }});"></span>
+            </button>
+            <span style="font-size:11px; color:var(--cp-muted);">{{ toggleLabel }}</span>
+          </div>
+          <p style="font-size:10px; color:var(--cp-faint); margin-top:10px; line-height:1.5;">Per-row enable in multi-host providers. Try it →</p>
+        </div>
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card);">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:12px;">directory · browse</div>
+          <div style="display:flex; gap:8px;">
+            <input value="/movies" style="flex:1; min-width:0; font-size:12px; padding:8px 12px; border-radius:6px; border:1px solid var(--cp-h06); background:var(--cp-h03); color:var(--cp-text); font-family:inherit;" />
+            <button style="padding:8px 12px; border-radius:6px; font-size:12px; background:var(--cp-h04); color:var(--cp-muted); border:none; cursor:pointer; white-space:nowrap;" style-hover="{ color:'var(--cp-text)', background:'var(--cp-h06)' }">Browse</button>
+          </div>
+          <p style="font-size:10px; color:var(--cp-faint); margin-top:6px; line-height:1.5;">Opens the folder browser modal.</p>
+        </div>
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card);">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:12px;">button · async action</div>
+          <button style="padding:9px 16px; border-radius:6px; font-size:12px; font-weight:500; background:rgba(53,197,244,.2); color:#35c5f4; border:none; cursor:pointer;" style-hover="{ background:'rgba(53,197,244,.3)' }">Sync from Jackett</button>
+          <p style="font-size:10px; color:var(--cp-faint); margin-top:8px; line-height:1.5;">Shows a spinner + inline success/error result.</p>
+        </div>
+
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card); grid-column:span 2;">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:12px;">combined · multi-row (host / api_key + use toggle)</div>
+          <div style="display:flex; gap:8px; align-items:center; font-size:10px; color:var(--cp-faint); margin-bottom:8px;"><span style="width:32px; flex:0 0 32px;"></span><span style="flex:2;">host</span><span style="flex:1;">api key</span><span style="width:16px; flex:0 0 16px;"></span></div>
+          <sc-for list="{{ combinedRows }}" as="row" hint-placeholder-count="2">
+            <div style="display:flex; gap:8px; align-items:center; margin-bottom:8px;">
+              <span style="width:32px; flex:0 0 32px; height:16px; border-radius:9999px; background:{{ row.bg }}; position:relative;"><span style="display:block; width:12px; height:12px; background:#fff; border-radius:50%; position:absolute; top:2px; transform:translateX({{ row.x }});"></span></span>
+              <input value="{{ row.host }}" style="flex:2; min-width:0; font-size:12px; padding:6px 10px; border-radius:6px; border:1px solid var(--cp-h06); background:var(--cp-h03); color:var(--cp-text); font-family:inherit;" />
+              <input value="{{ row.key }}" style="flex:1; min-width:0; font-size:12px; padding:6px 10px; border-radius:6px; border:1px solid var(--cp-h06); background:var(--cp-h03); color:var(--cp-muted); font-family:'JetBrains Mono',monospace;" />
+              <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="var(--cp-faint)" stroke-width="1.5" style="flex:0 0 16px;"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"></path></svg>
+            </div>
+          </sc-for>
+          <button style="font-size:11px; color:#35c5f4; background:none; border:none; cursor:pointer; padding:0; margin-top:4px;">+ Add</button>
+        </div>
+      </div>
+      <div style="margin-top:18px; border:1px solid var(--cp-border); border-radius:12px; background:var(--cp-card); overflow:hidden;">
+        <div style="padding:10px 18px; font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; border-bottom:1px solid var(--cp-border);">settings row layout</div>
+        <sc-for list="{{ settingsRows }}" as="sr" hint-placeholder-count="3">
+          <div class="settings-row" style="display:flex; align-items:center; justify-content:space-between; gap:24px; padding:14px 18px; border-bottom:1px solid var(--cp-h03); transition:background .15s;">
+            <div style="min-width:0;"><div style="font-size:13px; color:var(--cp-text);">{{ sr.label }}</div><div style="font-size:11px; color:var(--cp-faint); margin-top:2px;">{{ sr.hint }}</div></div>
+            <div style="flex:0 0 auto;">
+              <sc-if value="{{ sr.isToggle }}" hint-placeholder-val="{{ true }}"><span style="display:inline-block; width:32px; height:16px; border-radius:9999px; background:#35c5f4; position:relative;"><span style="display:block; width:12px; height:12px; background:#fff; border-radius:50%; position:absolute; top:2px; transform:translateX(16px);"></span></span></sc-if>
+              <sc-if value="{{ sr.isChip }}" hint-placeholder-val="{{ true }}"><span style="font-size:12px; color:var(--cp-muted); font-family:'JetBrains Mono',monospace;">{{ sr.control }}</span></sc-if>
+              <sc-if value="{{ sr.isNum }}" hint-placeholder-val="{{ true }}"><span style="font-size:12px; color:var(--cp-text); font-family:'JetBrains Mono',monospace; background:var(--cp-h03); border:1px solid var(--cp-h06); border-radius:6px; padding:6px 10px;">{{ sr.control }}</span></sc-if>
+            </div>
+          </div>
+        </sc-for>
+      </div>
+    </section>
+
+    <!-- Modals & overlays -->
+    <section id="modals" style="padding:24px 56px 16px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:var(--cp-accent-ink); text-transform:uppercase; margin-bottom:8px;">07 — Components</div>
+      <h2 style="font-size:30px; font-weight:600; letter-spacing:-.02em;">Modals &amp; overlays</h2>
+      <p style="color:var(--cp-muted); max-width:640px; font-size:15px; line-height:1.6; margin-top:8px; font-weight:300;">Dialogs sit on a <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">bg-black/60</code> scrim, centered, <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">max-w-lg</code>, 12px radius. Every one is <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">role="dialog" aria-modal</code> with Escape-to-close and a Tab focus trap. Header / scrollable body / footer is the standard skeleton.</p>
+    </section>
+
+    <section style="padding:24px 56px 40px;">
+      <div style="display:grid; grid-template-columns:1.3fr 1fr; gap:24px; align-items:start;">
+        <!-- dialog specimen on a scrim -->
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:28px; background:rgba(0,0,0,.5); background-image:radial-gradient(rgba(255,255,255,.025) 1px, transparent 1px); background-size:14px 14px;">
+          <div style="max-width:440px; margin:0 auto; background:var(--cp-card); border-radius:12px; border:1px solid var(--cp-h05); overflow:hidden; box-shadow:0 24px 60px rgba(0,0,0,.5);">
+            <div style="padding:12px 16px; border-bottom:1px solid var(--cp-h04); display:flex; align-items:center; justify-content:space-between;">
+              <h3 style="font-size:14px; font-weight:500;">Browse Folders</h3>
+              <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="var(--cp-faint)" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"></path></svg>
+            </div>
+            <div style="padding:8px 16px; border-bottom:1px solid var(--cp-h04); background:var(--cp-h02); display:flex; align-items:center; gap:8px;">
+              <span style="padding:3px 8px; border-radius:4px; font-size:11px; background:var(--cp-h04); color:var(--cp-muted);">↑ Up</span>
+              <span style="font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--cp-faint);">/movies/incoming</span>
+            </div>
+            <div>
+              <sc-for list="{{ folderRows }}" as="f" hint-placeholder-count="3">
+                <div class="dlg-row" style="display:flex; align-items:center; gap:8px; padding:9px 16px; border-bottom:1px solid var(--cp-h02); font-size:12px; cursor:pointer; transition:background .12s;">
+                  <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="#35c5f4" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z"></path></svg>
+                  <span>{{ f }}</span>
+                </div>
+              </sc-for>
+            </div>
+            <div style="padding:12px 16px; border-top:1px solid var(--cp-h04); display:flex; justify-content:flex-end; gap:8px;">
+              <button style="padding:8px 16px; border-radius:6px; font-size:12px; font-weight:500; color:var(--cp-muted); background:none; border:none; cursor:pointer;">Cancel</button>
+              <button style="padding:8px 16px; border-radius:6px; font-size:12px; font-weight:500; background:#35c5f4; color:#0d0d0d; border:none; cursor:pointer;" style-hover="{ background:'#4dd4ff' }">Select This Folder</button>
+            </div>
+          </div>
+        </div>
+        <div style="display:flex; flex-direction:column; gap:16px;">
+          <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card);">
+            <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:14px;">restart banner</div>
+            <div style="display:inline-flex; align-items:center; gap:12px; padding:11px 18px; border-radius:8px; background:rgba(229,160,13,.2); border:1px solid rgba(229,160,13,.3);">
+              <span style="font-size:12px; color:#e5a00d; font-weight:500;">Some changes need a restart.</span>
+              <button style="padding:4px 12px; border-radius:6px; font-size:12px; font-weight:500; background:#e5a00d; color:#000; border:none; cursor:pointer;">Restart</button>
+            </div>
+          </div>
+          <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card); font-size:12px; color:var(--cp-muted); line-height:1.7;">
+            <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:12px;">dialog contract</div>
+            <div style="display:flex; gap:8px;"><span style="color:#35c5f4;">·</span>role="dialog" aria-modal="true"</div>
+            <div style="display:flex; gap:8px;"><span style="color:#35c5f4;">·</span>Escape closes · Tab cycles within</div>
+            <div style="display:flex; gap:8px;"><span style="color:#35c5f4;">·</span>scrim click dismisses</div>
+            <div style="display:flex; gap:8px;"><span style="color:#35c5f4;">·</span>body max-h-[80vh], scrolls</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- States -->
+    <section id="states" style="padding:24px 56px 16px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:var(--cp-accent-ink); text-transform:uppercase; margin-bottom:8px;">08 — Patterns</div>
+      <h2 style="font-size:30px; font-weight:600; letter-spacing:-.02em;">Loading, empty &amp; error states</h2>
+      <p style="color:var(--cp-muted); max-width:640px; font-size:15px; line-height:1.6; margin-top:8px; font-weight:300;">htmx swaps content in place, so every async surface needs a resting state. Spinners use the shared SVG circle, lists fall back to a centered muted message, and skeletons pulse while posters load.</p>
+    </section>
+
+    <section style="padding:24px 56px 40px;">
+      <div style="display:grid; grid-template-columns:repeat(auto-fill,minmax(220px,1fr)); gap:18px;">
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card); min-height:150px; display:flex; flex-direction:column;">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:14px;">spinner</div>
+          <div style="flex:1; display:flex; align-items:center; justify-content:center;">
+            <svg class="cp-spin" width="26" height="26" viewBox="0 0 24 24" fill="none" style="color:#35c5f4;"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" style="opacity:.25;"></circle><path fill="currentColor" style="opacity:.85;" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
+          </div>
+        </div>
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card); min-height:150px;">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:14px;">skeleton</div>
+          <div style="display:flex; gap:10px;">
+            <div class="cp-pulse" style="width:46px; height:68px; border-radius:6px; background:var(--cp-border); flex:0 0 46px;"></div>
+            <div class="cp-pulse" style="flex:1; display:flex; flex-direction:column; gap:8px; justify-content:center;">
+              <div style="height:9px; border-radius:4px; background:var(--cp-border); width:80%;"></div>
+              <div style="height:9px; border-radius:4px; background:var(--cp-border); width:50%;"></div>
+            </div>
+          </div>
+        </div>
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card); min-height:150px; display:flex; flex-direction:column; align-items:center; justify-content:center; text-align:center;">
+          <svg width="34" height="34" fill="none" viewBox="0 0 24 24" stroke="#2a2a30" stroke-width="1"><path stroke-linecap="round" stroke-linejoin="round" d="m15.75 10.5 4.72-4.72a.75.75 0 0 1 1.28.53v11.38a.75.75 0 0 1-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 0 0 2.25-2.25v-9a2.25 2.25 0 0 0-2.25-2.25h-9A2.25 2.25 0 0 0 2.25 7.5v9a2.25 2.25 0 0 0 2.25 2.25Z"></path></svg>
+          <p style="font-size:12px; color:var(--cp-faint); margin-top:12px;">No movies found</p>
+        </div>
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card); min-height:150px; display:flex; flex-direction:column; align-items:center; justify-content:center; text-align:center;">
+          <svg width="34" height="34" fill="none" viewBox="0 0 24 24" stroke="#f04848" stroke-width="1.2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"></path></svg>
+          <p style="font-size:12px; color:#f04848; margin-top:12px;">Something went wrong</p>
+          <p style="font-size:11px; color:var(--cp-faint); margin-top:4px;">Couldn't reach the API</p>
+        </div>
+      </div>
+      <div style="margin-top:18px; display:grid; grid-template-columns:1fr 1fr 1fr; gap:12px;">
+        <sc-for list="{{ emptyCopy }}" as="e" hint-placeholder-count="3">
+          <div style="border:1px dashed #2a2a30; border-radius:10px; padding:16px; text-align:center; font-size:12px; color:var(--cp-faint);">"{{ e }}"</div>
+        </sc-for>
+      </div>
+    </section>
+
+    <!-- Surfaces & space -->
+    <section id="surfaces" style="padding:24px 56px 16px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:var(--cp-accent-ink); text-transform:uppercase; margin-bottom:8px;">09 — Foundations</div>
+      <h2 style="font-size:30px; font-weight:600; letter-spacing:-.02em;">Surfaces, elevation &amp; space</h2>
+      <p style="color:var(--cp-muted); max-width:640px; font-size:15px; line-height:1.6; margin-top:8px; font-weight:300;">Depth is built from three near-black layers plus translucent borders. Chrome (sidebar, top bar) floats with <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">bg-black/80 + backdrop-blur-xl</code>; cards sit flat and only the accent glow appears on hover.</p>
+    </section>
+
+    <section style="padding:24px 56px 40px;">
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:24px; align-items:start;">
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card);">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:16px;">layering · bg → surface → card</div>
+          <div style="background:var(--cp-bg); border-radius:10px; padding:20px;">
+            <div style="background:var(--cp-surface); border:1px solid var(--cp-border); border-radius:8px; padding:18px;">
+              <div style="background:var(--cp-card); border:1px solid var(--cp-border); border-radius:6px; padding:14px; font-size:12px; color:var(--cp-muted);">card · var(--cp-card)</div>
+              <div style="font-size:11px; color:var(--cp-faint); margin-top:8px; font-family:'JetBrains Mono',monospace;">surface · var(--cp-surface)</div>
+            </div>
+            <div style="font-size:11px; color:var(--cp-faint); margin-top:10px; font-family:'JetBrains Mono',monospace;">bg · #0d0d0d</div>
+          </div>
+        </div>
+        <div style="display:flex; flex-direction:column; gap:16px;">
+          <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card);">
+            <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:14px;">border opacities</div>
+            <div style="display:flex; flex-direction:column; gap:10px;">
+              <sc-for list="{{ borders }}" as="b" hint-placeholder-count="3">
+                <div style="display:flex; align-items:center; gap:12px;">
+                  <span style="width:60px; height:30px; border-radius:6px; background:var(--cp-card); border:1px solid {{ b.color }};"></span>
+                  <span style="font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--cp-muted);">{{ b.token }}</span>
+                </div>
+              </sc-for>
+            </div>
+          </div>
+          <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-chrome); backdrop-filter:blur(12px); position:relative; overflow:hidden;">
+            <div style="position:absolute; inset:0; background:radial-gradient(circle at 30% 20%, rgba(53,197,244,.25), transparent 60%); z-index:0;"></div>
+            <div style="position:relative; z-index:1; font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:8px;">floating chrome</div>
+            <div style="position:relative; z-index:1; font-size:12px; color:var(--cp-text);">bg-black/80 · backdrop-blur-xl</div>
+          </div>
+        </div>
+      </div>
+      <div style="margin-top:18px;">
+        <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:14px;">spacing scale · 4px base</div>
+        <div style="display:flex; gap:14px; align-items:flex-end; flex-wrap:wrap;">
+          <sc-for list="{{ spacing }}" as="sp" hint-placeholder-count="6">
+            <div style="text-align:center;">
+              <div style="width:{{ sp.px }}; height:{{ sp.px }}; background:#35c5f4; border-radius:3px; margin:0 auto;"></div>
+              <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-muted); margin-top:8px;">{{ sp.name }}</div>
+              <div style="font-family:'JetBrains Mono',monospace; font-size:9px; color:var(--cp-faint);">{{ sp.px }}</div>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+    </section>
+
+    <!-- Motion -->
+    <section id="motion" style="padding:24px 56px 16px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:var(--cp-accent-ink); text-transform:uppercase; margin-bottom:8px;">10 — Foundations</div>
+      <h2 style="font-size:30px; font-weight:600; letter-spacing:-.02em;">Motion</h2>
+      <p style="color:var(--cp-muted); max-width:640px; font-size:15px; line-height:1.6; margin-top:8px; font-weight:300;">Restrained and fast. A single <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">fade-in</code> for swapped content, short colour/opacity transitions on interactive elements, and a hard stop under <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">prefers-reduced-motion</code>.</p>
+    </section>
+
+    <section style="padding:24px 56px 40px;">
+      <div style="display:grid; grid-template-columns:repeat(auto-fill,minmax(220px,1fr)); gap:18px;">
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card);">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:16px;">durations</div>
+          <div style="display:flex; flex-direction:column; gap:12px;">
+            <sc-for list="{{ durations }}" as="d" hint-placeholder-count="3">
+              <div style="display:flex; align-items:center; gap:12px;">
+                <span style="font-family:'JetBrains Mono',monospace; font-size:11px; color:var(--cp-text); width:52px; flex:0 0 52px;">{{ d.ms }}</span>
+                <span style="flex:1; height:6px; border-radius:3px; background:linear-gradient(90deg,#35c5f4,#1f8fbf); max-width:{{ d.w }};"></span>
+                <span style="font-size:11px; color:var(--cp-faint);">{{ d.use }}</span>
+              </div>
+            </sc-for>
+          </div>
+        </div>
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card);">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:16px;">fade-in · live</div>
+          <button onClick="{{ replayFade }}" style="font-size:11px; color:#35c5f4; background:none; border:1px solid rgba(53,197,244,.3); border-radius:6px; padding:4px 10px; cursor:pointer; margin-bottom:14px;">Replay ↻</button>
+          <div key="{{ fadeKey }}" class="cp-fade" style="background:rgba(53,197,244,.1); border:1px solid rgba(53,197,244,.25); border-radius:8px; padding:14px; font-size:12px; color:#35c5f4;">Content swapped in</div>
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); margin-top:10px;">opacity 0→1 · translateY 4px→0 · .2s</div>
+        </div>
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:22px; background:var(--cp-card); display:flex; flex-direction:column; justify-content:center;">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:12px;">reduced motion</div>
+          <p style="font-size:12px; color:var(--cp-muted); line-height:1.6;">Under <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">prefers-reduced-motion</code>, all animation and scroll-behavior collapse to ~0ms. Spinners freeze, fades disappear.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Accessibility -->
+    <section id="a11y" style="padding:24px 56px 16px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:var(--cp-accent-ink); text-transform:uppercase; margin-bottom:8px;">11 — Foundations</div>
+      <h2 style="font-size:30px; font-weight:600; letter-spacing:-.02em;">Accessibility</h2>
+      <p style="color:var(--cp-muted); max-width:640px; font-size:15px; line-height:1.6; margin-top:8px; font-weight:300;">Accessibility is built into the UI, not bolted on — there's a dedicated Playwright + axe suite. These are the rules every component follows.</p>
+    </section>
+
+    <section style="padding:24px 56px 40px;">
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:18px;">
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:24px; background:var(--cp-card);">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:16px;">focus ring · live</div>
+          <div style="display:flex; gap:12px; align-items:center; flex-wrap:wrap;">
+            <button style="padding:8px 16px; border-radius:6px; font-size:13px; background:#35c5f4; color:#0d0d0d; border:none; outline:2px solid #35c5f4; outline-offset:2px; cursor:pointer;">Focused</button>
+            <input placeholder="Tab to me" style="padding:8px 12px; border-radius:6px; font-size:13px; background:var(--cp-h03); border:1px solid var(--cp-h06); color:var(--cp-text); font-family:inherit;" />
+          </div>
+          <p style="font-size:11px; color:var(--cp-faint); margin-top:14px; line-height:1.6; font-family:'JetBrains Mono',monospace;">:focus-visible → 2px #35c5f4, offset 2px</p>
+        </div>
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:24px; background:var(--cp-card);">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:16px;">skip link</div>
+          <div style="display:inline-block; padding:10px 22px; border-radius:8px; background:#35c5f4; color:#0d0d0d; font-weight:600; font-size:13px;">Skip to main content</div>
+          <p style="font-size:11px; color:var(--cp-faint); margin-top:14px; line-height:1.6;">Off-screen until focused, then pinned top-left — first tab stop on every page.</p>
+        </div>
+        <div style="border:1px solid var(--cp-border); border-radius:12px; padding:24px; background:var(--cp-card); grid-column:span 2;">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-faint); text-transform:uppercase; letter-spacing:1px; margin-bottom:16px;">checklist</div>
+          <div style="display:grid; grid-template-columns:1fr 1fr; gap:12px 28px;">
+            <sc-for list="{{ a11yItems }}" as="a" hint-placeholder-count="6">
+              <div style="display:flex; gap:10px; align-items:flex-start;">
+                <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="#3ddc84" stroke-width="2.2" style="flex:0 0 16px; margin-top:1px;"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"></path></svg>
+                <div><span style="font-size:13px; color:var(--cp-text);">{{ a.title }}</span><span style="font-size:12px; color:var(--cp-faint);"> — {{ a.note }}</span></div>
+              </div>
+            </sc-for>
+          </div>
+        </div>
+        <div style="border:1px solid rgba(53,197,244,.2); border-radius:12px; padding:24px; background:rgba(53,197,244,.04); grid-column:span 2;">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:10px; color:var(--cp-accent-ink); text-transform:uppercase; letter-spacing:1px; margin-bottom:10px;">contrast note</div>
+          <p style="font-size:13px; color:var(--cp-muted); line-height:1.6;">The cyan accent on a light-mode tint fails AA, so <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">.text-cp-accent</code> is overridden to <code style="font-family:'JetBrains Mono',monospace; color:#0e7490;">#0e7490</code> in light mode — same hue, sufficient contrast on <code style="font-family:'JetBrains Mono',monospace;">bg-cp-accent/10</code>.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Migration -->
+    <section id="migration" style="padding:0 56px 56px;">
+      <div style="font-family:'JetBrains Mono',monospace; font-size:12px; letter-spacing:2px; color:var(--cp-accent-ink); text-transform:uppercase; margin-bottom:8px;">12 — Migration</div>
+      <h2 style="font-size:30px; font-weight:600; margin-bottom:8px; letter-spacing:-.02em;">Retiring the classic UI</h2>
+      <p style="color:var(--cp-muted); max-width:640px; font-size:15px; line-height:1.6; margin-bottom:32px; font-weight:300;">The MooTools interface still ships behind <code style="font-family:'JetBrains Mono',monospace; color:var(--cp-accent-ink);">/old/</code>. These are the patterns worth carrying into the htmx UI — and the ones to leave behind.</p>
+      <div style="display:grid; grid-template-columns:1fr 1fr; gap:24px;">
+
+        <div style="border:1px solid rgba(61,220,132,.25); border-radius:12px; padding:26px; background:rgba(61,220,132,.04);">
+          <div style="display:flex; align-items:center; gap:10px; margin-bottom:18px;">
+            <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="#3ddc84" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"></path></svg>
+            <h3 style="font-size:14px; font-weight:600; color:#3ddc84;">Carry over</h3>
+          </div>
+          <sc-for list="{{ carryOver }}" as="k" hint-placeholder-count="5">
+            <div style="padding:11px 0; border-bottom:1px solid var(--cp-h04);">
+              <div style="font-size:13px; font-weight:500; color:var(--cp-text);">{{ k.title }}</div>
+              <div style="font-size:12px; color:var(--cp-muted); margin-top:3px; line-height:1.5; font-weight:300;">{{ k.note }}</div>
+            </div>
+          </sc-for>
+        </div>
+
+        <div style="border:1px solid rgba(240,72,72,.25); border-radius:12px; padding:26px; background:rgba(240,72,72,.04);">
+          <div style="display:flex; align-items:center; gap:10px; margin-bottom:18px;">
+            <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="#f04848" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"></path></svg>
+            <h3 style="font-size:14px; font-weight:600; color:#f04848;">Leave behind</h3>
+          </div>
+          <sc-for list="{{ leaveBehind }}" as="k" hint-placeholder-count="5">
+            <div style="padding:11px 0; border-bottom:1px solid var(--cp-h04);">
+              <div style="font-size:13px; font-weight:500; color:var(--cp-text);">{{ k.title }}</div>
+              <div style="font-size:12px; color:var(--cp-muted); margin-top:3px; line-height:1.5; font-weight:300;">{{ k.note }}</div>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+    </section>
+
+    <footer style="padding:24px 56px 48px; border-top:1px solid var(--cp-border); color:var(--cp-faint); font-size:12px; display:flex; justify-content:space-between; flex-wrap:wrap; gap:8px;">
+      <span style="font-family:'JetBrains Mono',monospace;">Extracted from couchpotato/ui/templates/base.html</span>
+      <span>bassings/CouchPotatoServer · v3</span>
+    </footer>
+
+  </main>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script>
+class Component extends DCLogic {
+  state = { toggleOn: true, fadeKey: 0, activeId: 'overview', dark: true };
+  _sectionIds = ['overview','color','type','metrics','icons','components','forms','modals','states','surfaces','motion','a11y','migration'];
+  componentDidMount(){
+    if (localStorage.getItem('cp-ds-theme') === 'light') {
+      document.documentElement.classList.add('light');
+      this.setState({ dark: false });
+    }
+    this._onScroll = () => {
+      let cur = this._sectionIds[0];
+      for (const id of this._sectionIds) {
+        const el = document.getElementById(id);
+        if (el && el.getBoundingClientRect().top <= 140) cur = id;
+      }
+      if (cur !== this.state.activeId) this.setState({ activeId: cur });
+    };
+    window.addEventListener('scroll', this._onScroll, { passive: true });
+    this._onScroll();
+  }
+  componentWillUnmount(){ if (this._onScroll) window.removeEventListener('scroll', this._onScroll); }
+  renderVals(){
+    const on = this.state.toggleOn;
+    const activeId = this.state.activeId;
+    const dark = this.state.dark;
+    const jump = (id) => (e) => {
+      e.preventDefault();
+      const el = document.getElementById(id);
+      if (el) el.scrollIntoView({ behavior:'smooth', block:'start' });
+    };
+    const N = (label, id, icon) => ({
+      label, href:'#'+id, onClick: jump(id), icon,
+      color: activeId === id ? 'var(--cp-accent-ink)' : 'var(--cp-muted)',
+      bg: activeId === id ? 'var(--cp-accent-tint)' : 'transparent',
+    });
+    const I = (name, legacy, path, fill) => ({ name, legacy, path, fill: fill || 'none' });
+
+    return {
+      navItems: [
+        N('Overview','overview','M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z', true),
+        N('Colour','color','M9.53 16.122a3 3 0 00-5.78 1.128 2.25 2.25 0 01-2.4 2.245 4.5 4.5 0 008.4-2.245c0-.399-.078-.78-.22-1.128zm0 0a15.998 15.998 0 003.388-1.62m-5.043-.025a15.994 15.994 0 011.622-3.395m3.42 3.42a15.995 15.995 0 004.764-4.648l3.876-5.814a1.151 1.151 0 00-1.597-1.597L14.146 6.32a15.996 15.996 0 00-4.649 4.763m3.42 3.42a6.776 6.776 0 00-3.42-3.42'),
+        N('Type','type','M6.429 9.75L2.25 12l4.179 2.25m0-4.5l5.571 3 5.571-3m-11.142 0L2.25 7.5 12 2.25l9.75 5.25-4.179 2.25m0 0L21.75 12l-4.179 2.25m0 0l4.179 2.25L12 21.75 2.25 16.5l4.179-2.25m11.142 0l-5.571 3-5.571-3'),
+        N('Icons','icons','M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z'),
+        N('Components','components','M2.25 7.125C2.25 6.504 2.754 6 3.375 6h6.75c.621 0 1.125.504 1.125 1.125v3.75c0 .621-.504 1.125-1.125 1.125h-6.75A1.125 1.125 0 012.25 10.875v-3.75zM14.25 8.625c0-.621.504-1.125 1.125-1.125h5.25c.621 0 1.125.504 1.125 1.125v8.25c0 .621-.504 1.125-1.125 1.125h-5.25a1.125 1.125 0 01-1.125-1.125v-8.25zM3.75 16.125c0-.621.504-1.125 1.125-1.125h5.25c.621 0 1.125.504 1.125 1.125v2.25c0 .621-.504 1.125-1.125 1.125h-5.25a1.125 1.125 0 01-1.125-1.125v-2.25z'),
+        N('Forms','forms','M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3'),
+        N('Modals','modals','M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15'),
+        N('States','states','M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z'),
+        N('Surfaces','surfaces','M6.429 9.75L2.25 12l4.179 2.25m0-4.5l5.571 3 5.571-3m-11.142 0L2.25 7.5 12 2.25l9.75 5.25-4.179 2.25m0 0L21.75 12l-4.179 2.25m0 0l4.179 2.25L12 21.75 2.25 16.5l4.179-2.25m11.142 0l-5.571 3-5.571-3'),
+        N('Motion','motion','M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z'),
+        N('A11y','a11y','M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281zM15 12a3 3 0 11-6 0 3 3 0 016 0z'),
+        N('Migration','migration','M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3'),
+      ],
+      heroStats: [
+        { value:'30', label:'icons mapped' },
+        { value:'2',  label:'themes' },
+        { value:'Inter', label:'typeface' },
+        { value:'#35c5f4', label:'accent' },
+      ],
+      themes: [
+        { name:'Dark (default)', css:':root', dot:'#35c5f4', swatches:[
+          { name:'--cp-bg',      role:'app background', hex:'#0d0d0d' },
+          { name:'--cp-surface', role:'inset / inputs', hex:'#111113' },
+          { name:'--cp-card',    role:'card surface', hex:'#161618' },
+          { name:'--cp-border',  role:'dividers, borders', hex:'#1e1e22' },
+          { name:'--cp-muted',   role:'secondary text', hex:'#9b9ba8' },
+          { name:'--cp-text',    role:'primary text', hex:'#e0e0e4' },
+        ]},
+        { name:'Light', css:':root.light', dot:'#0e7490', swatches:[
+          { name:'--cp-bg',      role:'app background', hex:'#f5f5f7' },
+          { name:'--cp-surface', role:'inset / inputs', hex:'#fafafa' },
+          { name:'--cp-card',    role:'card surface', hex:'#ffffff' },
+          { name:'--cp-border',  role:'dividers, borders', hex:'#e0e0e4' },
+          { name:'--cp-muted',   role:'secondary text', hex:'#666666' },
+          { name:'--cp-text',    role:'primary text', hex:'#1a1a1a' },
+        ]},
+      ],
+      semantic: [
+        { name:'accent', hex:'#35c5f4' },
+        { name:'accentHover', hex:'#4dd4ff' },
+        { name:'success', hex:'#3ddc84' },
+        { name:'warning', hex:'#e5a00d' },
+        { name:'danger', hex:'#f04848' },
+      ],
+      typeSamples: [
+        { meta:'h1 · 52 / 600',    size:'40px', weight:'600', tracking:'-.03em', color:'#e0e0e4', text:'Now downloading' },
+        { meta:'h2 · 30 / 600',    size:'26px', weight:'600', tracking:'-.02em', color:'#e0e0e4', text:'Wanted movies' },
+        { meta:'body · 15 / 300',  size:'15px', weight:'300', tracking:'-.01em', color:'#e0e0e4', text:'CouchPotato finds and grabs the best release for everything on your list.' },
+        { meta:'label · 13 / 500', size:'13px', weight:'500', tracking:'-.01em', color:'#e0e0e4', text:'42 releases found' },
+        { meta:'mono · caption',   size:'12px', weight:'400', tracking:'0',      color:'#9b9ba8', text:'Arrival.2016.1080p.BluRay.x264' },
+      ],
+      metrics: [
+        { value:'4px',   label:'rounded', barH:'34px', barW:'46px', barR:'4px' },
+        { value:'8px',   label:'rounded-lg', barH:'34px', barW:'46px', barR:'8px' },
+        { value:'12px',  label:'rounded-xl', barH:'34px', barW:'46px', barR:'12px' },
+        { value:'224px', label:'sidebar width', barH:'12px', barW:'72px', barR:'4px' },
+        { value:'64px',  label:'collapsed', barH:'12px', barW:'30px', barR:'4px' },
+        { value:'2px',   label:'focus ring', barH:'26px', barW:'26px', barR:'6px' },
+      ],
+      iconGroups: [
+        { title:'Navigation & chrome', items:[
+          I('home','icon-home','M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25'),
+          I('film','icon-movie','M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h6M9 12h6m-6 5.25h6M5.25 6.75h.008v.008H5.25V6.75zm0 5.25h.008v.008H5.25V12zm0 5.25h.008v.008H5.25v-.008zm13.5-10.5h.008v.008h-.008V6.75zm0 5.25h.008v.008h-.008V12zm0 5.25h.008v.008h-.008v-.008z'),
+          I('magnifying-glass','icon-search','M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z'),
+          I('cog-6-tooth','icon-settings','M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281zM15 12a3 3 0 11-6 0 3 3 0 016 0z'),
+          I('bars-3','icon-menu','M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5'),
+          I('bars-2','icon-handle','M3.75 9h16.5m-16.5 6.75h16.5'),
+          I('ellipsis','icon-dots','M6.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM12.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0zM18.75 12a.75.75 0 11-1.5 0 .75.75 0 011.5 0z'),
+          I('chevron-down','icon-dropdown','M19.5 8.25l-7.5 7.5-7.5-7.5'),
+          I('arrow-left','icon-left-arrow','M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18'),
+        ]},
+        { title:'Actions', items:[
+          I('plus','icon-plus','M12 4.5v15m7.5-7.5h-15'),
+          I('arrow-down-tray','icon-download','M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3'),
+          I('arrow-path','icon-refresh','M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99'),
+          I('arrow-uturn-right','icon-redo','M15 15l6-6m0 0l-6-6m6 6H9a6 6 0 000 12h3'),
+          I('trash','icon-delete','M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0'),
+          I('x-mark','icon-cancel','M6 18L18 6M6 6l12 12'),
+          I('check','icon-ok','M4.5 12.75l6 6 9-13.5'),
+          I('play','icon-play','M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z'),
+          I('eye','icon-eye','M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178zM15 12a3 3 0 11-6 0 3 3 0 016 0z'),
+          I('heart','icon-donate','M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z'),
+        ]},
+        { title:'Status & feedback', items:[
+          I('bell','icon-notifications','M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0'),
+          I('information-circle','icon-info','M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z'),
+          I('exclamation-triangle','icon-error','M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z'),
+          I('squares-2x2','icon-thumb','M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z'),
+          I('list-bullet','icon-list','M8.25 6.75h12M8.25 12h12M8.25 17.25h12M3.75 6.75h.007v.008H3.75V6.75zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM3.75 12h.007v.008H3.75V12zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zM3.75 17.25h.007v.008H3.75v-.008zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z'),
+          I('funnel','icon-filter','M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 01-.659 1.591l-5.432 5.432a2.25 2.25 0 00-.659 1.591v2.927a2.25 2.25 0 01-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 00-.659-1.591L3.659 7.409A2.25 2.25 0 013 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0112 3z'),
+          I('star','icon-star','M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z', '#35c5f4'),
+          I('star-half','icon-star-half','M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z', 'url(#halfFill)'),
+          I('star-empty','icon-star-empty','M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z'),
+        ]},
+        { title:'Empty states & mood · redrawn to match', items:[
+          I('face-frown','icon-emo-cry','M15.182 16.318A4.486 4.486 0 0012.016 15a4.486 4.486 0 00-3.198 1.318M21 12a9 9 0 11-18 0 9 9 0 0118 0zM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75zm-.375 0h.008v.015h-.008V9.75zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75zm-.375 0h.008v.015h-.008V9.75z'),
+          I('face-smile','icon-emo-sunglasses (alt)','M15.182 15.182a4.5 4.5 0 01-6.364 0M21 12a9 9 0 11-18 0 9 9 0 0118 0zM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75zm-.375 0h.008v.015h-.008V9.75zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75zm-.375 0h.008v.015h-.008V9.75z'),
+          I('sunglasses','icon-emo-sunglasses','M3 7.5h6a1.5 1.5 0 011.5 1.5 1.5 1.5 0 003 0 1.5 1.5 0 011.5-1.5h6M4.5 7.5v3a3 3 0 003 3 3 3 0 003-3v-3m3 0v3a3 3 0 003 3 3 3 0 003-3v-3'),
+          I('coffee','icon-emo-coffee','M4.5 7.5h12v6a4.5 4.5 0 01-4.5 4.5H9a4.5 4.5 0 01-4.5-4.5v-6zM16.5 9h1.5a2.25 2.25 0 010 4.5h-1.5M7.5 3.75c0 .621-.336 1.125-.75 1.5M10.5 3.75c0 .621-.336 1.125-.75 1.5M13.5 3.75c0 .621-.336 1.125-.75 1.5'),
+        ]},
+      ],
+      ratingStars: [ {fill:'#35c5f4'},{fill:'#35c5f4'},{fill:'#35c5f4'},{fill:'#35c5f4'},{fill:'url(#halfFill)'} ],
+      // Forms
+      toggleSwitch: () => this.setState(s => ({ toggleOn: !s.toggleOn })),
+      toggleBg: on ? '#35c5f4' : 'rgba(255,255,255,.08)',
+      toggleX: on ? '16px' : '2px',
+      toggleLabel: on ? 'enabled' : 'disabled',
+      combinedRows: [
+        { host:'https://api.nzbgeek.info', key:'a1b9…c4', bg:'#35c5f4', x:'16px' },
+        { host:'https://newznab.example', key:'7f2e…90', bg:'rgba(255,255,255,.08)', x:'2px' },
+      ],
+      settingsRows: [
+        { label:'Dark theme', hint:'Use the dark colour scheme', isToggle:true, isChip:false, isNum:false, control:'' },
+        { label:'Permanent unrar', hint:'Keep extracted files after import', isToggle:false, isChip:true, isNum:false, control:'bool' },
+        { label:'Minimum score', hint:'Reject releases below this', isToggle:false, isChip:false, isNum:true, control:'20' },
+      ],
+      // Theme
+      toggleTheme: () => {
+        const isLight = document.documentElement.classList.toggle('light');
+        localStorage.setItem('cp-ds-theme', isLight ? 'light' : 'dark');
+        this.setState({ dark: !isLight });
+      },
+      themeLabel: dark ? 'Light mode' : 'Dark mode',
+      themeIcon: dark
+        ? 'M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z'
+        : 'M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z',
+      // Modals
+      folderRows: ['incoming', 'sorted', '_unpack'],
+      // States
+      emptyCopy: ['No results found', 'No notifications (yet)', 'Empty folder'],
+      // Surfaces
+      borders: [
+        { token:'white/[0.04]', color:'rgba(255,255,255,.04)' },
+        { token:'white/[0.06]', color:'rgba(255,255,255,.06)' },
+        { token:'white/[0.12] · hover', color:'rgba(255,255,255,.12)' },
+      ],
+      spacing: [
+        { name:'1', px:'4px' }, { name:'2', px:'8px' }, { name:'2.5', px:'10px' },
+        { name:'3', px:'12px' }, { name:'4', px:'16px' }, { name:'6', px:'24px' },
+      ],
+      // Motion
+      durations: [
+        { ms:'150ms', w:'45%', use:'colour / hover' },
+        { ms:'200ms', w:'65%', use:'fade-in, transitions' },
+        { ms:'300ms', w:'100%', use:'sidebar collapse' },
+      ],
+      replayFade: () => this.setState(s => ({ fadeKey: s.fadeKey + 1 })),
+      fadeKey: this.state.fadeKey,
+      // A11y
+      a11yItems: [
+        { title:'aria-current', note:'on the active nav link' },
+        { title:'aria-label', note:'on every icon-only button' },
+        { title:'aria-hidden', note:'on decorative SVGs' },
+        { title:'role + aria-live', note:'on toasts & status regions' },
+        { title:'sr-only', note:'visually-hidden labels for context' },
+        { title:'aria-modal + focus trap', note:'on dialogs' },
+      ],
+      releases: [
+        { name:'Arrival.2016.1080p.BluRay.x264', source:'Torrent', size:'8.4 GB', seeds:'214', seedColor:'#3ddc84' },
+        { name:'Arrival.2016.720p.WEB-DL.DD5.1', source:'Usenet',  size:'4.1 GB', seeds:'—',   seedColor:'#6a6a78' },
+        { name:'Arrival.2016.2160p.UHD.HDR.x265', source:'Torrent', size:'22 GB',  seeds:'37',  seedColor:'#3ddc84' },
+        { name:'Arrival.2016.1080p.WEBRip.x264', source:'Torrent', size:'2.0 GB', seeds:'6',   seedColor:'#e5a00d' },
+      ],
+      carryOver: [
+        { title:'Poster grid & status badges', note:'The card layout, hover refresh and wanted/done/snatched badges already ported into movie_cards.html — keep as the core browse pattern.' },
+        { title:'Release table', note:'Sortable name/source/size/seeds rows. Restyle with cp-border dividers and mono numerics.' },
+        { title:'Quality profiles', note:'1080p / 720p / 4K labelling and the profile editor concept stay — they map straight to the badge component.' },
+        { title:'Star ratings', note:'Half-star support carries over; fill with accent instead of red.' },
+        { title:'Dark / light theming', note:'Classic had a dark mode too. The CSS-variable approach is the modern continuation.' },
+      ],
+      leaveBehind: [
+        { title:'Lobster wordmark', note:'Decorative script logo replaced by the couch mark + Inter semibold.' },
+        { title:'Open Sans 300', note:'Superseded by Inter across the board.' },
+        { title:'#ac0000 red accent', note:'Retired in favour of cyan #35c5f4 (warm orange in classic dark mode also drops).' },
+        { title:'Custom icon font', note:'The 30-glyph EOT/WOFF font is replaced by inline Heroicons SVGs — no font load, themeable via currentColor.' },
+        { title:'MooTools + Uniform + ripple', note:'Replaced by htmx + Alpine. The JS ripple effect and Uniform form styling are gone.' },
+      ],
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design-system/couchpotato-design-system.dc.html
+++ b/docs/design-system/couchpotato-design-system.dc.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<script src="./support.js"></script>
 </head>
 <body>
 <x-dc>

--- a/specs/UI-MIGRATION.md
+++ b/specs/UI-MIGRATION.md
@@ -1,0 +1,36 @@
+# SPEC: Retire the legacy `/old` UI; fully adopt the modern design system
+
+## Problem
+Two UIs ship today: the modern htmx+Alpine+Tailwind UI (`couchpotato/ui/`, served
+at `/`) and the legacy MooTools+SCSS UI (served at `/old/` via the `views` dict and
+`clientscript.py`). The legacy stack is unmaintained, carries ~1.5 MB of MooTools/SCSS
+and a custom icon font, and duplicates functionality. We are moving to a single,
+design-system-conformant UI.
+
+A read-only parity audit found the new UI is **not yet feature-complete** vs `/old`:
+18 user-facing gaps (4 critical, 7 high, 7 medium). See the migration backlog below.
+
+## Approach (decided)
+1. **Redirect** `/old/* → /` immediately (legacy code stays in-repo as porting reference).
+2. **Port all 18 gaps** into the new UI — one TDD'd PR each, in priority order.
+3. **Delete** all legacy code/assets once the ports land.
+4. **Conform** the new UI to `docs/design-system/README.md` per `docs/design-system/CONFORMANCE.md`.
+
+## Coding standards (every PR)
+Security · Accessibility (axe-clean) · Supportability · Maintainability · **TDD**
+(failing test first). No new framework / CSS-in-JS / component library. Pure logic
+extracted into tested `couchpotato/static/scripts/ui/` modules. Each PR must pass the
+9 required CI checks + Claude review before merge.
+
+## Migration backlog (port order)
+Critical: quality-profile mgmt · category mgmt · userscript add-via-URL · search-all-wanted + progress.
+High: per-movie category · watch toggle · re-add (ignore-previous) · home dashboard · suggestion "mark seen" · release table Size/Provider/Try-next · Trakt+Put.io OAuth.
+Medium: quick library scan · manual folder scan · log pagination · notification center · per-movie files view · update-install button · DB-management page.
+
+## Acceptance criteria
+- [ ] `/old/*` returns a redirect to `/`; no page is served from the legacy stack.
+- [ ] All 18 audited features are available in the new UI, each with unit + e2e (+ axe) coverage.
+- [ ] Legacy assets removed: `views`/`addView`, `clientscript.py`, `static/style/*.scss`,
+      non-vendor MooTools `static/scripts/*`, the legacy icon font, old server templates.
+- [ ] New UI passes `docs/design-system/CONFORMANCE.md` (tokens, Heroicons, components, a11y).
+- [ ] No references to `/old` or the legacy stack remain in code or docs.


### PR DESCRIPTION
Adds the design system handoff under `docs/design-system/`:
- `README.md` — source of truth (tokens, typography, iconography, components, motion, a11y).
- `couchpotato-design-system.dc.html` / `...-classic.dc.html` — interactive references.
- `CONFORMANCE.md` — checklist the UI-adoption PRs are implemented against.

First step of retiring the legacy `/old` UI and fully adopting the modern design system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)