### PR TITLE
fix: P0 security & observability hardening (REG-003)

### DIFF
--- a/couchpotato/core/_base/_core.py
+++ b/couchpotato/core/_base/_core.py
@@ -5,7 +5,6 @@ import signal
 import time
 import traceback
 import webbrowser
-import sys
 
 from couchpotato.api import addApiView
 from couchpotato.core.event import fireEvent, addEvent
@@ -65,14 +64,6 @@ class Core(Plugin):
         # Set default urlopen timeout
         import socket
         socket.setdefaulttimeout(30)
-
-        # Don't check ssl by default
-        try:
-            if sys.version_info >= (2, 7, 9):
-                import ssl
-                ssl._create_default_https_context = ssl._create_unverified_context
-        except Exception:
-            log.debug('Failed setting default ssl context: %s', traceback.format_exc())
 
     def dependencies(self):
 

--- a/couchpotato/core/event.py
+++ b/couchpotato/core/event.py
@@ -48,12 +48,20 @@ def addEvent(name, handler, priority=100):
                 if bc:
                     parent.beforeCall(handler)
 
-            h = runHandler(name, handler, *args, **kwargs)
-
-            if parent and has_parent:
-                ac = hasattr(parent, 'afterCall')
-                if ac:
-                    parent.afterCall(handler)
+            # afterCall MUST run even if the handler raises -- runHandler
+            # re-raises handler exceptions by design, and beforeCall has
+            # already marked `<Class>.<method>` running. Without the finally,
+            # a raised handler would leak that entry in Plugin._running
+            # forever, so `fireEvent('plugin.running', merge=True)` would
+            # never drain and Core.initShutdown's wait loop would hang on its
+            # hard 30s timeout for the rest of the process life. PR #151.
+            try:
+                h = runHandler(name, handler, *args, **kwargs)
+            finally:
+                if parent and has_parent:
+                    ac = hasattr(parent, 'afterCall')
+                    if ac:
+                        parent.afterCall(handler)
         except Exception:
             log.error('Failed creating handler %s %s: %s', name, handler, traceback.format_exc())
 

--- a/couchpotato/core/event.py
+++ b/couchpotato/core/event.py
@@ -34,7 +34,13 @@ def addEvent(name, handler, priority=100):
     def createHandle(*args, **kwargs):
         h = None
         try:
-            has_parent = hasattr(handler, 'im_self')
+            # `__self__` is the Python 3 attribute holding a bound method's
+            # owning instance (the Python 2 name was `im_self`, which is
+            # always absent on Python 3 -- see REG-003 item 6). Detecting
+            # it correctly is what lets beforeCall/afterCall populate
+            # Plugin._running, which Core.initShutdown's wait loop depends
+            # on to know when it's safe to shut down.
+            has_parent = hasattr(handler, '__self__')
             parent = None
             if has_parent:
                 parent = handler.__self__

--- a/couchpotato/core/logger.py
+++ b/couchpotato/core/logger.py
@@ -15,8 +15,12 @@ import logging
 import re
 import sys
 
-# Custom log level for "info2" (less important info, between DEBUG and INFO)
-INFO2 = 19
+# Custom log level for "info2" (release-rejection reasons, provider
+# circuit-breaker trips, etc). Must be ABOVE INFO (20) so it is visible at
+# the default production log level -- setup_logging(debug=False) sets the
+# root logger to INFO, and anything below that threshold is dropped before
+# it ever reaches a handler. REG-003 item 4.
+INFO2 = 21
 logging.addLevelName(INFO2, 'INFO')
 
 # Privacy filter patterns
@@ -147,10 +151,21 @@ def setup_logging(log_path=None, debug=False, console=True, encoding='utf-8'):
     fmt = '%(asctime)s %(levelname)s %(message)s'
     datefmt = '%m-%d %H:%M:%S'
 
+    # Privacy filter must be attached to each HANDLER, not the root logger.
+    # A Logger's own `.filters` only run for records that *originate* on
+    # that logger (see Logger.handle()); CPLog always logs through a named
+    # child logger, whose records reach the root's handlers via
+    # `callHandlers()` without ever consulting the root logger's own
+    # filters. Handler.handle() re-checks its filters for every record it
+    # emits regardless of which logger it came from, so attaching there
+    # actually redacts secrets (api_key, passkey, ...) in logged URLs.
+    # REG-003 item 5.
+
     # Console handler with colors
     if console:
         console_handler = logging.StreamHandler(sys.stderr)
         console_handler.setFormatter(ColorFormatter(fmt, datefmt))
+        console_handler.addFilter(PrivacyFilter())
         logger.addHandler(console_handler)
 
     # File handler (no colors)
@@ -160,10 +175,8 @@ def setup_logging(log_path=None, debug=False, console=True, encoding='utf-8'):
             backupCount=10, encoding=encoding
         )
         file_handler.setFormatter(logging.Formatter(fmt, datefmt))
+        file_handler.addFilter(PrivacyFilter())
         logger.addHandler(file_handler)
-
-    # Add privacy filter to root logger
-    logger.addFilter(PrivacyFilter())
 
     # Quiet noisy libraries
     for name in ['enzyme', 'guessit', 'subliminal', 'apscheduler', 'uvicorn', 'requests']:

--- a/couchpotato/core/plugins/base.py
+++ b/couchpotato/core/plugins/base.py
@@ -166,10 +166,24 @@ class Plugin:
         )
 
 
+    # Bookkeeping/query handlers that must NOT be recorded as "running" when
+    # they execute. `isRunning` is itself registered as a `plugin.running`
+    # event handler (see registerPlugin), so if call-tracking recorded it,
+    # querying "who is running" would append its own entry and then return a
+    # snapshot that includes it -- `fireEvent('plugin.running', merge=True)`
+    # in Core.initShutdown would never drain and every shutdown/restart would
+    # hang on the hard 30s timeout. It's the only handler that reads
+    # `_running`, so a targeted exemption is sufficient. REG-003 review.
+    _call_tracking_exempt = frozenset({'isRunning'})
+
     def beforeCall(self, handler):
+        if handler.__name__ in self._call_tracking_exempt:
+            return
         self.isRunning('%s.%s' % (self.getName(), handler.__name__))
 
     def afterCall(self, handler):
+        if handler.__name__ in self._call_tracking_exempt:
+            return
         self.isRunning('%s.%s' % (self.getName(), handler.__name__), False)
 
     def doShutdown(self, *args, **kwargs):

--- a/couchpotato/core/plugins/scanner/folder_scanner.py
+++ b/couchpotato/core/plugins/scanner/folder_scanner.py
@@ -51,12 +51,9 @@ class FolderScannerMixin:
         leftovers = []
 
         if not files:
+            files = []
             try:
-                files = []
-                for root, dirs, walk_files in os.walk(folder, followlinks=True):
-                    files.extend([sp(os.path.join(sp(root), sp(filename))) for filename in walk_files])
-                    if self.shuttingDown():
-                        break
+                files = self._gatherFiles(folder)
             except Exception:
                 log.error('Failed getting files from %s: %s', folder, traceback.format_exc())
 
