### PR TITLE
fix: restore 9 silently-dropped plugins + unblock the event loop (REG-001/REG-002)

### DIFF
--- a/couchpotato/__init__.py
+++ b/couchpotato/__init__.py
@@ -21,6 +21,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from jinja2 import Environment as JinjaEnv, FileSystemLoader, select_autoescape
 from markupsafe import Markup
+from starlette.concurrency import run_in_threadpool
 
 log = CPLog(__name__)
 
@@ -239,7 +240,12 @@ def create_app(api_key: str, web_base: str, static_dir: str = None) -> FastAPI:
                         return JSONResponse(content={'success': False, 'error': 'Invalid JSON body'}, status_code=400)
                 if isinstance(body, dict):
                     kwargs.update(body)
-        result = callApiHandler(route, **kwargs)
+        # Dispatched in the threadpool (REG-002): callApiHandler is
+        # synchronous and can block for a long time (e.g. the chart
+        # scrapers hitting IMDB/Blu-ray.com over the network). Running it
+        # inline on the event loop would freeze every other concurrent
+        # request for the same duration.
+        result = await run_in_threadpool(callApiHandler, route, **kwargs)
 
         if isinstance(result, tuple) and result[0] == 'redirect':
             return RedirectResponse(url=result[1])

--- a/couchpotato/core/loader.py
+++ b/couchpotato/core/loader.py
@@ -152,7 +152,11 @@ class Loader:
         try:
             return importlib.import_module(name)
         except (ImportError, SyntaxError):
-            log.debug('Skip loading module plugin %s: %s', name, traceback.format_exc())
+            # Log loudly: a plugin that fails to import must never disappear
+            # silently (see REG-001, where DEBUG here hid nine dropped
+            # plugins from every log level anyone actually looks at). Still
+            # swallow the error so one broken plugin doesn't abort the rest.
+            log.error('Skip loading module plugin %s: %s', name, traceback.format_exc())
             return None
         except Exception:
             raise

--- a/couchpotato/core/media/movie/providers/automation/bluray.py
+++ b/couchpotato/core/media/movie/providers/automation/bluray.py
@@ -1,7 +1,7 @@
 import traceback
 
 from bs4 import BeautifulSoup
-from couchpotato import fireEvent
+from couchpotato.core.event import fireEvent
 from couchpotato.core.helpers.rss import RSS
 from couchpotato.core.helpers.variable import tryInt
 from couchpotato.core.logger import CPLog

--- a/couchpotato/core/media/movie/providers/automation/imdb.py
+++ b/couchpotato/core/media/movie/providers/automation/imdb.py
@@ -1,7 +1,7 @@
 import traceback
 import re
 
-from couchpotato import fireEvent
+from couchpotato.core.event import fireEvent
 from couchpotato.core.helpers.encoding import ss, toUnicode
 from couchpotato.core.helpers.rss import RSS
 from couchpotato.core.helpers.variable import getImdb, splitString, tryInt

--- a/couchpotato/core/media/movie/providers/automation/popularmovies.py
+++ b/couchpotato/core/media/movie/providers/automation/popularmovies.py
@@ -1,4 +1,4 @@
-from couchpotato import fireEvent
+from couchpotato.core.event import fireEvent
 from couchpotato.core.logger import CPLog
 from couchpotato.core.media.movie.providers.automation.base import Automation
 

--- a/couchpotato/core/media/movie/providers/automation/tmdb_charts.py
+++ b/couchpotato/core/media/movie/providers/automation/tmdb_charts.py
@@ -7,7 +7,7 @@ import random
 import traceback
 from base64 import b64decode as bd
 
-from couchpotato import fireEvent
+from couchpotato.core.event import fireEvent
 from couchpotato.core.helpers.variable import tryInt
 from couchpotato.core.logger import CPLog
 from couchpotato.core.media._base.providers.base import MultiProvider

--- a/couchpotato/core/media/movie/providers/automation/trakt/main.py
+++ b/couchpotato/core/media/movie/providers/automation/trakt/main.py
@@ -2,12 +2,12 @@ import json
 import traceback
 import time
 
-from couchpotato import Env, fireEvent
 from couchpotato.api import addApiView
-from couchpotato.core.event import addEvent
+from couchpotato.core.event import addEvent, fireEvent
 from couchpotato.core.logger import CPLog
 from couchpotato.core.media._base.providers.base import Provider
 from couchpotato.core.media.movie.providers.automation.base import Automation
+from couchpotato.environment import Env
 
 
 log = CPLog(__name__)

--- a/couchpotato/core/media/movie/providers/automation/yifypopular.py
+++ b/couchpotato/core/media/movie/providers/automation/yifypopular.py
@@ -1,5 +1,5 @@
 from html.parser import HTMLParser as _HTMLParser
-from couchpotato import fireEvent
+from couchpotato.core.event import fireEvent
 from couchpotato.core.logger import CPLog
 from couchpotato.core.media.movie.providers.automation.base import Automation
 

--- a/couchpotato/core/media/movie/providers/userscript/filmweb.py
+++ b/couchpotato/core/media/movie/providers/userscript/filmweb.py
@@ -1,5 +1,5 @@
 from bs4 import BeautifulSoup
-from couchpotato import fireEvent
+from couchpotato.core.event import fireEvent
 
 from couchpotato.core.media._base.providers.userscript.base import UserscriptBase
 

--- a/couchpotato/core/media/movie/providers/userscript/reddit.py
+++ b/couchpotato/core/media/movie/providers/userscript/reddit.py
@@ -1,4 +1,4 @@
-from couchpotato import fireEvent
+from couchpotato.core.event import fireEvent
 from couchpotato.core.helpers.variable import splitString
 from couchpotato.core.media._base.providers.userscript.base import UserscriptBase
 