@@ -300,6 +297,46 @@ class FolderScannerMixin:
             log.debug('Found no movies in the folder %s', folder)
 
         return processed_movies
+
+    def _gatherFiles(self, folder):
+        """Walk `folder` and return every file found inside it.
+
+        Any entry (whether reached directly or via a symlinked directory)
+        whose real path resolves outside `folder` is skipped. Without this,
+        a symlink planted inside a release folder can point at an arbitrary
+        file elsewhere on disk (e.g. a large host file); once "scanned" as
+        a movie file, the renamer would move/delete the real target instead
+        of the symlink. `os.walk`'s `followlinks` flag does not help here --
+        it only controls recursion into symlinked *directories*, symlinked
+        *files* are listed regardless of that flag -- so containment has to
+        be checked per file. REG-003 item 2.
+        """
+        real_folder = os.path.realpath(folder)
+
+        found_files = []
+        for root, dirs, walk_files in os.walk(folder, followlinks=True):
+            for filename in walk_files:
+                file_path = sp(os.path.join(sp(root), sp(filename)))
+
+                if not self._isWithinFolder(file_path, real_folder):
+                    log.debug('Skipping file that resolves outside the scanned folder (symlink escape): %s', file_path)
+                    continue
+
+                found_files.append(file_path)
+
+            if self.shuttingDown():
+                break
+
+        return found_files
+
+    @staticmethod
+    def _isWithinFolder(file_path, real_folder):
+        try:
+            real_path = os.path.realpath(file_path)
+            return os.path.commonpath([real_folder, real_path]) == real_folder
+        except ValueError:
+            # e.g. paths on different drives on Windows
+            return False
 
     def determineMedia(self, group, release_download=None):
         imdb_id = release_download and release_download.get('imdb_id')

--- a/couchpotato/core/plugins/scanner/folder_scanner.py
+++ b/couchpotato/core/plugins/scanner/folder_scanner.py
@@ -51,11 +51,7 @@ class FolderScannerMixin:
         leftovers = []
 
         if not files:
-            files = []
-            try:
-                files = self._gatherFiles(folder)
-            except Exception:
-                log.error('Failed getting files from %s: %s', folder, traceback.format_exc())
+            files = self._gatherFiles(folder)
 
             log.debug('Found %s files to scan and group in %s', len(files), folder)
         else:
@@ -310,22 +306,30 @@ class FolderScannerMixin:
         it only controls recursion into symlinked *directories*, symlinked
         *files* are listed regardless of that flag -- so containment has to
         be checked per file. REG-003 item 2.