--- a/couchpotato/core/media/movie/providers/userscript/rottentomatoes.py
+++ b/couchpotato/core/media/movie/providers/userscript/rottentomatoes.py
@@ -1,7 +1,7 @@
 import re
 import traceback
 
-from couchpotato import fireEvent
+from couchpotato.core.event import fireEvent
 from couchpotato.core.logger import CPLog
 from couchpotato.core.media._base.providers.userscript.base import UserscriptBase
 

--- a/couchpotato/core/plugins/suggestion.py
+++ b/couchpotato/core/plugins/suggestion.py
@@ -5,6 +5,7 @@ Picks random movies from the user's library, fetches TMDB recommendations,
 and filters out movies already in the library.
 """
 import random
+import threading
 import time
 import traceback
 from base64 import b64decode as bd
@@ -19,6 +20,15 @@ from couchpotato.environment import Env
 log = CPLog(__name__)
 
 autoload = 'Suggestion'
+
+# Guards Suggestion._ignored: suggestion.ignore mutates it while
+# suggestion.view reads it, and callApiHandler's per-route api_locks only
+# serialize same-route calls — since REG-002 dispatches handlers on
+# threadpool workers, cross-route interleaving is reachable from ordinary
+# web traffic. Module-level lock, mirroring _charts_ignore_lock in
+# couchpotato/core/media/movie/charts/main.py. Critical sections stay
+# tight: never held across network calls.
+_ignored_lock = threading.Lock()
 
 
 class Suggestion(Plugin):
@@ -59,10 +69,17 @@ class Suggestion(Plugin):
         """Load the set of ignored suggestion IDs from properties."""
         ignored_str = Env.prop('suggestion.ignored', default='')
         if ignored_str:
-            self._ignored = set(ignored_str.split(','))
+            with _ignored_lock:
+                self._ignored = set(ignored_str.split(','))
 
     def _saveIgnored(self):
-        """Persist the ignored set to properties."""
+        """Persist the ignored set to properties.
+
+        Caller must hold ``_ignored_lock``: the snapshot (join) and the
+        write must be atomic with respect to concurrent mutations, or a
+        stale snapshot persisted last silently drops another request's
+        ignore.
+        """
         Env.prop('suggestion.ignored', ','.join(self._ignored))
 
     _validated_key = None
@@ -253,7 +270,13 @@ class Suggestion(Plugin):
             except Exception:
                 pass
 
-        # Filter out movies already in library or ignored
+        # Filter out movies already in library or ignored. Snapshot the
+        # ignored set under the lock (a concurrent suggestion.ignore may be
+        # mutating it) and iterate the snapshot — the TMDB fetches above and
+        # the loop below must not run with the lock held.
+        with _ignored_lock:
+            ignored = set(self._ignored)
+
         suggestions = []
         for tmdb_id, movie in candidates.items():
             if tmdb_id in library_tmdb_ids:
@@ -261,7 +284,7 @@ class Suggestion(Plugin):
             # We can't easily check IMDB IDs without extra API calls
             # but we filter by TMDB ID which is good enough
             imdb_check = str(tmdb_id)
-            if imdb_check in self._ignored:
+            if imdb_check in ignored:
                 continue
             suggestions.append(self._tmdbToMovieFormat(movie))
 
@@ -297,12 +320,13 @@ class Suggestion(Plugin):
         imdb_id = kwargs.get('imdb', '')
         tmdb_id = kwargs.get('tmdb', '')
 
-        if imdb_id:
-            self._ignored.add(imdb_id)
-        if tmdb_id:
-            self._ignored.add(str(tmdb_id))
+        with _ignored_lock:
+            if imdb_id:
+                self._ignored.add(imdb_id)
+            if tmdb_id:
+                self._ignored.add(str(tmdb_id))
 
-        self._saveIgnored()
+            self._saveIgnored()
 
         # Clear cache so ignored movie is removed
         self._cache = None

--- a/couchpotato/ui/__init__.py
+++ b/couchpotato/ui/__init__.py
@@ -9,6 +9,7 @@ from urllib.parse import urlsplit
 from fastapi import APIRouter, Request, Depends
 from fastapi.responses import HTMLResponse, RedirectResponse
 from jinja2 import Environment as JinjaEnv, FileSystemLoader
+from starlette.concurrency import run_in_threadpool
 
 from couchpotato.environment import Env
 from couchpotato.core.logger import CPLog
@@ -161,7 +162,7 @@ def create_router(require_auth) -> APIRouter:
             # with_releases=False → Wanted page: active movies with no releases yet
             params['has_releases'] = with_releases
 
-            result = callApiHandler('media.list', **params)
+            result = await run_in_threadpool(callApiHandler, 'media.list', **params)
             if isinstance(result, dict):
                 movies = result.get('movies', [])
             else:
@@ -177,7 +178,7 @@ def create_router(require_auth) -> APIRouter:
         """Return movie detail as HTML partial."""
         from couchpotato.api import callApiHandler
         try:
-            result = callApiHandler('media.get', id=movie_id)
+            result = await run_in_threadpool(callApiHandler, 'media.get', id=movie_id)
             if isinstance(result, dict):
                 movie = result.get('media', result)
             else:
@@ -195,7 +196,7 @@ def create_router(require_auth) -> APIRouter:
         movies = []
         if q:
             try:
-                result = callApiHandler('movie.search', q=q)
+                result = await run_in_threadpool(callApiHandler, 'movie.search', q=q)
                 if isinstance(result, dict):
                     movies = result.get('movies', [])
                 elif isinstance(result, list):
@@ -219,7 +220,7 @@ def create_router(require_auth) -> APIRouter:
         error = None
         if url:
             try:
-                result = callApiHandler('userscript.add_via_url', url=url)
+                result = await run_in_threadpool(callApiHandler, 'userscript.add_via_url', url=url)
                 candidate = result.get('movie') if isinstance(result, dict) else None
                 # `and candidate` guards the empty-dict case: getViaUrl treats a
                 # truthy-but-empty {} movie as success (no error key), but the
@@ -248,7 +249,7 @@ def create_router(require_auth) -> APIRouter:
         """Return movie suggestions as HTML partial."""
         from couchpotato.api import callApiHandler
         try:
-            result = callApiHandler('suggestion.view')
+            result = await run_in_threadpool(callApiHandler, 'suggestion.view')
             # callApiHandler swallows handler exceptions and returns
             # {'success': False, ...} rather than raising, so an error-shaped
             # result — not just a thrown exception — is the real failure signal.
@@ -273,7 +274,7 @@ def create_router(require_auth) -> APIRouter:
         """Return chart lists (IMDB, Blu-ray, etc.) as HTML partial."""
         from couchpotato.api import callApiHandler
         try:
-            result = callApiHandler('charts.view')
+            result = await run_in_threadpool(callApiHandler, 'charts.view')
             # callApiHandler swallows handler exceptions and returns
             # {'success': False, ...} rather than raising, so an error-shaped
             # result — not just a thrown exception — is the real failure signal.
@@ -299,7 +300,7 @@ def create_router(require_auth) -> APIRouter:
         from couchpotato.api import callApiHandler
         collections = []
         try:
-            result = callApiHandler('collection.list')
+            result = await run_in_threadpool(callApiHandler, 'collection.list')
             if isinstance(result, dict):
                 collections = result.get('collections', [])
         except Exception:
@@ -313,7 +314,7 @@ def create_router(require_auth) -> APIRouter:
         from couchpotato.api import callApiHandler
         collections = []
         try:
-            result = callApiHandler('collection.list', include_movies='0')
+            result = await run_in_threadpool(callApiHandler, 'collection.list', include_movies='0')
             if isinstance(result, dict):
                 collections = result.get('collections', [])
         except Exception:
@@ -338,7 +339,7 @@ def create_router(require_auth) -> APIRouter:
         """Return quality profiles as options."""
         from couchpotato.api import callApiHandler
         try:
-            result = callApiHandler('profile.list')
+            result = await run_in_threadpool(callApiHandler, 'profile.list')
             if isinstance(result, dict):
                 profiles = result.get('list', result.get('profiles', []))
             else:

--- a/specs/REG-001-restore-plugin-loading.md
+++ b/specs/REG-001-restore-plugin-loading.md
@@ -71,7 +71,9 @@ doesn't use the root import.
   tmdb_charts, popularmovies, yifypopular, trakt AND
   `Loaded media_movie_providers_userscript:` for filmweb, reddit, rottentomatoes;
   `GET /api/<key>/settings` contains sections `imdb`, `bluray`, `tmdb_charts`,
-  `popularmovies`, `yifypopular`, `trakt`. Kill the server and delete
+  `popularmovies`, `ytspopular`, `trakt` (note: `yifypopular.py` has always
+  registered its config section as `ytspopular` — pre-existing naming quirk,
+  not part of this regression). Kill the server and delete
   `.reg001-data` afterwards (it is not gitignored — do not commit it).
 - No UI/template changes → no E2E updates needed.
 - Conventional commit(s) locally. **STOP after committing — do NOT push.**

--- a/specs/REG-001-restore-plugin-loading.md
+++ b/specs/REG-001-restore-plugin-loading.md
@@ -1,0 +1,85 @@
+# REG-001 — Restore silently-dropped plugins (fireEvent import regression from #148)
+
+## Problem
+
+PR #148 removed `from couchpotato.core.event import fireEvent` from
+`couchpotato/__init__.py` (it looked unused *within that file*). But nine plugin
+modules import it **via the package root** — `from couchpotato import fireEvent` —
+and `Loader.loadModule()` (`couchpotato/core/loader.py:151`) catches
+`ImportError` and logs it at **DEBUG**, so all nine plugins vanished silently.
+CI stayed green because nothing imports these modules in tests and the loader
+never surfaces the failure.
+
+### Confirmed casualties (verified on v3.8.0, local + production)
+
+Automation / chart providers (`couchpotato/core/media/movie/providers/automation/`):
+- `imdb.py` — IMDB charts **and** IMDB watchlist automation
+- `bluray.py` — Blu-ray.com chart
+- `tmdb_charts.py` — TMDB charts
+- `popularmovies.py`
+- `yifypopular.py`
+- `trakt/main.py` (`from couchpotato import Env, fireEvent`) — Trakt watchlist automation
+
+Userscript URL resolvers (`couchpotato/core/media/movie/providers/userscript/`):
+- `filmweb.py`, `reddit.py`, `rottentomatoes.py`
+
+### User-visible symptoms
+- Suggestions page → "Charts" section: "No charts available" (charts.view returns 0 charts).
+- Settings: all chart/automation provider config sections gone (their `config`
+  blocks never register).
+- Trakt/IMDB watchlist automation silently dead.
+- Add-via-URL no longer resolves filmweb/reddit/rottentomatoes URLs.
+
+The "For You" (suggestion.view) feature is NOT broken — `couchpotato/core/plugins/suggestion.py`
+doesn't use the root import.
+
+## Fix
+
+1. **The nine modules:** import from the canonical homes instead of the package root:
+   - `from couchpotato import fireEvent` → `from couchpotato.core.event import fireEvent`
+   - `trakt/main.py`: `from couchpotato import Env, fireEvent` →
+     `from couchpotato.environment import Env` + `from couchpotato.core.event import fireEvent`
+   - Do NOT re-add the re-export to `couchpotato/__init__.py` (ruff would flag it
+     unused; prod `custom_plugins/` is empty so nothing external relies on it).
+
+2. **Loader visibility (the meta-bug):** in `Loader.loadModule()`, log
+   `ImportError`/`SyntaxError` at **ERROR** with the traceback (keep returning
+   `None` so one broken plugin doesn't abort the rest). A plugin that fails to
+   import must never again disappear silently.
+
+3. **Regression tests (TDD — write these first, watch them fail on current code):**
+   a. `tests/unit/test_plugin_import_sweep.py`: walk every module under
+      `couchpotato.core` with `pkgutil.walk_packages` and import each one;
+      collect failures and assert the list is empty (report module + error in
+      the assertion message). Skip nothing except non-package dirs
+      (`static/` has no `__init__.py`, so walk_packages won't yield it).
+      Note: `import couchpotato` needs `libs/` on `sys.path`
+      (`CouchPotato.py:28` does `sys.path.insert(0, .../libs)`); mirror that in
+      the test/conftest if pytest doesn't already provide it. This test must
+      fail on current master naming exactly the nine modules above.
+   b. Loader test: a module raising ImportError gets logged at ERROR
+      (use `caplog` against `Loader.loadModule` with a fabricated module name,
+      or monkeypatch importlib).
+
+## Acceptance criteria
+
+- New sweep test fails before the fix (listing the 9 modules), passes after.
+- `.venv/bin/python -m pytest tests/unit/ -q` fully green.
+- `ruff check .` clean.
+- Boot check: `.venv/bin/python CouchPotato.py --data_dir=.reg001-data --console_log`
+  logs `Loaded media_movie_providers_automation:` lines for imdb, bluray,
+  tmdb_charts, popularmovies, yifypopular, trakt AND
+  `Loaded media_movie_providers_userscript:` for filmweb, reddit, rottentomatoes;
+  `GET /api/<key>/settings` contains sections `imdb`, `bluray`, `tmdb_charts`,
+  `popularmovies`, `yifypopular`, `trakt`. Kill the server and delete
+  `.reg001-data` afterwards (it is not gitignored — do not commit it).
+- No UI/template changes → no E2E updates needed.
+- Conventional commit(s) locally. **STOP after committing — do NOT push.**
+
+## Files
+
+- `couchpotato/core/media/movie/providers/automation/{imdb,bluray,tmdb_charts,popularmovies,yifypopular}.py`
+- `couchpotato/core/media/movie/providers/automation/trakt/main.py`
+- `couchpotato/core/media/movie/providers/userscript/{filmweb,reddit,rottentomatoes}.py`
+- `couchpotato/core/loader.py`
+- `tests/unit/test_plugin_import_sweep.py` (new)

--- a/specs/REG-002-threadpool-api-dispatch.md
+++ b/specs/REG-002-threadpool-api-dispatch.md
@@ -40,6 +40,10 @@ kwargs):
 
 ### Why this is safe
 
+- `callApiHandler` already serializes same-route calls via per-route
+  `api_locks` (`couchpotato/api.py`), so the new concurrency surface this
+  change introduces is **cross-route only** — a handler can never interleave
+  with another invocation of itself.
 - The DB layer is already multi-thread aware: `SQLiteAdapter` uses
   `check_same_thread=False` plus an `RLock` around writes, and background
   threads (searchers, scheduler jobs, renamer scans) already call handlers and
@@ -68,7 +72,9 @@ kwargs):
 ## Acceptance criteria
 
 - New concurrency test fails before the fix, passes after.
-- `.venv/bin/python -m pytest tests/unit/ -q` fully green (770 expected).
+- `.venv/bin/python -m pytest tests/unit/ -q` fully green (771 expected —
+  768 pre-existing + the concurrency test + the two `Suggestion._ignored`
+  lock tests added by the review follow-up).
 - `ruff check .` clean.
 - Boot check from this worktree:
   `/Volumes/Storage/home/scott.b/repos/CouchPotatoServer/.venv/bin/python CouchPotato.py --data_dir=.reg002-data --console_log`,

--- a/specs/REG-002-threadpool-api-dispatch.md
+++ b/specs/REG-002-threadpool-api-dispatch.md
@@ -1,0 +1,88 @@
+# REG-002 — Run blocking API handlers off the event loop
+
+## Problem
+
+Every FastAPI route in this app is `async def` and calls the synchronous,
+blocking `callApiHandler()` directly on the event loop — both the main API
+dispatcher (`_dispatch_api` in `couchpotato/__init__.py`) and all the
+`/partial/*` + page handlers in `couchpotato/ui/__init__.py`. Any slow handler
+therefore freezes the **entire server** for its duration.
+
+This was invisible while the slowest handlers (the chart scrapers) were dead
+(see REG-001). With them restored, it's fatal — measured on this branch:
+
+- cold `charts.view` = **84s** of network scraping (IMDB, Blu-ray.com, …)
+- while it runs, concurrent `GET /settings/` and `GET /wanted/` hang
+  (curl timed out at 40s); after it finishes they return instantly
+- the full Playwright E2E suite fails 9 tests with `page.goto` timeouts
+  (settings, wanted, navigation, search specs) purely from this head-of-line
+  blocking — on master (charts dead) the same suite is 130/130.
+
+## Fix
+
+Dispatch blocking handler work in the threadpool instead of on the loop, via
+`starlette.concurrency.run_in_threadpool` (Starlette ships it; it accepts
+kwargs):
+
+1. `couchpotato/__init__.py` `_dispatch_api()`: the
+   `result = callApiHandler(route, **kwargs)` call becomes
+   `result = await run_in_threadpool(callApiHandler, route, **kwargs)`.
+   Leave the `api_nonblock` long-poll path as-is (it's already
+   callback/future-based) unless it also calls blocking code inline — read it
+   and decide; explain in your report.
+2. `couchpotato/ui/__init__.py`: every `callApiHandler(...)` call site inside
+   the async handlers (partial_movies, partial_movie_detail, partial_search,
+   partial_add_via_url, partial_suggestions, partial_charts,
+   partial_settings_profiles, partial_profiles — enumerate by grep, don't
+   trust this list) gets the same `await run_in_threadpool(...)` treatment.
+3. Template rendering and other CPU-trivial work stays on the loop — do NOT
+   blanket-wrap everything; only the `callApiHandler` dispatches.
+
+### Why this is safe
+
+- The DB layer is already multi-thread aware: `SQLiteAdapter` uses
+  `check_same_thread=False` plus an `RLock` around writes, and background
+  threads (searchers, scheduler jobs, renamer scans) already call handlers and
+  the DB concurrently with web requests today. The event-loop serialization
+  was accidental, not a designed invariant.
+- Known technical debt (CLAUDE.md): read-modify-write races exist in some DB
+  patterns regardless; this change restores the legacy threaded execution
+  model the code was written for rather than introducing a new one.
+
+## Tests (TDD — write first, watch fail on current code)
+
+`tests/unit/test_api_dispatch_concurrency.py`:
+
+- Build the app via `couchpotato.create_app(...)` the same way existing tests
+  do (see `tests/unit/test_fastapi_web.py` / `test_api_auth.py` for the
+  bootstrap pattern), register two fake API views through
+  `couchpotato.api.addApiView`: `slowtest.sleep` (blocks ~1.5s via
+  `time.sleep`) and `fasttest.ping` (returns immediately).
+- Using `httpx.AsyncClient` + `asyncio.gather`, fire the slow request and,
+  ~0.2s later, the fast one. Assert the fast response arrives well before the
+  slow one completes (e.g. fast elapsed < 1.0s while slow elapsed ≥ 1.5s).
+  On current code this fails (fast waits behind slow); after the fix it
+  passes.
+- Keep the timing margins generous (no flaky <100ms assertions).
+
+## Acceptance criteria
+
+- New concurrency test fails before the fix, passes after.
+- `.venv/bin/python -m pytest tests/unit/ -q` fully green (770 expected).
+- `ruff check .` clean.
+- Boot check from this worktree:
+  `/Volumes/Storage/home/scott.b/repos/CouchPotatoServer/.venv/bin/python CouchPotato.py --data_dir=.reg002-data --console_log`,
+  wait ~15s, then with the api key from `.reg002-data/config.ini`: start
+  `curl "http://localhost:5050/api/<key>/charts.view"` in the background and
+  immediately `curl -m 10 http://localhost:5050/login/` — the login page must
+  return in well under 10s while charts is still fetching. Kill the server and
+  delete `.reg002-data` afterwards (not gitignored — do not commit it).
+- No UI/template changes.
+- Conventional commit on `fix/reg-001-plugin-loading`. **STOP after
+  committing — do NOT push.**
+
+## Files
+
+- `couchpotato/__init__.py`
+- `couchpotato/ui/__init__.py`
+- `tests/unit/test_api_dispatch_concurrency.py` (new)

--- a/tests/unit/test_api_dispatch_concurrency.py
+++ b/tests/unit/test_api_dispatch_concurrency.py
@@ -1,0 +1,146 @@
+"""Regression test for REG-002: blocking API handlers must not stall the
+event loop.
+
+Every FastAPI route dispatches to the synchronous ``callApiHandler``. Before
+the fix, that call happened directly on the event loop, so a slow handler
+(e.g. the chart scrapers) blocked every other concurrent request for its
+entire duration. This test proves a fast request completes promptly even
+while a slow request registered through the same dispatcher is still
+in-flight.
+"""
+import asyncio
+import os
+import time
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from couchpotato.api import (
+    addApiView,
+    api,
+    api_docs,
+    api_docs_missing,
+    api_locks,
+    api_nonblock,
+)
+from couchpotato.environment import Env
+
+
+@pytest.fixture(autouse=True)
+def setup_env(tmp_path):
+    """Set up minimal Env for testing (mirrors test_fastapi_web.py)."""
+    old_api = dict(api)
+    old_locks = dict(api_locks)
+    old_nonblock = dict(api_nonblock)
+    old_docs = dict(api_docs)
+    old_missing = list(api_docs_missing)
+
+    Env.set('web_base', '/')
+    Env.set('api_base', '/api/testkey123/')
+    Env.set('static_path', '/static/')
+    Env.set('app_dir', os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+    Env.set('dev', False)
+
+    settings_data = {
+        'username': '',
+        'password': '',
+        'api_key': 'testkey123',
+        'dark_theme': False,
+    }
+
+    original_setting = Env.setting
+
+    def mock_setting(key=None, *args, **kwargs):
+        if 'value' in kwargs:
+            settings_data[key] = kwargs['value']
+            return
+        if key in settings_data:
+            return settings_data[key]
+        return kwargs.get('default', '')
+
+    Env.setting = staticmethod(mock_setting)
+
+    yield settings_data
+
+    Env.setting = original_setting
+    api.clear()
+    api.update(old_api)
+    api_locks.clear()
+    api_locks.update(old_locks)
+    api_nonblock.clear()
+    api_nonblock.update(old_nonblock)
+    api_docs.clear()
+    api_docs.update(old_docs)
+    api_docs_missing.clear()
+    api_docs_missing.extend(old_missing)
+
+
+@pytest.fixture
+def app(setup_env):
+    from couchpotato import create_app
+    return create_app('testkey123', '/')
+
+
+def test_slow_handler_does_not_block_concurrent_fast_handler(app):
+    """A slow blocking API handler must not stall an unrelated concurrent request.
+
+    Fails on the pre-fix code: callApiHandler runs synchronously on the event
+    loop inside _dispatch_api, so the fast request queues up behind the slow
+    one and only returns after ~1.5s (instead of near-instantly).
+
+    No pytest-asyncio plugin is installed in this project, so the coroutine
+    is driven directly via asyncio.run() rather than an async test function.
+    """
+    SLOW_SECONDS = 1.5
+
+    def slow_sleep():
+        time.sleep(SLOW_SECONDS)
+        return {'success': True, 'slow': True}
+
+    def fast_ping():
+        return {'success': True, 'fast': True}
+
+    addApiView('slowtest.sleep', slow_sleep)
+    addApiView('fasttest.ping', fast_ping)
+
+    async def run():
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url='http://testserver') as client:
+            # Both elapsed times are measured from this single shared start
+            # point (not from inside each coroutine) — that's what makes the
+            # assertion meaningful. If the event loop were fully blocked by
+            # slow_sleep's inline time.sleep(), call_fast's own
+            # `await asyncio.sleep(0.2)` would never get a chance to run
+            # until the slow request finished, so fast_elapsed would end up
+            # close to SLOW_SECONDS too. Measuring per-coroutine elapsed time
+            # from *inside* each coroutine (i.e. only around the client.get
+            # call) would hide that: once unblocked, the actual GET is fast
+            # regardless, and the test would pass even against the buggy code.
+            start = time.monotonic()
+
+            async def call_slow():
+                resp = await client.get('/api/testkey123/slowtest.sleep')
+                return resp, time.monotonic() - start
+
+            async def call_fast():
+                await asyncio.sleep(0.2)
+                resp = await client.get('/api/testkey123/fasttest.ping')
+                return resp, time.monotonic() - start
+
+            return await asyncio.gather(call_slow(), call_fast())
+
+    (slow_resp, slow_elapsed), (fast_resp, fast_elapsed) = asyncio.run(run())
+
+    assert slow_resp.status_code == 200
+    assert slow_resp.json() == {'success': True, 'slow': True}
+    assert fast_resp.status_code == 200
+    assert fast_resp.json() == {'success': True, 'fast': True}
+
+    assert slow_elapsed >= SLOW_SECONDS
+    # Generous margin: the fast request should return in well under the slow
+    # handler's sleep duration, proving it wasn't queued up behind it on the
+    # event loop.
+    assert fast_elapsed < 1.0, (
+        'fast request took %.2fs — it appears to have been blocked behind '
+        'the slow handler on the event loop (REG-002 regression)' % fast_elapsed
+    )

--- a/tests/unit/test_plugin_import_sweep.py
+++ b/tests/unit/test_plugin_import_sweep.py
@@ -1,0 +1,104 @@
+"""REG-001: sweep-import every module under couchpotato.core.
+
+PR #148 removed `from couchpotato.core.event import fireEvent` from
+`couchpotato/__init__.py`. Nine plugin modules imported it via the package
+root (`from couchpotato import fireEvent`), and `Loader.loadModule()` (see
+`couchpotato/core/loader.py`) swallows `ImportError` at DEBUG level, so those
+plugins vanished silently instead of failing loudly anywhere CI would notice.
+
+This test walks every module reachable under `couchpotato.core` and imports
+it directly (bypassing the Loader's error-swallowing), so a broken import
+shows up as a hard test failure rather than a quiet DEBUG log line.
+"""
+import importlib
+import logging
+import os
+import pkgutil
+import sys
+import traceback
+
+import pytest
+
+# Mirror CouchPotato.py's sys.path setup (libs/ holds vendored deps such as
+# CodernityDB) so `import couchpotato` and everything under it resolves the
+# same way it does at runtime. tests/conftest.py already does this for the
+# whole suite, but keep this local and explicit in case the test is ever run
+# in isolation (e.g. `pytest tests/unit/test_plugin_import_sweep.py`).
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _path in (REPO_ROOT, os.path.join(REPO_ROOT, 'libs')):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+import couchpotato.core  # noqa: E402
+
+
+def _sweep_import_failures():
+    """Import every module under couchpotato.core, returning {name: traceback}."""
+    failures = {}
+
+    def onerror(name):
+        # Raised while walk_packages itself tries to import a *package* to
+        # recurse into it (e.g. a broken __init__.py in a subpackage).
+        failures[name] = traceback.format_exc()
+
+    for _finder, name, _ispkg in pkgutil.walk_packages(
+        couchpotato.core.__path__, prefix='couchpotato.core.', onerror=onerror
+    ):
+        if name in failures:
+            continue
+        try:
+            importlib.import_module(name)
+        except Exception:
+            failures[name] = traceback.format_exc()
+
+    return failures
+
+
+def test_every_core_module_imports_cleanly():
+    """No module under couchpotato.core should fail to import.
+
+    Regression guard for REG-001: PR #148 silently dropped nine plugins
+    (imdb, bluray, tmdb_charts, popularmovies, yifypopular, trakt automation,
+    filmweb, reddit, rottentomatoes) because they imported `fireEvent` via
+    `from couchpotato import fireEvent`, which broke when the re-export was
+    removed from `couchpotato/__init__.py`, and the Loader only logs
+    ImportError at DEBUG.
+    """
+    failures = _sweep_import_failures()
+
+    if failures:
+        details = '\n'.join(
+            f'--- {name} ---\n{tb}' for name, tb in sorted(failures.items())
+        )
+        pytest.fail(
+            f'{len(failures)} module(s) under couchpotato.core failed to import:\n{details}'
+        )
+
+
+def test_loader_logs_import_error_at_error_level(caplog):
+    """A plugin module that fails to import must be logged loudly.
+
+    Before REG-001, `Loader.loadModule()` caught ImportError/SyntaxError and
+    logged it at DEBUG (couchpotato/core/loader.py), which is exactly why the
+    nine broken plugins never showed up anywhere: DEBUG isn't even enabled by
+    default in production. loadModule() must still swallow the error (one bad
+    plugin shouldn't abort the rest) but it must log at ERROR with the
+    traceback so it's actually visible.
+    """
+    from couchpotato.core.loader import Loader
+
+    loader = Loader()
+
+    with caplog.at_level(logging.DEBUG):
+        result = loader.loadModule('couchpotato_reg001_test_nonexistent_module')
+
+    # Still returns None so the caller (Loader.run) can skip this one plugin
+    # and keep loading everything else.
+    assert result is None
+
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records, (
+        'Expected an ERROR-level log record for the failed import, got: '
+        f'{[(r.levelname, r.message) for r in caplog.records]}'
+    )
+    assert any('couchpotato_reg001_test_nonexistent_module' in r.message for r in error_records)

--- a/tests/unit/test_suggestion_ignore_concurrency.py
+++ b/tests/unit/test_suggestion_ignore_concurrency.py
@@ -126,8 +126,13 @@ def test_concurrent_ignore_stress_no_errors_and_no_lost_updates(monkeypatch):
     threads = [threading.Thread(target=worker, args=(t,)) for t in range(n_threads)]
     for t in threads:
         t.start()
+    # Bounded join so a reintroduced deadlock (e.g. a lock-ordering bug)
+    # fails fast with a clear signal instead of hanging until the blunt
+    # suite-wide pytest-timeout fires.
     for t in threads:
-        t.join()
+        t.join(timeout=30)
+    stuck = [t.name for t in threads if t.is_alive()]
+    assert not stuck, 'worker threads deadlocked / never finished: %r' % stuck
 
     assert not errors, 'concurrent ignoreSuggestion raised: %r' % errors
 

--- a/tests/unit/test_suggestion_ignore_concurrency.py
+++ b/tests/unit/test_suggestion_ignore_concurrency.py
@@ -1,0 +1,145 @@
+"""Regression tests for the REG-002 review finding: Suggestion._ignored races.
+
+``Suggestion._ignored`` is shared state mutated by ``ignoreSuggestion``
+(route ``suggestion.ignore``) and read by ``getSuggestions`` (route
+``suggestion.view``). ``callApiHandler``'s per-route ``api_locks`` only
+serialize same-route calls, and REG-002 moved API dispatch into the
+threadpool, so cross-route interleavings are now reachable from ordinary
+web traffic.
+
+The concrete lost-update mode tested deterministically here: without a lock
+held across add + snapshot + persist, request A can join its (stale)
+snapshot of the set, get pre-empted while request B adds an id and persists
+a newer snapshot, and then write its stale snapshot last — silently
+dropping B's ignore from the persisted value.
+
+(The classic ``RuntimeError: Set changed size during iteration`` mode is
+not deterministically reproducible under the GIL — ``str.join`` iterates
+the set inside a single C call — so it is covered only incidentally by the
+stress test below.)
+"""
+import threading
+
+from couchpotato.core.plugins.suggestion import Suggestion
+from couchpotato.environment import Env
+
+
+def _bare_suggestion():
+    """A Suggestion instance without __init__ side effects.
+
+    __init__ registers API views and events in module-global registries;
+    bypassing it keeps these tests hermetic. Instance attributes shadow the
+    class-level ``_ignored``/``_cache`` so the class object stays clean.
+    """
+    inst = object.__new__(Suggestion)
+    inst._ignored = set()
+    inst._cache = None
+    return inst
+
+
+def test_stale_ignore_snapshot_cannot_be_persisted_last(monkeypatch):
+    """A racing second ignore must not be overwritten by a stale snapshot.
+
+    Orchestrated interleaving (deterministic, mirrors the
+    TestConcurrentChartIgnore fake-Env.prop pattern in
+    test_race_conditions.py):
+
+    - Thread A ignores 'aaa'; its persist call is held open by fake_prop,
+      giving thread B the chance to slip in.
+    - Thread B ignores 'bbb'.
+    - Pre-fix (no lock): B's complete snapshot {'aaa','bbb'} lands first,
+      then A wakes and overwrites it with its stale {'aaa'} — 'bbb' is
+      silently lost from the persisted value.
+    - Post-fix: ignoreSuggestion holds the lock across add + persist, so B
+      cannot even reach fake_prop until A's write has landed; A's gate wait
+      simply times out and both ids survive.
+    """
+    stored = {}
+    a_inside_persist = threading.Event()
+    second_write_landed = threading.Event()
+    write_count = [0]
+
+    def fake_prop(identifier, value=None, default=None):
+        if value is None:
+            return stored.get(identifier, default)
+        write_count[0] += 1
+        if write_count[0] == 1:
+            a_inside_persist.set()
+            # Hold the first write open so a concurrent ignore can persist
+            # first (pre-fix it can; post-fix the lock keeps it out and
+            # this wait just times out).
+            second_write_landed.wait(timeout=0.5)
+            stored[identifier] = value
+        else:
+            stored[identifier] = value
+            second_write_landed.set()
+
+    monkeypatch.setattr(Env, 'prop', staticmethod(fake_prop))
+    inst = _bare_suggestion()
+
+    thread_a = threading.Thread(target=inst.ignoreSuggestion, kwargs={'imdb': 'aaa'})
+    thread_b = threading.Thread(target=inst.ignoreSuggestion, kwargs={'imdb': 'bbb'})
+
+    thread_a.start()
+    assert a_inside_persist.wait(timeout=2), 'thread A never reached the persist call'
+    thread_b.start()
+    thread_a.join(timeout=5)
+    thread_b.join(timeout=5)
+    assert not thread_a.is_alive() and not thread_b.is_alive()
+
+    persisted = set(stored['suggestion.ignored'].split(','))
+    assert persisted == {'aaa', 'bbb'}, (
+        'final persisted ignore list %r lost a concurrent ignore '
+        '(stale snapshot written last)' % sorted(persisted)
+    )
+
+
+def test_concurrent_ignore_stress_no_errors_and_no_lost_updates(monkeypatch):
+    """Many parallel ignoreSuggestion calls: no exception, nothing lost."""
+    stored = {}
+
+    def fake_prop(identifier, value=None, default=None):
+        if value is None:
+            return stored.get(identifier, default)
+        stored[identifier] = value
+
+    monkeypatch.setattr(Env, 'prop', staticmethod(fake_prop))
+
+    inst = _bare_suggestion()
+    # Pre-seed with many ids so the ','.join snapshot in the persist path is
+    # long enough for concurrent adds to interleave with it.
+    inst._ignored.update('seed%06d' % i for i in range(20000))
+
+    n_threads = 8
+    per_thread = 200
+    barrier = threading.Barrier(n_threads)
+    errors = []
+
+    def worker(tid):
+        try:
+            barrier.wait()
+            for i in range(per_thread):
+                inst.ignoreSuggestion(tmdb='t%d-%d' % (tid, i))
+        except Exception as e:  # pragma: no cover - only on regression
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(t,)) for t in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, 'concurrent ignoreSuggestion raised: %r' % errors
+
+    expected = {'t%d-%d' % (t, i) for t in range(n_threads) for i in range(per_thread)}
+
+    # In-memory set must contain every ignored id.
+    assert expected <= inst._ignored
+
+    # And so must the final persisted write: with add + snapshot + persist
+    # serialized under one lock, the chronologically last save necessarily
+    # contains every id added before it — i.e. all of them once the
+    # threads have finished.
+    persisted = set(stored['suggestion.ignored'].split(','))
+    missing = expected - persisted
+    assert not missing, 'last persisted write lost %d ignored ids' % len(missing)


### PR DESCRIPTION
## What broke

PR #148 removed the unused-looking `fireEvent` re-export from `couchpotato/__init__.py`. Nine plugin modules import it via the package root (`from couchpotato import fireEvent`), and `Loader.loadModule()` swallowed the resulting ImportError at **DEBUG**, so they vanished silently — green CI, nothing in logs:

- **Chart/automation providers**: `imdb` (charts + watchlist), `bluray`, `tmdb_charts`, `popularmovies`, `yifypopular`, `trakt` (watchlist) — plus `notifications.trakt` transitively
- **Userscript URL resolvers**: `filmweb`, `reddit`, `rottentomatoes`

User-visible: Suggestions → Charts shows "No charts available", all chart/automation provider sections gone from Settings, watchlist automation dead, add-via-URL broken for those sites. Verified on production v3.8.0.

## REG-001 (`e49cf5a5`)

- The nine modules import `fireEvent`/`Env` from their canonical homes.
- `Loader.loadModule()` logs plugin import failures at **ERROR** (still non-fatal to other plugins).
- New `tests/unit/test_plugin_import_sweep.py`: imports every module under `couchpotato.core`; fails on master naming exactly the 10 broken modules. A plugin can never vanish silently again.

## REG-002 (`28f374f3`, + `3f107ecd`/`3cce64f9` from review)

Restoring the chart scrapers exposed a pre-existing architecture bug: every route is `async def` calling the sync `callApiHandler` **on the event loop**, so one slow handler froze the whole server. Measured: cold `charts.view` = 84s of scraping; concurrent `/settings/` + `/wanted/` hung until it finished (9 E2E failures purely from head-of-line blocking).

- All 10 request-path `callApiHandler` dispatches now go through `starlette.concurrency.run_in_threadpool` (main `/api` dispatcher + 9 UI partials). Post-fix: `/login/` answers in **2.7ms** during a live 60s+ charts scrape.
- Safety: `SQLiteAdapter` is already cross-thread (`check_same_thread=False` + write RLock); background jobs already run concurrently with requests; `callApiHandler`'s per-route `api_locks` mean the new concurrency surface is cross-route only.
- Review follow-ups: `Suggestion._ignored` guarded by a module-level lock (lost-update race between `suggestion.view`/`suggestion.ignore` became reachable; deterministic regression test proves fail-before/pass-after), stress-test joins bounded.
- New `tests/unit/test_api_dispatch_concurrency.py`: a slow handler must not block a concurrent fast request (fails on the pre-fix dispatch, verified by two independent reviewers reverting the change).

## Verification

- 771 unit tests green, ruff clean.
- Fresh full E2E: 129/130, sole failure is the known-flaky `Navigation › sidebar links` test which passes on immediate retry; suite wall-time back to 5.3m (was 9.9m with the blocking bug).
- Boot check: all restored providers load; settings sections (`imdb`, `bluray`, `tmdb_charts`, `popularmovies`, `ytspopular`, `trakt`) reappear.
- Local review gate: two full-branch reviewers + one delta reviewer, all findings resolved; TDD claims verified empirically (reviewers reverted the fixes and watched the tests fail).

Specs: `specs/REG-001-restore-plugin-loading.md`, `specs/REG-002-threadpool-api-dispatch.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RU1LBHaKDFozqA36bxkeY