+
+        Best-effort: if the walk raises partway through (e.g. a permission
+        error deep in the tree), the files gathered before the error are
+        still returned rather than discarded, matching the pre-refactor
+        behaviour.
         """
         real_folder = os.path.realpath(folder)
 
         found_files = []
-        for root, dirs, walk_files in os.walk(folder, followlinks=True):
-            for filename in walk_files:
-                file_path = sp(os.path.join(sp(root), sp(filename)))
+        try:
+            for root, dirs, walk_files in os.walk(folder, followlinks=True):
+                for filename in walk_files:
+                    file_path = sp(os.path.join(sp(root), sp(filename)))
 
-                if not self._isWithinFolder(file_path, real_folder):
-                    log.debug('Skipping file that resolves outside the scanned folder (symlink escape): %s', file_path)
-                    continue
+                    if not self._isWithinFolder(file_path, real_folder):
+                        log.debug('Skipping file that resolves outside the scanned folder (symlink escape): %s', file_path)
+                        continue
 
-                found_files.append(file_path)
+                    found_files.append(file_path)
 
-            if self.shuttingDown():
-                break
+                if self.shuttingDown():
+                    break
+        except Exception:
+            log.error('Failed getting files from %s: %s', folder, traceback.format_exc())
 
         return found_files
 

--- a/couchpotato/core/plugins/scanner/folder_scanner.py
+++ b/couchpotato/core/plugins/scanner/folder_scanner.py
@@ -307,6 +307,17 @@ class FolderScannerMixin:
         *files* are listed regardless of that flag -- so containment has to
         be checked per file. REG-003 item 2.
 
+        Escaping symlinked *directories* are additionally pruned in place
+        (`dirs[:] = ...`) BEFORE os.walk recurses into them. Filtering only
+        per-file would let os.walk fully enumerate the escape target first
+        (an NFS mount, /proc, another library) -- a scan-time perf/DoS hit --
+        and, since `followlinks=True` has no loop detection, a dir symlink
+        chain could otherwise be followed until the OS symlink limit. Pruning
+        keeps the "whole scanned folder is itself a symlink" case working
+        (its own realpath is the containment boundary) while stopping descent
+        into inner escaping symlinked dirs. The per-file check is retained as
+        belt-and-braces for file symlinks. PR #151 review.
+
         Best-effort: if the walk raises partway through (e.g. a permission
         error deep in the tree), the files gathered before the error are
         still returned rather than discarded, matching the pre-refactor
@@ -317,6 +328,10 @@ class FolderScannerMixin:
         found_files = []
         try:
             for root, dirs, walk_files in os.walk(folder, followlinks=True):
+                # Prune escaping symlinked subdirs before descending into them.
+                dirs[:] = [d for d in dirs
+                           if self._isWithinFolder(os.path.join(root, d), real_folder)]
+
                 for filename in walk_files:
                     file_path = sp(os.path.join(sp(root), sp(filename)))
 

--- a/couchpotato/runner.py
+++ b/couchpotato/runner.py
@@ -252,6 +252,22 @@ def runCouchPotato(options, base_path, args, data_dir=None, log_dir=None, Env=No
     fireEventAsync('app.load')
 
     # Run with uvicorn
+    try:
+        _run_uvicorn(application, config, debug)
+    except Exception as e:
+        log.error('Failed starting: %s', traceback.format_exc())
+        if hasattr(e, 'errno') and e.errno == 48:
+            log.info('Port (%s) is already in use', config.get('port'))
+
+
+def _run_uvicorn(application, config, debug):
+    """Start the uvicorn ASGI server for `application`.
+
+    `access_log=False` keeps request paths -- which embed the URL-based
+    api_key (see CLAUDE.md "Known Technical Debt") -- out of uvicorn's
+    access log, which would otherwise land in stdout/`docker logs` on every
+    request. REG-003 item 3.
+    """
     import uvicorn
 
     ssl_kwargs = {}
@@ -261,16 +277,12 @@ def runCouchPotato(options, base_path, args, data_dir=None, log_dir=None, Env=No
             'ssl_keyfile': config['ssl_key'],
         }
 
-    try:
-        uvicorn.run(
-            application,
-            host=config['host'],
-            port=config['port'],
-            reload=config['use_reloader'],
-            log_level='debug' if debug else 'info',
-            **ssl_kwargs
-        )
-    except Exception as e:
-        log.error('Failed starting: %s', traceback.format_exc())
-        if hasattr(e, 'errno') and e.errno == 48:
-            log.info('Port (%s) is already in use', config.get('port'))
+    uvicorn.run(
+        application,
+        host=config['host'],
+        port=config['port'],
+        reload=config['use_reloader'],
+        log_level='debug' if debug else 'info',
+        access_log=False,
+        **ssl_kwargs
+    )

--- a/specs/REG-003-p0-security-observability.md
+++ b/specs/REG-003-p0-security-observability.md
@@ -95,6 +95,29 @@ symlinking a subtree in.
 created inside a `tmp_path` scan folder pointing at a file created *outside*
 that folder is not returned as a scannable file by `scan()`.
 
+### PR #151 review follow-up (MEDIUM): prune escaping dirs before recursion
+Cloud review noted that per-file containment runs *after*
+`os.walk(followlinks=True)` has already recursed into an escaping symlinked
+*subdirectory* — so the escape target (an NFS mount, `/proc`, another
+library) still gets fully walked at scan time (perf/DoS), and, since
+`followlinks=True` has no loop detection, a dir-symlink chain could be
+followed to the OS symlink limit. Fix: prune in place inside the walk loop —
+`dirs[:] = [d for d in dirs if self._isWithinFolder(os.path.join(root, d),
+real_folder)]` — so os.walk never descends into an escaping symlinked dir.
+The "whole scanned folder is itself a symlink" case still works (its own
+realpath is the containment boundary); the per-file check is kept as
+belt-and-braces for *file* symlinks. Tests:
+`test_escaping_symlinked_dir_is_not_descended_into` (spies on `os.walk` and
+asserts the escape target is never yielded as a visited root — the stronger
+claim per-file filtering alone does not provide) and
+`test_self_looping_symlink_terminates`.
+
+> Note: this closes the *scan-time* symlink exposure. A residual
+> time-of-check/time-of-use gap at *move/rename* time (a path validated here
+> could be swapped for a symlink before the renamer acts on it) is out of
+> scope for this package and routed to the renamer package by the
+> orchestrator.
+
 ## 3. API key leaked to logs (HIGH)
 
 ### Problem
@@ -245,6 +268,24 @@ sufficient; no other handler has the self-counting problem.
   and reports *only* a genuinely in-flight handler when one plugin's
   `_running` is non-empty. Fails on the blocked code
   (`['PluginA.isRunning', 'PluginB.isRunning']`), passes after the exemption.
+
+### PR #151 review follow-up (HIGH): afterCall must run on handler exception
+Cloud review found a second door to the same shutdown-hang failure mode.
+`createHandle` marks the handler running via `beforeCall`, then calls
+`runHandler`, which **re-raises** handler exceptions by design. `afterCall`
+only ran on the success path, so any tracked handler that raised leaked its
+`beforeCall` entry in `Plugin._running` permanently — after that,
+`fireEvent('plugin.running', merge=True)` never returns `[]` again and
+`Core.initShutdown` hangs on its hard 30s timeout for the rest of the
+process life. The `isRunning` exemption does **not** cover this (any *other*
+handler raising leaks). Fix: wrap the call so `afterCall` always runs —
+`try: h = runHandler(...) finally: afterCall (if present)` — keeping the
+outer `except Exception` swallow so one bad handler still doesn't kill the
+whole `fireEvent` dispatch. Tests
+(`tests/unit/test_event_system.py::TestAfterCallOnHandlerException`): a real
+`Plugin` handler that raises leaves `_running` empty afterward AND
+`fireEvent('plugin.running', merge=True)` returns `[]`. Both fail without the
+`finally`.
 
 ## CLAUDE.md "Known Technical Debt" lines this makes stale
 

--- a/specs/REG-003-p0-security-observability.md
+++ b/specs/REG-003-p0-security-observability.md
@@ -1,0 +1,226 @@
+# REG-003: P0 Security + Observability Hardening
+
+Five independent findings from a code review. Each is fixed with the smallest
+correct diff and a TDD regression test.
+
+## 1. Global TLS validation disabled (CRITICAL)
+
+### Problem
+`couchpotato/core/_base/_core.py` (in `Core.__init__`) globally monkeypatches
+the stdlib default HTTPS context:
+
+```python
+try:
+    if sys.version_info >= (2, 7, 9):
+        import ssl
+        ssl._create_default_https_context = ssl._create_unverified_context
+except Exception:
+    log.debug('Failed setting default ssl context: %s', traceback.format_exc())
+```
+
+This disables certificate validation (no hostname check, no CA verification)
+for **every** `urllib`/`http.client`-based HTTPS call made anywhere in the
+process for the lifetime of the app — not just CouchPotato's own requests.
+It's a leftover Python-2.7.9 workaround (the version guard is dead code on
+Python 3.10+, which is the supported floor per `CLAUDE.md`). A
+man-in-the-middle can intercept any HTTPS call CouchPotato or a library it
+loads makes (provider APIs, notifications, update checks, etc.) and the app
+will not notice.
+
+Grepped the tree for anything relying on unverified requests specifically:
+no call site depends on this monkeypatch. The bundled `HttpClient` /
+`requests`-based helpers use `requests`, which does its own verification
+independent of the stdlib default context; nothing exercises
+`urllib.request.urlopen` against a self-signed/legacy host that needed this
+patch.
+
+### Fix
+Delete the monkeypatch entirely (`couchpotato/core/_base/_core.py`). No
+call site needs an unverified context, so there is nothing to scope down.
+
+### Test
+`tests/unit/test_core_ssl_context.py` — after importing
+`couchpotato.core._base._core`, `ssl._create_default_https_context()` must
+have `verify_mode == ssl.CERT_REQUIRED` and `check_hostname is True` (i.e. the
+stdlib default, unmodified).
+
+## 2. Symlink-following scanner (CRITICAL)
+
+### Problem
+`couchpotato/core/plugins/scanner/folder_scanner.py` (`FolderScannerMixin.scan`)
+walked the release folder with `os.walk(folder, followlinks=True)`. A
+malicious/corrupt release containing a symlink to a large host file (e.g.
+`/etc/shadow`, a Docker socket, another user's media library) gets treated as
+a normal scannable movie file. Once picked up, the renamer will move/rename/
+delete the file the symlink points at — i.e. the *real* target outside the
+scanned folder — not just the symlink itself.
+
+**Important finding during TDD:** `followlinks` only controls whether
+`os.walk` *recurses into symlinked directories*; it has no effect on whether
+a symlink to a *regular file* appears in `os.walk`'s `files` list — that
+happens regardless of `followlinks`. Verified locally:
+
+```python
+os.symlink(secret_file, os.path.join(scan_dir, 'link.mkv'))
+# os.walk(scan_dir, followlinks=True)  -> lists link.mkv
+# os.walk(scan_dir, followlinks=False) -> lists link.mkv  (same!)
+```
+
+So "just drop `followlinks=True`" alone does **not** close the hole for the
+attack as described (a symlink to a file, not a directory) — it only reduces
+the *separate* risk of recursing into a symlinked subdirectory that points
+outside the scanned tree.
+
+### Fix (chosen: realpath containment, not just dropping `followlinks`)
+Kept `followlinks=True` (so folder-level symlinked media libraries — a
+common home-media-server pattern — keep working), but added a containment
+check: for every file yielded by the walk, resolve its real path with
+`os.path.realpath()` and skip it if that real path does not resolve inside
+`os.path.realpath(folder)`. This closes the actual vulnerability (a symlink —
+file or directory — that escapes the scanned folder is never handed to the
+rest of the scan/rename pipeline) while still supporting the case where the
+*whole* scanned folder itself is a symlink/mountpoint (its realpath is
+computed once and used as the containment boundary, so everything genuinely
+inside it still passes).
+
+Trade-off documented: a subdirectory *inside* the scanned folder that is
+itself a symlink to a location outside the scanned tree is now excluded from
+scanning. Given the CRITICAL severity (arbitrary host file corruption via
+rename/delete), this is the correct default; anyone with that specific setup
+should point the library entry directly at the storage location instead of
+symlinking a subtree in.
+
+### Test
+`tests/unit/test_scanner_modules.py::TestSymlinkContainment` — a symlink
+created inside a `tmp_path` scan folder pointing at a file created *outside*
+that folder is not returned as a scannable file by `scan()`.
+
+## 3. API key leaked to logs (HIGH)
+
+### Problem
+`couchpotato/runner.py` calls `uvicorn.run(...)` without `access_log=False`.
+CouchPotato's API auth is URL-based (`api_key` embedded in the request path,
+per `CLAUDE.md`'s "Known Technical Debt"), so uvicorn's default access log
+writes every request path — including the api_key — to stdout, which lands
+in `docker logs` in the shipped container.
+
+### Fix
+Extracted the uvicorn invocation into a small, directly-testable
+`_run_uvicorn(application, config, debug)` helper in `couchpotato/runner.py`
+and added `access_log=False` to the `uvicorn.run(...)` call. This keeps the
+change minimal while making it possible to unit test the server invocation
+without standing up the full `runCouchPotato` startup pipeline (DB, plugin
+loader, etc.), which has no existing test seam.
+
+### Test
+`tests/unit/test_runner_uvicorn.py` — patches `uvicorn.run`, calls
+`_run_uvicorn(...)`, and asserts it was called with `access_log=False`.
+
+## 4. `info2` log level invisible in production (HIGH)
+
+### Problem
+`couchpotato/core/logger.py` defines `INFO2 = 19`, which is *below*
+`logging.INFO` (20). The root logger defaults to `INFO` in
+non-debug/production mode (`setup_logging(debug=False)`), so any
+`log.info2(...)` call — used for release-rejection reasons and provider
+circuit-breaker trips — is silently dropped by the standard level filter
+before it ever reaches a handler.
+
+### Fix
+Changed `INFO2` from `19` to `21` (between `INFO`=20 and `WARNING`=30), so it
+is visible at the default production level. Kept
+`logging.addLevelName(INFO2, 'INFO')` as-is (unchanged registration behavior
+— the display name stays `INFO` intentionally, matching the pre-existing
+`ColorFormatter` mapping which already keyed off the `INFO2` constant rather
+than the literal number, so no other code needed to change).
+
+Checked for any code that relies on `info2` being *below* `info` (e.g. a
+level comparison or a "DEBUG < INFO2 < INFO" invariant) — found none;
+`ColorFormatter.COLORS` and the level-name registration both reference the
+`INFO2` symbol, not the literal `19`, so they pick up the new value
+automatically.
+
+### Test
+`tests/unit/test_logging.py::TestSetupLogging::test_info2_visible_in_production_level`
+— configures logging via `setup_logging(debug=False)` (production level) and
+asserts a `log.info2(...)` record is emitted to a handler (previously
+swallowed at level 19 < 20).
+
+## 5. `PrivacyFilter` never applied (HIGH)
+
+### Problem
+`couchpotato/core/logger.py::setup_logging` attaches `PrivacyFilter` to the
+**root logger** via `logger.addFilter(...)`. Per stdlib `logging` semantics,
+filters attached to a `Logger` (as opposed to a `Handler`) only run for
+records *originated* by that logger — they are **not** re-applied to records
+that arrive via propagation from a child logger. `CPLog` always logs through
+a named child logger (`logging.getLogger(context)`), so in practice every
+record CouchPotato ever logs propagates up to the root logger and is emitted
+by the root's handlers *without* ever passing through the root logger's own
+filter list. Net effect: API keys/passkeys embedded in logged URLs are never
+redacted in production.
+
+### Fix
+Moved the `PrivacyFilter` from the root **logger** to each root **handler**
+(`console_handler` and `file_handler`) in `setup_logging`. Handler-level
+filters run for every record the handler emits regardless of which logger in
+the hierarchy the record originated from, which is what's needed here.
+
+### Test
+`tests/unit/test_logging.py::TestSetupLogging::test_privacy_filter_applied_via_child_logger`
+— configures logging via `setup_logging`, logs through a *named child*
+`CPLog` logger with an `api_key=SECRET` message, and asserts the secret does
+not appear in the handler's emitted output (captured via a `StringIO`-backed
+`StreamHandler` swapped in for the test).
+
+## 6. Py2 `im_self` remnant disabled graceful shutdown (MED, reliability)
+
+### Problem
+`couchpotato/core/event.py::addEvent`'s `createHandle` closure detects
+whether an event handler is a bound method (so it can call
+`parent.beforeCall(handler)` / `parent.afterCall(handler)` on the owning
+`Plugin` instance) via `hasattr(handler, 'im_self')`. `im_self` was the
+Python 2 attribute name for a bound method's instance; Python 3 uses
+`__self__`. `hasattr(handler, 'im_self')` is therefore always `False` on
+Python 3, so `beforeCall`/`afterCall` never fire for any plugin event
+handler. This means `Plugin._running` (populated by `beforeCall` via
+`isRunning(...)`) never gets entries, so
+`Core.initShutdown`'s wait loop —
+`fireEvent('plugin.running', merge=True)` — always reports nothing running
+and shutdown/restart never actually waits for in-flight plugin work to
+finish before tearing down.
+
+### Fix
+Changed `hasattr(handler, 'im_self')` to `hasattr(handler, '__self__')` in
+`couchpotato/core/event.py`.
+
+### Test
+`tests/unit/test_event_system.py::TestBeforeAfterCall` — registers a bound
+method of a `Plugin` instance as an event handler, fires the event from
+inside the handler body (so we can observe state *during* the call), and
+asserts `plugin.isRunning()` contains the handler's running-key during the
+call and no longer contains it afterward.
+
+## CLAUDE.md "Known Technical Debt" lines this makes stale
+
+(Orchestrator updates `CLAUDE.md` centrally — noting here for that pass.)
+
+- `API auth via URL key only, no rate limiting` — still true structurally,
+  but the specific consequence "the api_key leaks into `docker logs` via
+  uvicorn's access log" (item 3) and "logged URLs are never redacted" (item
+  5) are now fixed; the line itself should probably be kept (auth mechanism
+  unchanged) but could gain a footnote that log exposure of the key is now
+  mitigated.
+- No existing debt line covers the TLS monkeypatch, the scanner symlink
+  issue, the `info2` level bug, or the `im_self` shutdown bug — these were
+  undocumented defects, not listed debt, so no existing bullet needs
+  removal; the orchestrator may want to note the fixes in a "Recently Fixed"
+  section instead.
+
+## Acceptance Criteria
+
+- [ ] All 6 fixes above implemented with a failing-then-passing regression test
+- [ ] `.venv/bin/python -m pytest tests/unit/ -q` — fully green
+- [ ] `.venv/bin/ruff check .` — clean
+- [ ] No changes under `libs/`, `couchpotato/lib/`, or to CodernityDB
+- [ ] Commit message: `fix(security,logging): P0 hardening — TLS, symlink scan, key-in-logs, log visibility, shutdown wait (REG-003)`

--- a/specs/REG-003-p0-security-observability.md
+++ b/specs/REG-003-p0-security-observability.md
@@ -116,6 +116,19 @@ loader, etc.), which has no existing test seam.
 `tests/unit/test_runner_uvicorn.py` — patches `uvicorn.run`, calls
 `_run_uvicorn(...)`, and asserts it was called with `access_log=False`.
 
+### Trade-off / follow-up (noted, not implemented here)
+`access_log=False` disables uvicorn's request access log **entirely** — not
+just the api_key portion of it. That removes the per-request line
+(method/path/status/latency) that can be useful for debugging and basic
+traffic visibility. The correct long-term fix is redacted request logging
+(a custom access-log formatter / logging middleware that strips the
+`api_key` path segment and query param but still emits the request line, or
+moving API auth off the URL entirely). That is deliberately **out of scope**
+for this P0 hardening pass and is tracked as a **separate follow-up** — the
+immediate priority is stopping the secret from leaking, and turning the
+access log off is the smallest change that does so. Do not re-enable
+`access_log` without the redaction layer in place.
+
 ## 4. `info2` log level invisible in production (HIGH)
 
 ### Problem
@@ -194,12 +207,44 @@ finish before tearing down.
 Changed `hasattr(handler, 'im_self')` to `hasattr(handler, '__self__')` in
 `couchpotato/core/event.py`.
 
+### Review follow-up (BLOCKER found in local review): isRunning self-count
+Re-enabling `beforeCall`/`afterCall` surfaced a latent self-referential bug.
+Every `Plugin` registers `addEvent('plugin.running', self.isRunning)` in
+`registerPlugin`. When `Core.initShutdown` fires `plugin.running`, the
+call-tracking wrapper would record the `isRunning` bookkeeping handler
+itself as "running" (append `"<Class>.isRunning"` to `_running`) and then
+`isRunning()` returns a snapshot that includes that just-added entry.
+Result: `fireEvent('plugin.running', merge=True)` is **never** empty, none
+of the reported `*.isRunning` entries are in `Core.ignore_restart`, so the
+shutdown/restart wait loop always burns its hard 30s timeout — a mandatory
+30s hang on every UI restart, auto-update restart, and post-migration
+restart (where before the `im_self` fix it was an instant no-op).
+
+Fix: exempt query/bookkeeping handlers from call-tracking. Added a
+`Plugin._call_tracking_exempt = frozenset({'isRunning'})` set and a guard in
+`Plugin.beforeCall`/`afterCall` that returns early when
+`handler.__name__` is in it. Placed in `base.py` (not `event.py`) because
+the exemption is *Plugin domain knowledge* — the generic event dispatcher
+shouldn't know that `isRunning` is special — and expressed as a named set
+rather than an inline magic string so future exempt handlers are added in
+one obvious place. Grepped for other event handlers that read `_running`:
+`isRunning` is the only reader (the only method that both queries `_running`
+and is registered as an event handler), so a targeted exemption is
+sufficient; no other handler has the self-counting problem.
+
 ### Test
-`tests/unit/test_event_system.py::TestBeforeAfterCall` — registers a bound
-method of a `Plugin` instance as an event handler, fires the event from
-inside the handler body (so we can observe state *during* the call), and
-asserts `plugin.isRunning()` contains the handler's running-key during the
-call and no longer contains it afterward.
+- `tests/unit/test_event_system.py::TestBeforeAfterCall` — registers a bound
+  method (`work`, a normal handler) of a `Plugin` instance as an event
+  handler, observes state *during* the call, and asserts `_running` contains
+  the handler's key during the call and is cleared afterward (proves
+  before/afterCall genuinely fire).
+- `tests/unit/test_event_system.py::TestPluginRunningAggregation` — exercises
+  the real `plugin.running` aggregation the way `initShutdown` uses it:
+  registers two actual `Plugin` subclasses and asserts
+  `fireEvent('plugin.running', merge=True)` is `[]` when nothing is running,
+  and reports *only* a genuinely in-flight handler when one plugin's
+  `_running` is non-empty. Fails on the blocked code
+  (`['PluginA.isRunning', 'PluginB.isRunning']`), passes after the exemption.
 
 ## CLAUDE.md "Known Technical Debt" lines this makes stale
 

--- a/tests/unit/test_core_ssl_context.py
+++ b/tests/unit/test_core_ssl_context.py
@@ -1,0 +1,29 @@
+"""Regression test for REG-003 item 1: global TLS validation must not be disabled.
+
+couchpotato/core/_base/_core.py used to monkeypatch
+`ssl._create_default_https_context = ssl._create_unverified_context` inside
+`Core.__init__`, disabling certificate + hostname validation for every
+stdlib HTTPS call made anywhere in the process for the lifetime of the app.
+Instantiating Core must not alter the stdlib default HTTPS context.
+"""
+import ssl
+
+from couchpotato.environment import Env
+
+
+def test_instantiating_core_does_not_disable_ssl_verification(monkeypatch):
+    from couchpotato.core._base._core import Core
+
+    # Skip registering global SIGINT/SIGTERM handlers (unrelated side effect
+    # of Core.__init__ that would clobber pytest's own signal handling).
+    monkeypatch.setattr(Env, '_desktop', True)
+
+    original_context_factory = ssl._create_default_https_context
+    try:
+        Core()
+
+        ctx = ssl._create_default_https_context()
+        assert ctx.verify_mode == ssl.CERT_REQUIRED
+        assert ctx.check_hostname is True
+    finally:
+        ssl._create_default_https_context = original_context_factory

--- a/tests/unit/test_event_system.py
+++ b/tests/unit/test_event_system.py
@@ -243,6 +243,49 @@ class TestErrorHandling:
         assert 'good' in result
 
 
+class TestBeforeAfterCall:
+    """REG-003 item 6: addEvent's createHandle used to detect a bound-method
+    handler via `hasattr(handler, 'im_self')` -- the Python 2 attribute name
+    for a bound method's owning instance. On Python 3 this is always False
+    (the attribute is `__self__`), so `Plugin.beforeCall`/`afterCall` never
+    ran for any plugin event handler, `Plugin._running` never got entries,
+    and `Core.initShutdown`'s wait loop (`fireEvent('plugin.running',
+    merge=True)`) was a silent no-op -- shutdown/restart never actually
+    waited for in-flight plugin work.
+    """
+
+    def test_bound_method_handler_populates_running_during_call(self):
+        from couchpotato.core.event import addEvent, fireEvent, events
+        from couchpotato.core.plugins.base import Plugin
+
+        events.clear()
+        try:
+            class FakePlugin(Plugin):
+                def __init__(self):
+                    self.observed_running = None
+
+                def work(self):
+                    # Snapshot _running from *inside* the call, since
+                    # afterCall clears it again once the handler returns.
+                    self.observed_running = list(self.isRunning())
+                    return 'done'
+
+            plugin = FakePlugin()
+            addEvent('test.reg003.before_after_call', plugin.work)
+
+            result = fireEvent('test.reg003.before_after_call', single=True)
+
+            assert result == 'done'
+            assert plugin.observed_running == ['FakePlugin.work'], (
+                'beforeCall never populated Plugin._running during the call'
+            )
+            assert plugin.isRunning() == [], (
+                'afterCall never cleared Plugin._running after the call'
+            )
+        finally:
+            events.clear()
+
+
 class TestGetEvent:
     def test_get_event(self):
         from couchpotato.core.event import addEvent, getEvent

--- a/tests/unit/test_event_system.py
+++ b/tests/unit/test_event_system.py
@@ -355,6 +355,70 @@ class TestPluginRunningAggregation:
             events.clear()
 
 
+class TestAfterCallOnHandlerException:
+    """PR #151 review (HIGH): afterCall must run even when the handler raises.
+
+    createHandle marks `<Class>.<method>` running via beforeCall, then calls
+    runHandler (which re-raises on a handler exception by design). If afterCall
+    only runs on the success path, a raised handler leaks its beforeCall entry
+    in Plugin._running permanently. After ANY tracked handler ever raises,
+    `fireEvent('plugin.running', merge=True)` never returns [] again, so
+    Core.initShutdown's wait loop hits its hard 30s timeout on every restart
+    for the rest of the process life -- the same failure mode item 6 fixed,
+    via a different door. The isRunning exemption does NOT cover this (any
+    other handler raising leaks).
+    """
+
+    def test_raised_handler_does_not_leak_running_entry(self):
+        from couchpotato.core.event import addEvent, fireEvent, events
+        from couchpotato.core.plugins.base import Plugin
+
+        events.clear()
+        try:
+            class BoomPlugin(Plugin):
+                def work(self):
+                    raise ValueError('boom')
+
+            plugin = BoomPlugin()
+            addEvent('test.reg003.raising_handler', plugin.work)
+
+            # fireEvent swallows the handler exception (callers rely on one
+            # bad handler not killing the whole dispatch).
+            fireEvent('test.reg003.raising_handler', single=True)
+
+            assert plugin.isRunning() == [], (
+                'afterCall was skipped on exception, leaking a _running '
+                'entry: %r' % (plugin.isRunning(),)
+            )
+        finally:
+            events.clear()
+
+    def test_raised_handler_does_not_stick_shutdown_loop(self):
+        from couchpotato.core.event import addEvent, fireEvent, events
+        from couchpotato.core.plugins.base import Plugin
+
+        events.clear()
+        try:
+            class BoomPlugin(Plugin):
+                def work(self):
+                    raise ValueError('boom')
+
+            plugin = BoomPlugin()
+            addEvent('test.reg003.raising_handler2', plugin.work)
+
+            fireEvent('test.reg003.raising_handler2', single=True)
+
+            # This is exactly how Core.initShutdown asks "who is running".
+            still_running = fireEvent('plugin.running', merge=True)
+
+            assert still_running == [], (
+                'a raised handler left the shutdown loop stuck: %r'
+                % (still_running,)
+            )
+        finally:
+            events.clear()
+
+
 class TestGetEvent:
     def test_get_event(self):
         from couchpotato.core.event import addEvent, getEvent

--- a/tests/unit/test_event_system.py
+++ b/tests/unit/test_event_system.py
@@ -286,6 +286,75 @@ class TestBeforeAfterCall:
             events.clear()
 
 
+class TestPluginRunningAggregation:
+    """REG-003 review: re-enabling beforeCall/afterCall (item 6) must NOT make
+    the `plugin.running` query self-report.
+
+    Every Plugin registers `addEvent('plugin.running', self.isRunning)`.
+    `Core.initShutdown` fires `plugin.running` (merge=True) in a loop and
+    waits until the result (minus an ignore allowlist) is empty. If the
+    call-tracking wrapper records the `isRunning` bookkeeping handler itself
+    as "running", every plugin reports `<Class>.isRunning` as running, the
+    result is never empty, nothing is in the allowlist, and every
+    shutdown/restart hangs on the hard 30s timeout instead of returning
+    instantly. The isRunning query handler must be exempt from call-tracking.
+    """
+
+    def test_running_aggregation_empty_when_nothing_running(self):
+        from couchpotato.core.event import fireEvent, events
+        from couchpotato.core.plugins.base import Plugin
+
+        events.clear()
+        try:
+            class PluginA(Plugin):
+                pass
+
+            class PluginB(Plugin):
+                pass
+
+            # Plugin.__new__ -> registerPlugin registers
+            # addEvent('plugin.running', self.isRunning) for each instance.
+            PluginA()
+            PluginB()
+
+            # This is exactly how Core.initShutdown asks "who is running".
+            still_running = fireEvent('plugin.running', merge=True)
+
+            assert still_running == [], (
+                'plugin.running self-reported when nothing was actually '
+                'running: %r' % (still_running,)
+            )
+        finally:
+            events.clear()
+
+    def test_running_aggregation_reports_only_genuine_work(self):
+        from couchpotato.core.event import fireEvent, events
+        from couchpotato.core.plugins.base import Plugin
+
+        events.clear()
+        try:
+            class PluginA(Plugin):
+                pass
+
+            class PluginB(Plugin):
+                pass
+
+            a = PluginA()
+            PluginB()
+
+            # Simulate PluginA genuinely mid-handler.
+            a.isRunning('PluginA.realWork')
+
+            still_running = fireEvent('plugin.running', merge=True)
+
+            assert still_running == ['PluginA.realWork'], (
+                'expected only the genuine in-flight handler, got: %r'
+                % (still_running,)
+            )
+        finally:
+            events.clear()
+
+
 class TestGetEvent:
     def test_get_event(self):
         from couchpotato.core.event import addEvent, getEvent

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,4 +1,5 @@
 """Tests for the modernized logging system."""
+import io
 import logging
 import os
 import tempfile
@@ -6,6 +7,7 @@ import tempfile
 import pytest
 
 from couchpotato.core.logger import CPLog, ColorFormatter, PrivacyFilter, INFO2, setup_logging
+from couchpotato.environment import Env
 
 
 class TestCPLog:
@@ -190,4 +192,86 @@ class TestSetupLogging:
 
     def test_info2_level_registered(self):
         assert logging.getLevelName(INFO2) == 'INFO'
-        assert INFO2 == 19
+        assert INFO2 == 21
+
+    def test_info2_visible_in_production_level(self):
+        """REG-003 item 4: INFO2 used to be 19 (below the default INFO=20
+        root level), so log.info2(...) -- release-rejection reasons,
+        provider circuit-breaker trips -- was silently dropped in
+        production. INFO2 must be above INFO so it's visible at the
+        default (non-debug) level.
+
+        Deliberately avoids caplog.at_level(), which sets the *logger's*
+        own level directly and would mask the bug (it bypasses the
+        root-level threshold this test needs to exercise). Uses a plain
+        handler on the real root logger instead.
+        """
+        root = logging.getLogger()
+        old_handlers = root.handlers[:]
+        old_filters = root.filters[:]
+        old_level = root.level
+        try:
+            root.handlers.clear()
+            root.filters.clear()
+            setup_logging(console=False, debug=False)
+
+            assert root.level == logging.INFO
+            assert INFO2 > logging.INFO
+
+            records = []
+
+            class ListHandler(logging.Handler):
+                def emit(self, record):
+                    records.append(record)
+
+            handler = ListHandler()
+            handler.setLevel(0)
+            root.addHandler(handler)
+
+            log = CPLog('test.info2.visibility')
+            log.info2('provider circuit breaker tripped')
+
+            assert any('provider circuit breaker tripped' in r.getMessage() for r in records)
+        finally:
+            root.handlers = old_handlers
+            root.filters = old_filters
+            root.level = old_level
+
+    def test_privacy_filter_applied_via_child_logger(self, monkeypatch):
+        """REG-003 item 5: setup_logging attached PrivacyFilter to the ROOT
+        LOGGER (`logger.addFilter(...)`). Per stdlib semantics, a Logger's
+        own `.filters` only run for records that *originate* on that
+        logger -- not for records propagated up from a child logger's
+        `callHandlers()`. CPLog always logs through a named child logger
+        (`logging.getLogger(context)`), so the filter never actually ran
+        for a real log record and secrets (api_key, passkey, ...) in
+        logged URLs were never redacted. The filter must be attached to
+        the HANDLERS instead, since Handler.handle() re-checks its own
+        filters for every record it emits regardless of origin.
+        """
+        root = logging.getLogger()
+        old_handlers = root.handlers[:]
+        old_filters = root.filters[:]
+        old_level = root.level
+        try:
+            root.handlers.clear()
+            root.filters.clear()
+            monkeypatch.setattr(Env, '_dev', False)
+
+            setup_logging(console=True, debug=False)
+
+            stream_handler = next(h for h in root.handlers if isinstance(h, logging.StreamHandler))
+            buffer = io.StringIO()
+            stream_handler.stream = buffer
+
+            log = CPLog('test.privacy.child')
+            log.info('request failed: /api/xxx?api_key=SECRETVALUE&other=1')
+
+            output = buffer.getvalue()
+            assert output, 'expected the handler to emit a record'
+            assert 'SECRETVALUE' not in output
+            assert 'api_key=xxx' in output
+        finally:
+            root.handlers = old_handlers
+            root.filters = old_filters
+            root.level = old_level

--- a/tests/unit/test_runner_uvicorn.py
+++ b/tests/unit/test_runner_uvicorn.py
@@ -1,0 +1,57 @@
+"""Regression test for REG-003 item 3: api_key must not be leaked via uvicorn's
+access log.
+
+CouchPotato authenticates the API via a key embedded in the URL path (see
+CLAUDE.md "Known Technical Debt"). Uvicorn's default access log writes every
+request path -- including that key -- to stdout, which lands in `docker
+logs`. `couchpotato/runner.py` must start uvicorn with `access_log=False`.
+"""
+import uvicorn
+
+from couchpotato.runner import _run_uvicorn
+
+
+def test_run_uvicorn_disables_access_log(monkeypatch):
+    calls = {}
+
+    def fake_run(application, **kwargs):
+        calls['application'] = application
+        calls.update(kwargs)
+
+    monkeypatch.setattr(uvicorn, 'run', fake_run)
+
+    config = {
+        'host': '0.0.0.0',
+        'port': 5050,
+        'use_reloader': False,
+        'ssl_cert': None,
+        'ssl_key': None,
+    }
+
+    _run_uvicorn(application=object(), config=config, debug=False)
+
+    assert calls.get('access_log') is False
+
+
+def test_run_uvicorn_passes_through_ssl_kwargs_when_configured(monkeypatch):
+    calls = {}
+
+    def fake_run(application, **kwargs):
+        calls.update(kwargs)
+
+    monkeypatch.setattr(uvicorn, 'run', fake_run)
+
+    config = {
+        'host': '0.0.0.0',
+        'port': 5050,
+        'use_reloader': False,
+        'ssl_cert': '/tmp/cert.pem',
+        'ssl_key': '/tmp/key.pem',
+    }
+
+    _run_uvicorn(application=object(), config=config, debug=True)
+
+    assert calls.get('access_log') is False
+    assert calls.get('ssl_certfile') == '/tmp/cert.pem'
+    assert calls.get('ssl_keyfile') == '/tmp/key.pem'
+    assert calls.get('log_level') == 'debug'

--- a/tests/unit/test_scanner_modules.py
+++ b/tests/unit/test_scanner_modules.py
@@ -268,6 +268,59 @@ class TestGetCPImdb:
         assert scanner.getCPImdb('movie.mkv') is False
 
 
+class FakeScannerWithShutdown(FolderScannerMixin):
+    """FolderScannerMixin needs `shuttingDown()` from Plugin; stub it here so
+    `_gatherFiles`/`scan` can be exercised without instantiating the full
+    Scanner plugin (which needs Env/loader wiring)."""
+
+    def shuttingDown(self):
+        return False
+
+
+class TestGatherFilesSymlinkContainment:
+    """REG-003 item 2: a symlink inside the scanned folder that resolves to a
+    location outside it must never be handed back as a scannable file --
+    otherwise the renamer will move/delete the real target."""
+
+    def test_symlink_to_external_file_is_excluded(self, tmp_path):
+        scanner = FakeScannerWithShutdown()
+        scan_dir = tmp_path / 'scan'
+        scan_dir.mkdir()
+        outside_file = tmp_path / 'secret.mkv'
+        outside_file.write_bytes(b'\0' * 1024)
+        link = scan_dir / 'link.mkv'
+        link.symlink_to(outside_file)
+
+        files = scanner._gatherFiles(str(scan_dir))
+
+        assert str(link) not in files
+
+    def test_symlink_to_external_directory_is_excluded(self, tmp_path):
+        scanner = FakeScannerWithShutdown()
+        scan_dir = tmp_path / 'scan'
+        scan_dir.mkdir()
+        outside_dir = tmp_path / 'outside'
+        outside_dir.mkdir()
+        (outside_dir / 'movie.mkv').write_bytes(b'\0' * 1024)
+        linked_dir = scan_dir / 'linked'
+        linked_dir.symlink_to(outside_dir)
+
+        files = scanner._gatherFiles(str(scan_dir))
+
+        assert not any('movie.mkv' in f for f in files)
+
+    def test_regular_file_inside_scan_folder_is_included(self, tmp_path):
+        scanner = FakeScannerWithShutdown()
+        scan_dir = tmp_path / 'scan'
+        scan_dir.mkdir()
+        regular = scan_dir / 'movie.mkv'
+        regular.write_bytes(b'\0' * 1024)
+
+        files = scanner._gatherFiles(str(scan_dir))
+
+        assert str(regular) in files
+
+
 class TestGetReleaseNameYear:
     def test_basic(self, scanner):
         result = scanner.getReleaseNameYear('The.Movie.2023.720p.BluRay')

--- a/tests/unit/test_scanner_modules.py
+++ b/tests/unit/test_scanner_modules.py
@@ -320,6 +320,29 @@ class TestGatherFilesSymlinkContainment:
 
         assert str(regular) in files
 
+    def test_partial_results_returned_on_midwalk_error(self, monkeypatch):
+        """REG-003 review nit (a): if os.walk raises partway through, files
+        gathered before the error must still be returned (best-effort),
+        matching the pre-refactor behaviour -- not discarded."""
+        import couchpotato.core.plugins.scanner.folder_scanner as fs
+
+        scanner = FakeScannerWithShutdown()
+
+        def exploding_walk(folder, followlinks=False):
+            yield ('/movies', [], ['first.mkv'])
+            raise OSError('permission denied deep in the tree')
+
+        # Keep files contained: everything under the yielded root resolves
+        # inside it, so containment doesn't filter them out.
+        monkeypatch.setattr(fs.os, 'walk', exploding_walk)
+        monkeypatch.setattr(scanner, '_isWithinFolder', lambda file_path, real_folder: True)
+
+        files = scanner._gatherFiles('/movies')
+
+        assert any('first.mkv' in f for f in files), (
+            'partial results gathered before the error were discarded'
+        )
+
 
 class TestGetReleaseNameYear:
     def test_basic(self, scanner):

--- a/tests/unit/test_scanner_modules.py
+++ b/tests/unit/test_scanner_modules.py
@@ -343,6 +343,64 @@ class TestGatherFilesSymlinkContainment:
             'partial results gathered before the error were discarded'
         )
 
+    def test_escaping_symlinked_dir_is_not_descended_into(self, tmp_path, monkeypatch):
+        """PR #151 review (MEDIUM): a symlinked subdirectory that escapes the
+        scan folder must be pruned BEFORE os.walk recurses into it -- not just
+        filtered per-file after the fact. Otherwise the escape target (an NFS
+        mount, /proc, another library) gets fully walked at scan time (perf /
+        DoS). Assert os.walk never *descends* into it -- the stronger claim
+        that per-file filtering alone does NOT provide (per-file filtering
+        would still enumerate the escape target's contents first)."""
+        import couchpotato.core.plugins.scanner.folder_scanner as fs
+
+        scanner = FakeScannerWithShutdown()
+        scan_dir = tmp_path / 'scan'
+        scan_dir.mkdir()
+        outside_dir = tmp_path / 'outside'
+        outside_dir.mkdir()
+        (outside_dir / 'ONLY_IN_ESCAPE_TARGET.mkv').write_bytes(b'\0' * 1024)
+        linked_dir = scan_dir / 'linked'
+        linked_dir.symlink_to(outside_dir)
+
+        # Spy: record every directory os.walk actually visits (yields as root).
+        real_walk = os.walk
+        visited_roots = []
+
+        def spying_walk(top, *args, **kwargs):
+            for root, dirs, walk_files in real_walk(top, *args, **kwargs):
+                visited_roots.append(root)
+                yield root, dirs, walk_files
+
+        monkeypatch.setattr(fs.os, 'walk', spying_walk)
+
+        files = scanner._gatherFiles(str(scan_dir))
+
+        # The escaping symlinked dir must never be descended into...
+        assert not any(os.path.realpath(r) == os.path.realpath(str(outside_dir))
+                       for r in visited_roots), (
+            'os.walk descended into the escaping symlinked dir before '
+            'containment pruning: %r' % (visited_roots,)
+        )
+        # ...and its contents are of course not returned either.
+        assert not any('ONLY_IN_ESCAPE_TARGET' in f for f in files)
+
+    def test_self_looping_symlink_terminates(self, tmp_path):
+        """PR #151 review (MEDIUM): followlinks=True has no loop detection.
+        A dir symlink looping back to the scan root must not hang / recurse
+        without bound. Confirm _gatherFiles terminates and still returns the
+        real media file."""
+        scanner = FakeScannerWithShutdown()
+        scan_dir = tmp_path / 'scan'
+        scan_dir.mkdir()
+        (scan_dir / 'movie.mkv').write_bytes(b'\0' * 1024)
+        loop = scan_dir / 'loop'
+        loop.symlink_to(scan_dir)
+
+        # Must terminate (SYMLOOP_MAX bounds the OS symlink resolution).
+        files = scanner._gatherFiles(str(scan_dir))
+
+        assert any('movie.mkv' in f for f in files)
+
 
 class TestGetReleaseNameYear:
     def test_basic(self, scanner):


### PR DESCRIPTION
First batch of the nine-dimension review's P0 items — six verified findings, all small diffs, each with a regression test that fails without the fix.

## Security
- **Global TLS validation was disabled** (`_core.py`): removed the `ssl._create_default_https_context = ssl._create_unverified_context` monkeypatch that stripped cert validation from all stdlib HTTPS.
- **Symlink-following library scan** (`folder_scanner.py`): a release containing a symlink to a host file could make the renamer move/delete the real target. Added realpath-containment (`commonpath`-based, mountpoint-safe) so any file resolving outside the scan folder is skipped. (A narrower scan-vs-move TOCTOU residual is routed to the renamer package.)
- **API key leaked to `docker logs`** (`runner.py`): `access_log=False` on uvicorn so the URL-embedded key stops landing in the access log. (Redacted request logging tracked as a follow-up.)

## Observability
- **`info2` was below the production log threshold** (`logger.py`): raised 19→21 so release-rejection reasons and provider circuit-breaker trips are visible at the default level.
- **PrivacyFilter never redacted anything** (`logger.py`): it was attached to the root logger, which doesn't filter records propagated from child loggers; moved it onto the handlers so secrets in logged URLs are actually redacted.

## Reliability
- **Graceful shutdown was a silent no-op** (`event.py`): a Python-2 `im_self` remnant meant `beforeCall`/`afterCall` never fired, so the shutdown "wait for in-flight plugin work" loop did nothing. Fixed to `__self__`, and exempted the `isRunning` bookkeeping handler from call-tracking so querying "what's running" doesn't self-trigger (caught in local review — would otherwise hang every restart 30s).

## Verification
- 783 unit tests green, ruff clean, full E2E 129/130 (sole failure is the known-flaky sidebar-nav test; passes on isolated retry).
- Local review: two full-branch reviewers + one delta reviewer on the blocker fix, all findings resolved and each fix empirically confirmed to fail without the change.

Spec: `specs/REG-003-p0-security-observability.md`. CodernityDB untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RU1LBHaKDFozqA36bxkeY