### PR TITLE
fix: P0 data-integrity — unique media-identifier backstop + self-upgrade (REG-004)

### DIFF
--- a/couchpotato/core/db/schema.sql
+++ b/couchpotato/core/db/schema.sql
@@ -91,7 +91,15 @@ CREATE TABLE IF NOT EXISTS media_identifiers (
     PRIMARY KEY (media_id, provider)
 );
 
-CREATE INDEX IF NOT EXISTS idx_media_identifiers_lookup ON media_identifiers(provider, identifier);
+-- UNIQUE: a given (provider, identifier) pair (e.g. imdb/tt1234567) must map
+-- to exactly one media document. Without this, a lookup race in the
+-- get-or-insert path (see movie/_base/main.py:add) could create duplicate
+-- media rows for the same movie -- this is the storage-layer backstop for
+-- that class of bug (see REG-004 / the 77-duplicate-movie prod incident).
+-- Fresh installs only: no migration is run against existing databases here
+-- (there is no migration runner yet, and historical dup rows in prod DBs
+-- would make creating this index fail).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_media_identifiers_lookup ON media_identifiers(provider, identifier);
 
 -- === Media tags lookup table ===
 -- Denormalized for fast tag lookups (MediaTagIndex is a MultiTreeBasedIndex)

--- a/couchpotato/core/db/schema.sql
+++ b/couchpotato/core/db/schema.sql
@@ -96,9 +96,12 @@ CREATE TABLE IF NOT EXISTS media_identifiers (
 -- get-or-insert path (see movie/_base/main.py:add) could create duplicate
 -- media rows for the same movie -- this is the storage-layer backstop for
 -- that class of bug (see REG-004 / the 77-duplicate-movie prod incident).
--- Fresh installs only: no migration is run against existing databases here
--- (there is no migration runner yet, and historical dup rows in prod DBs
--- would make creating this index fail).
+-- This statement covers fresh installs (create() -> _init_schema()). Existing
+-- databases never re-run this file, so SQLiteAdapter.open() self-upgrades them
+-- via _ensure_unique_media_identifier_index(): a clean DB gets this UNIQUE
+-- index on next open; a DB that still holds historical duplicate rows keeps its
+-- non-unique index and runs lock-only (with a loud warning) until a dedup
+-- migration clears the dups (see REG-004 / the 77-duplicate-movie prod incident).
 CREATE UNIQUE INDEX IF NOT EXISTS idx_media_identifiers_lookup ON media_identifiers(provider, identifier);
 
 -- === Media tags lookup table ===

--- a/couchpotato/core/db/sqlite_adapter.py
+++ b/couchpotato/core/db/sqlite_adapter.py
@@ -143,11 +143,12 @@ class SQLiteAdapter(DatabaseInterface):
                     pass
                 if dropped:
                     try:
-                        conn.execute(
-                            "CREATE INDEX IF NOT EXISTS idx_media_identifiers_lookup "
-                            "ON media_identifiers(provider, identifier)"
-                        )
-                        conn.commit()
+                        with self._write_lock:
+                            conn.execute(
+                                "CREATE INDEX IF NOT EXISTS idx_media_identifiers_lookup "
+                                "ON media_identifiers(provider, identifier)"
+                            )
+                            conn.commit()
                     except sqlite3.Error:
                         pass
                 if isinstance(create_error, (sqlite3.IntegrityError, sqlite3.OperationalError)):

--- a/couchpotato/core/db/sqlite_adapter.py
+++ b/couchpotato/core/db/sqlite_adapter.py
@@ -12,6 +12,10 @@ from typing import Any, Dict, List, Optional
 from collections.abc import Iterator
 
 from couchpotato.core.db.interface import DatabaseInterface
+from couchpotato.core.logger import CPLog
+
+
+log = CPLog(__name__)
 
 
 def _generate_id():
@@ -58,7 +62,104 @@ class SQLiteAdapter(DatabaseInterface):
         schema_path = os.path.join(os.path.dirname(__file__), 'schema.sql')
         with open(schema_path) as f:
             schema_sql = f.read()
-        self._conn.executescript(schema_sql)
+        try:
+            self._conn.executescript(schema_sql)
+        except (sqlite3.IntegrityError, sqlite3.OperationalError):
+            # Fail-safe: create() ran against a path that already holds data
+            # with duplicate (provider, identifier) rows, so the UNIQUE index
+            # in schema.sql can't be built. Fall back to the non-unique index
+            # so the rest of the schema still initializes and startup never
+            # bricks. Every schema statement uses IF NOT EXISTS, so re-running
+            # the (downgraded) script is idempotent.
+            log.warning(
+                'Could not apply the full schema (likely duplicate media '
+                'identifiers): retrying without the UNIQUE identifier index. '
+                'Running with in-process-lock duplicate protection only; run '
+                'the dedup migration to enable the DB-level backstop (REG-004).'
+            )
+            safe_sql = schema_sql.replace(
+                'CREATE UNIQUE INDEX IF NOT EXISTS idx_media_identifiers_lookup',
+                'CREATE INDEX IF NOT EXISTS idx_media_identifiers_lookup',
+            )
+            self._conn.executescript(safe_sql)
+
+    def _has_unique_identifier_index(self) -> bool:
+        """Return True if a UNIQUE index on media_identifiers(provider,
+        identifier) already exists (fresh installs get one from schema.sql)."""
+        conn = self._get_conn()
+        for idx in conn.execute("PRAGMA index_list('media_identifiers')").fetchall():
+            if not idx['unique']:
+                continue
+            # Index names here come from our own schema; quote defensively.
+            name = str(idx['name']).replace("'", "''")
+            cols = [r['name'] for r in
+                    conn.execute("PRAGMA index_info('%s')" % name).fetchall()]
+            if cols == ['provider', 'identifier']:
+                return True
+        return False
+
+    def _ensure_unique_media_identifier_index(self) -> None:
+        """Idempotently upgrade an existing install to the UNIQUE
+        media_identifiers(provider, identifier) index (REG-004).
+
+        Fresh installs already get the UNIQUE index from schema.sql, so this
+        is a no-op there. Pre-REG-004 installs have a NON-unique index named
+        ``idx_media_identifiers_lookup``; ``CREATE UNIQUE INDEX IF NOT EXISTS``
+        with that same name would silently do nothing, so we must DROP the old
+        index and recreate it UNIQUE. If historical duplicate rows exist the
+        CREATE fails -- in that case we restore the non-unique index, warn
+        loudly, and continue running with in-process-lock protection only.
+        This never auto-dedups (destructive) and never bricks startup.
+
+        Note: sqlite3 auto-commits DDL, so a failed CREATE cannot be undone by
+        a rollback -- we explicitly recreate the non-unique index instead.
+        """
+        conn = self._get_conn()
+        try:
+            if self._has_unique_identifier_index():
+                return
+
+            dropped = False
+            try:
+                with self._write_lock:
+                    conn.execute("DROP INDEX IF EXISTS idx_media_identifiers_lookup")
+                    dropped = True
+                    conn.execute(
+                        "CREATE UNIQUE INDEX IF NOT EXISTS idx_media_identifiers_lookup "
+                        "ON media_identifiers(provider, identifier)"
+                    )
+                    conn.commit()
+                log.info('Upgraded media_identifiers(provider, identifier) to a '
+                         'UNIQUE index (REG-004 duplicate-media backstop).')
+            except (sqlite3.IntegrityError, sqlite3.OperationalError):
+                # Duplicate (provider, identifier) rows already exist (the exact
+                # state the prod incident left behind), so the DB-level backstop
+                # can't be enabled yet. Restore the original non-unique index so
+                # lookups stay indexed, and warn loudly.
+                try:
+                    conn.rollback()
+                except sqlite3.Error:
+                    pass
+                if dropped:
+                    try:
+                        conn.execute(
+                            "CREATE INDEX IF NOT EXISTS idx_media_identifiers_lookup "
+                            "ON media_identifiers(provider, identifier)"
+                        )
+                        conn.commit()
+                    except sqlite3.Error:
+                        pass
+                log.warning(
+                    'Duplicate media identifiers present in the database: could '
+                    'not create the UNIQUE (provider, identifier) index. Running '
+                    'with in-process-lock duplicate protection only. Run the '
+                    'dedup migration to enable the database-level backstop '
+                    '(REG-004).'
+                )
+        except Exception:
+            # Absolute fail-safe: index maintenance must never brick startup.
+            log.warning('Failed ensuring the unique media identifier index; '
+                        'continuing without the DB-level backstop (REG-004).')
 
     def open(self, path: str) -> None:
         if self._conn is not None:
@@ -69,6 +170,9 @@ class SQLiteAdapter(DatabaseInterface):
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA journal_mode = WAL")
         self._conn.execute("PRAGMA foreign_keys = ON")
+        # Existing DBs never re-run schema.sql (open() doesn't call
+        # _init_schema), so self-upgrade the duplicate-media backstop here.
+        self._ensure_unique_media_identifier_index()
 
     def create(self, path: str) -> None:
         if self._conn is not None:

--- a/couchpotato/core/db/sqlite_adapter.py
+++ b/couchpotato/core/db/sqlite_adapter.py
@@ -131,11 +131,12 @@ class SQLiteAdapter(DatabaseInterface):
                     conn.commit()
                 log.info('Upgraded media_identifiers(provider, identifier) to a '
                          'UNIQUE index (REG-004 duplicate-media backstop).')
-            except (sqlite3.IntegrityError, sqlite3.OperationalError):
-                # Duplicate (provider, identifier) rows already exist (the exact
-                # state the prod incident left behind), so the DB-level backstop
-                # can't be enabled yet. Restore the original non-unique index so
-                # lookups stay indexed, and warn loudly.
+            except Exception as create_error:
+                # The UNIQUE index could not be created. Restore the original
+                # non-unique index on ANY failure once we've dropped it --
+                # otherwise media_identifiers is left with NO index at all,
+                # a lookup perf cliff on large prod DBs. (This runs for the
+                # expected duplicate-rows case AND any unexpected error.)
                 try:
                     conn.rollback()
                 except sqlite3.Error:
@@ -149,13 +150,22 @@ class SQLiteAdapter(DatabaseInterface):
                         conn.commit()
                     except sqlite3.Error:
                         pass
-                log.warning(
-                    'Duplicate media identifiers present in the database: could '
-                    'not create the UNIQUE (provider, identifier) index. Running '
-                    'with in-process-lock duplicate protection only. Run the '
-                    'dedup migration to enable the database-level backstop '
-                    '(REG-004).'
-                )
+                if isinstance(create_error, (sqlite3.IntegrityError, sqlite3.OperationalError)):
+                    # Expected case: duplicate (provider, identifier) rows already
+                    # exist (the exact state the prod incident left behind), so the
+                    # DB-level backstop can't be enabled yet.
+                    log.warning(
+                        'Duplicate media identifiers present in the database: could '
+                        'not create the UNIQUE (provider, identifier) index. Running '
+                        'with in-process-lock duplicate protection only. Run the '
+                        'dedup migration to enable the database-level backstop '
+                        '(REG-004).'
+                    )
+                else:
+                    log.warning('Failed creating the unique media identifier index '
+                                '(%s); restored the non-unique index and continuing '
+                                'without the DB-level backstop (REG-004).',
+                                create_error)
         except Exception:
             # Absolute fail-safe: index maintenance must never brick startup.
             log.warning('Failed ensuring the unique media identifier index; '

--- a/couchpotato/core/db/sqlite_adapter.py
+++ b/couchpotato/core/db/sqlite_adapter.py
@@ -187,13 +187,26 @@ class SQLiteAdapter(DatabaseInterface):
 
             json_data = self._doc_to_json(data)
 
-            conn.execute(
-                "INSERT INTO documents (_id, _rev, _t, data, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
-                (doc_id, doc_rev, doc_type, json_data, now, now)
-            )
+            try:
+                conn.execute(
+                    "INSERT INTO documents (_id, _rev, _t, data, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+                    (doc_id, doc_rev, doc_type, json_data, now, now)
+                )
 
-            # Update denormalized tables
-            self._update_denormalized(doc_id, data)
+                # Update denormalized tables
+                self._update_denormalized(doc_id, data)
+            except sqlite3.IntegrityError:
+                # E.g. the UNIQUE(provider, identifier) index on
+                # media_identifiers rejected a duplicate media doc (see
+                # REG-004). Roll back so the partially-inserted document row
+                # doesn't linger uncommitted and get swept into some later,
+                # unrelated commit -- then let the caller decide what to do
+                # (movie.add() catches this and re-fetches the existing doc
+                # instead of duplicating it).
+                if self._transaction_depth == 0:
+                    conn.rollback()
+                raise
+
             self._commit_if_not_transaction()
 
             return {'_id': doc_id, '_rev': doc_rev}
@@ -215,13 +228,22 @@ class SQLiteAdapter(DatabaseInterface):
             now = time.time()
             json_data = self._doc_to_json(data)
 
-            conn.execute(
-                "UPDATE documents SET _rev = ?, _t = ?, data = ?, updated_at = ? WHERE _id = ?",
-                (doc_rev, doc_type, json_data, now, doc_id)
-            )
+            try:
+                conn.execute(
+                    "UPDATE documents SET _rev = ?, _t = ?, data = ?, updated_at = ? WHERE _id = ?",
+                    (doc_rev, doc_type, json_data, now, doc_id)
+                )
 
-            # Update denormalized tables
-            self._update_denormalized(doc_id, data)
+                # Update denormalized tables
+                self._update_denormalized(doc_id, data)
+            except sqlite3.IntegrityError:
+                # E.g. an edit gave this doc an identifier another media doc
+                # already owns. Roll back rather than leaving an uncommitted
+                # half-applied update sitting on the connection.
+                if self._transaction_depth == 0:
+                    conn.rollback()
+                raise
+
             self._commit_if_not_transaction()
 
             return {'_id': doc_id, '_rev': doc_rev}
@@ -511,8 +533,14 @@ class SQLiteAdapter(DatabaseInterface):
                 identifiers['imdb'] = data['identifier']
             for provider, ident in identifiers.items():
                 if ident:
+                    # Plain INSERT (not OR REPLACE): the DELETE above already
+                    # cleared any rows this same doc owned, so the only way
+                    # this can violate the UNIQUE(provider, identifier) index
+                    # is if a *different* media doc already owns this
+                    # identifier -- in which case we want IntegrityError, not
+                    # a silent REPLACE that would delete the other doc's row.
                     conn.execute(
-                        "INSERT OR REPLACE INTO media_identifiers (media_id, provider, identifier) VALUES (?, ?, ?)",
+                        "INSERT INTO media_identifiers (media_id, provider, identifier) VALUES (?, ?, ?)",
                         (doc_id, provider, str(ident))
                     )
 

--- a/couchpotato/core/db/sqlite_adapter.py
+++ b/couchpotato/core/db/sqlite_adapter.py
@@ -64,19 +64,29 @@ class SQLiteAdapter(DatabaseInterface):
             schema_sql = f.read()
         try:
             self._conn.executescript(schema_sql)
-        except (sqlite3.IntegrityError, sqlite3.OperationalError):
-            # Fail-safe: create() ran against a path that already holds data
-            # with duplicate (provider, identifier) rows, so the UNIQUE index
-            # in schema.sql can't be built. Fall back to the non-unique index
-            # so the rest of the schema still initializes and startup never
-            # bricks. Every schema statement uses IF NOT EXISTS, so re-running
-            # the (downgraded) script is idempotent.
-            log.warning(
-                'Could not apply the full schema (likely duplicate media '
-                'identifiers): retrying without the UNIQUE identifier index. '
-                'Running with in-process-lock duplicate protection only; run '
-                'the dedup migration to enable the DB-level backstop (REG-004).'
-            )
+        except (sqlite3.IntegrityError, sqlite3.OperationalError) as schema_error:
+            # Fail-safe: the full schema (with its UNIQUE identifier index)
+            # could not be applied -- fall back to the non-unique index so the
+            # rest of the schema still initializes and startup never bricks.
+            # Every schema statement uses IF NOT EXISTS, so re-running the
+            # (downgraded) script is idempotent. Only an IntegrityError actually
+            # implies duplicate rows; an OperationalError (locked DB, I/O, an
+            # unrelated schema statement) does not -- keep the diagnosis honest
+            # so on-call isn't sent to the dedup migration for a lock error.
+            if isinstance(schema_error, sqlite3.IntegrityError):
+                log.warning(
+                    'Could not apply the full schema (likely duplicate media '
+                    'identifiers): retrying without the UNIQUE identifier index. '
+                    'Running with in-process-lock duplicate protection only; run '
+                    'the dedup migration to enable the DB-level backstop (REG-004).'
+                )
+            else:
+                log.warning(
+                    'Could not apply the full schema (%s): retrying without the '
+                    'UNIQUE identifier index. This is likely a locked database or '
+                    'an unrelated schema error rather than duplicate identifiers '
+                    '(REG-004).', schema_error
+                )
             safe_sql = schema_sql.replace(
                 'CREATE UNIQUE INDEX IF NOT EXISTS idx_media_identifiers_lookup',
                 'CREATE INDEX IF NOT EXISTS idx_media_identifiers_lookup',
@@ -151,10 +161,12 @@ class SQLiteAdapter(DatabaseInterface):
                             conn.commit()
                     except sqlite3.Error:
                         pass
-                if isinstance(create_error, (sqlite3.IntegrityError, sqlite3.OperationalError)):
+                if isinstance(create_error, sqlite3.IntegrityError):
                     # Expected case: duplicate (provider, identifier) rows already
                     # exist (the exact state the prod incident left behind), so the
-                    # DB-level backstop can't be enabled yet.
+                    # DB-level backstop can't be enabled yet. Only an IntegrityError
+                    # implies duplicates -- an OperationalError (locked DB, I/O) does
+                    # not, so it takes the generic message below.
                     log.warning(
                         'Duplicate media identifiers present in the database: could '
                         'not create the UNIQUE (provider, identifier) index. Running '

--- a/couchpotato/core/media/movie/_base/main.py
+++ b/couchpotato/core/media/movie/_base/main.py
@@ -54,6 +54,25 @@ class MovieBase(MovieTypeBase):
         addEvent('movie.update', self.update)
         addEvent('movie.update_release_dates', self.updateReleaseDate)
 
+    def existingProfileId(self, db, m):
+        """Return the media doc's current profile_id if it still resolves to a
+        real profile, else None.
+
+        Used by add() to preserve an existing (or just-inserted-by-the-race-
+        winner) movie's profile across a force_readd instead of overwriting it
+        with this call's params/default. Called from BOTH the genuine 'found'
+        branch and the IntegrityError race-loss re-fetch branch so race
+        recovery behaves identically to a real found re-add.
+        """
+        try:
+            db.get('id', m.get('profile_id'))
+            return m.get('profile_id')
+        except (RecordNotFound, KeyError):
+            return None
+        except Exception:
+            log.error('Failed getting previous profile: %s', traceback.format_exc())
+            return None
+
     def add(self, params = None, force_readd = True, search_after = True, update_after = True, notify_after = True, status = None):
         if not params: params = {}
 
@@ -127,14 +146,7 @@ class MovieBase(MovieTypeBase):
             with media_lock(identifier_key):
                 try:
                     m = db.get('media', identifier_key, with_doc = True)['doc']
-
-                    try:
-                        db.get('id', m.get('profile_id'))
-                        previous_profile = m.get('profile_id')
-                    except (RecordNotFound, KeyError):
-                        pass
-                    except Exception:
-                        log.error('Failed getting previous profile: %s', traceback.format_exc())
+                    previous_profile = self.existingProfileId(db, m)
                 except (RecordNotFound, KeyError):
                     new = True
                     try:
@@ -144,10 +156,13 @@ class MovieBase(MovieTypeBase):
                         # covered by our in-process lock): the unique
                         # (provider, identifier) index rejected our insert
                         # because a concurrent insert already created this
-                        # movie. Use that one instead of failing or
-                        # duplicating.
+                        # movie. Re-fetch the winner's doc and preserve its
+                        # profile exactly as a genuine found re-add does --
+                        # otherwise force_readd below would stomp the winner's
+                        # profile_id with this (losing) call's params/default.
                         new = False
                         m = db.get('media', identifier_key, with_doc = True)['doc']
+                        previous_profile = self.existingProfileId(db, m)
 
             # Update dict to be usable
             m.update(media)

--- a/couchpotato/core/media/movie/_base/main.py
+++ b/couchpotato/core/media/movie/_base/main.py
@@ -1,3 +1,4 @@
+import sqlite3
 import traceback
 import time
 
@@ -9,6 +10,7 @@ from couchpotato.core.helpers.encoding import toUnicode
 from couchpotato.core.helpers.variable import splitString, getTitle, getImdb, getIdentifier
 from couchpotato.core.logger import CPLog
 from couchpotato.core.media.movie import MovieTypeBase
+from couchpotato.core.media_lock import media_lock
 
 
 log = CPLog(__name__)
@@ -116,19 +118,36 @@ class MovieBase(MovieTypeBase):
 
             new = False
             previous_profile = None
-            try:
-                m = db.get('media', 'imdb-%s' % params.get('identifier'), with_doc = True)['doc']
+            identifier_key = 'imdb-%s' % params.get('identifier')
 
+            # Serialize the get-or-insert critical section per imdb id so two
+            # concurrent add()s for the same movie can't both decide "not
+            # found" and both insert (REG-004: this created 77 duplicate
+            # movie entries in production).
+            with media_lock(identifier_key):
                 try:
-                    db.get('id', m.get('profile_id'))
-                    previous_profile = m.get('profile_id')
+                    m = db.get('media', identifier_key, with_doc = True)['doc']
+
+                    try:
+                        db.get('id', m.get('profile_id'))
+                        previous_profile = m.get('profile_id')
+                    except (RecordNotFound, KeyError):
+                        pass
+                    except Exception:
+                        log.error('Failed getting previous profile: %s', traceback.format_exc())
                 except (RecordNotFound, KeyError):
-                    pass
-                except Exception:
-                    log.error('Failed getting previous profile: %s', traceback.format_exc())
-            except Exception:
-                new = True
-                m = db.insert(media)
+                    new = True
+                    try:
+                        m = db.insert(media)
+                    except sqlite3.IntegrityError:
+                        # Lost the race anyway (e.g. another process, not
+                        # covered by our in-process lock): the unique
+                        # (provider, identifier) index rejected our insert
+                        # because a concurrent insert already created this
+                        # movie. Use that one instead of failing or
+                        # duplicating.
+                        new = False
+                        m = db.get('media', identifier_key, with_doc = True)['doc']
 
             # Update dict to be usable
             m.update(media)
@@ -172,7 +191,7 @@ class MovieBase(MovieTypeBase):
 
             # Remove releases
             for rel in fireEvent('release.for_media', m['_id'], single = True):
-                if rel['status'] is 'available':
+                if rel['status'] == 'available':
                     db.delete(rel)
 
             movie_dict = fireEvent('media.get', m['_id'], single = True)
@@ -226,7 +245,7 @@ class MovieBase(MovieTypeBase):
 
                     # Remove releases
                     for rel in fireEvent('release.for_media', m['_id'], single = True):
-                        if rel['status'] is 'available':
+                        if rel['status'] == 'available':
                             db.delete(rel)
 
                     # Default title

--- a/couchpotato/core/media/movie/_base/main.py
+++ b/couchpotato/core/media/movie/_base/main.py
@@ -148,7 +148,14 @@ class MovieBase(MovieTypeBase):
                 try:
                     m = db.get('media', identifier_key, with_doc = True)['doc']
                     previous_profile = self.existingProfileId(db, m)
-                    previous_category = m.get('category_id')
+                    # NB: previous_category is deliberately NOT set here.
+                    # profile_id and category_id have intentionally ASYMMETRIC
+                    # genuine-found semantics (matching master): a found re-add
+                    # keeps the existing profile (existing-wins, via
+                    # previous_profile) but HONORS an explicitly-passed
+                    # category_id (new-wins, via the else-branch below). Only
+                    # the race-loss branch preserves category, to stop a losing
+                    # concurrent add() from clobbering the winner's value.
                 except (RecordNotFound, KeyError):
                     new = True
                     try:
@@ -159,10 +166,12 @@ class MovieBase(MovieTypeBase):
                         # (provider, identifier) index rejected our insert
                         # because a concurrent insert already created this
                         # movie. Re-fetch the winner's doc and preserve its
-                        # profile/category exactly as a genuine found re-add
-                        # does -- otherwise force_readd below would stomp the
-                        # winner's values with this (losing) call's
-                        # params/default.
+                        # profile/category -- otherwise force_readd below would
+                        # stomp the winner's values with this (losing) call's
+                        # params/default. previous_category is taken unvalidated
+                        # (unlike previous_profile's existingProfileId check):
+                        # the just-inserted winner's category is valid by
+                        # construction.
                         new = False
                         m = db.get('media', identifier_key, with_doc = True)['doc']
                         previous_profile = self.existingProfileId(db, m)
@@ -191,7 +200,7 @@ class MovieBase(MovieTypeBase):
                             fireEvent('release.delete', release['_id'], single = True)
 
                 m['profile_id'] = (params.get('profile_id') or default_profile.get('_id')) if not previous_profile else previous_profile
-                m['category_id'] = (cat_id if cat_id is not None and len(cat_id) > 0 else None) if not previous_category else previous_category
+                m['category_id'] = previous_category if previous_category else (cat_id if cat_id is not None and len(cat_id) > 0 else (m.get('category_id') or None))
                 m['last_edit'] = int(time.time())
                 m['tags'] = []
 

--- a/couchpotato/core/media/movie/_base/main.py
+++ b/couchpotato/core/media/movie/_base/main.py
@@ -137,6 +137,7 @@ class MovieBase(MovieTypeBase):
 
             new = False
             previous_profile = None
+            previous_category = None
             identifier_key = 'imdb-%s' % params.get('identifier')
 
             # Serialize the get-or-insert critical section per imdb id so two
@@ -147,6 +148,7 @@ class MovieBase(MovieTypeBase):
                 try:
                     m = db.get('media', identifier_key, with_doc = True)['doc']
                     previous_profile = self.existingProfileId(db, m)
+                    previous_category = m.get('category_id')
                 except (RecordNotFound, KeyError):
                     new = True
                     try:
@@ -157,12 +159,14 @@ class MovieBase(MovieTypeBase):
                         # (provider, identifier) index rejected our insert
                         # because a concurrent insert already created this
                         # movie. Re-fetch the winner's doc and preserve its
-                        # profile exactly as a genuine found re-add does --
-                        # otherwise force_readd below would stomp the winner's
-                        # profile_id with this (losing) call's params/default.
+                        # profile/category exactly as a genuine found re-add
+                        # does -- otherwise force_readd below would stomp the
+                        # winner's values with this (losing) call's
+                        # params/default.
                         new = False
                         m = db.get('media', identifier_key, with_doc = True)['doc']
                         previous_profile = self.existingProfileId(db, m)
+                        previous_category = m.get('category_id')
 
             # Update dict to be usable
             m.update(media)
@@ -187,7 +191,7 @@ class MovieBase(MovieTypeBase):
                             fireEvent('release.delete', release['_id'], single = True)
 
                 m['profile_id'] = (params.get('profile_id') or default_profile.get('_id')) if not previous_profile else previous_profile
-                m['category_id'] = cat_id if cat_id is not None and len(cat_id) > 0 else (m.get('category_id') or None)
+                m['category_id'] = (cat_id if cat_id is not None and len(cat_id) > 0 else None) if not previous_category else previous_category
                 m['last_edit'] = int(time.time())
                 m['tags'] = []
 

--- a/couchpotato/core/migration/codernity_to_sqlite.py
+++ b/couchpotato/core/migration/codernity_to_sqlite.py
@@ -72,23 +72,36 @@ def migrate_codernity_to_sqlite(codernity_path: str, sqlite_path: str, sqlite_db
                     print(f"  Migrated {migrated} documents...", end='\r')
 
             except sqlite3.IntegrityError as e:
-                # The UNIQUE (provider, identifier) index (REG-004) rejected a
-                # document whose media identifier is already taken by an
-                # earlier-migrated doc. This is a DATA-LOSS event on a
-                # disaster-recovery path -- the source DB contained duplicate
-                # media, and this row is NOT carried into SQLite. Make it loud;
-                # the original CodernityDB is preserved in database.bak.
-                duplicates += 1
                 doc_id = doc.get('_id', 'unknown')
-                print(f"  DUPLICATE: skipping document {doc_id} (identifier already migrated): {e}")
-                log.warning(
-                    'Migration DROPPED a duplicate-identifier document %s '
-                    '(_t=%s): its media identifier was already migrated, and '
-                    'the UNIQUE index rejected it (REG-004). This row was NOT '
-                    'migrated (data loss); the original is preserved in '
-                    'database.bak. Error: %s',
-                    doc_id, doc.get('_t', 'unknown'), e,
-                )
+                # insert() can raise IntegrityError from TWO distinct
+                # constraints: the UNIQUE (provider, identifier) index
+                # (REG-004, a real duplicate movie) OR the documents._id
+                # PRIMARY KEY (a duplicate/malformed _id in the source
+                # CodernityDB). Only the former is an "already-migrated
+                # identifier" -- attribute by the error text so a different
+                # corruption isn't mislabeled as a duplicate identifier.
+                if 'media_identifiers' in str(e):
+                    # DATA-LOSS event on a disaster-recovery path -- the source
+                    # DB contained duplicate media and this row is NOT carried
+                    # into SQLite. Make it loud; the original CodernityDB is
+                    # preserved in database.bak.
+                    duplicates += 1
+                    print(f"  DUPLICATE: skipping document {doc_id} (identifier already migrated): {e}")
+                    log.warning(
+                        'Migration DROPPED a duplicate-identifier document %s '
+                        '(_t=%s): its media identifier was already migrated, and '
+                        'the UNIQUE index rejected it (REG-004). This row was NOT '
+                        'migrated (data loss); the original is preserved in '
+                        'database.bak. Error: %s',
+                        doc_id, doc.get('_t', 'unknown'), e,
+                    )
+                else:
+                    # A different integrity violation (e.g. duplicate _id
+                    # PRIMARY KEY): treat as a generic migration error, not an
+                    # already-migrated identifier.
+                    errors += 1
+                    print(f"  Warning: Failed to migrate document {doc_id}: {e}")
+                    log.warning('Failed to migrate document %s: %s', doc_id, e)
 
             except Exception as e:
                 errors += 1

--- a/couchpotato/core/migration/codernity_to_sqlite.py
+++ b/couchpotato/core/migration/codernity_to_sqlite.py
@@ -4,9 +4,14 @@ This module provides one-way migration from the legacy CodernityDB
 document store to the new SQLite database format.
 """
 import os
+import sqlite3
 import sys
 
 from CodernityDB.database_super_thread_safe import SuperThreadSafeDatabase
+from couchpotato.core.logger import CPLog
+
+
+log = CPLog(__name__)
 
 
 def migrate_codernity_to_sqlite(codernity_path: str, sqlite_path: str, sqlite_db) -> int:
@@ -46,6 +51,7 @@ def migrate_codernity_to_sqlite(codernity_path: str, sqlite_path: str, sqlite_db
     # Migrate all documents
     migrated = 0
     errors = 0
+    duplicates = 0
     doc_types = {}
 
     print("  Reading documents from CodernityDB...")
@@ -65,9 +71,30 @@ def migrate_codernity_to_sqlite(codernity_path: str, sqlite_path: str, sqlite_db
                 if migrated % 100 == 0:
                     print(f"  Migrated {migrated} documents...", end='\r')
 
+            except sqlite3.IntegrityError as e:
+                # The UNIQUE (provider, identifier) index (REG-004) rejected a
+                # document whose media identifier is already taken by an
+                # earlier-migrated doc. This is a DATA-LOSS event on a
+                # disaster-recovery path -- the source DB contained duplicate
+                # media, and this row is NOT carried into SQLite. Make it loud;
+                # the original CodernityDB is preserved in database.bak.
+                duplicates += 1
+                doc_id = doc.get('_id', 'unknown')
+                print(f"  DUPLICATE: skipping document {doc_id} (identifier already migrated): {e}")
+                log.warning(
+                    'Migration DROPPED a duplicate-identifier document %s '
+                    '(_t=%s): its media identifier was already migrated, and '
+                    'the UNIQUE index rejected it (REG-004). This row was NOT '
+                    'migrated (data loss); the original is preserved in '
+                    'database.bak. Error: %s',
+                    doc_id, doc.get('_t', 'unknown'), e,
+                )
+
             except Exception as e:
                 errors += 1
-                print(f"  Warning: Failed to migrate document {doc.get('_id', 'unknown')}: {e}")
+                doc_id = doc.get('_id', 'unknown')
+                print(f"  Warning: Failed to migrate document {doc_id}: {e}")
+                log.warning('Failed to migrate document %s: %s', doc_id, e)
 
     except Exception as e:
         print(f"  Error iterating CodernityDB: {e}")
@@ -77,7 +104,16 @@ def migrate_codernity_to_sqlite(codernity_path: str, sqlite_path: str, sqlite_db
         codernity_db.close()
 
     # Print summary
-    print(f"\n  Migration complete: {migrated} documents, {errors} errors")
+    print(f"\n  Migration complete: {migrated} documents, {errors} errors, "
+          f"{duplicates} duplicate-identifier documents skipped")
+    if duplicates:
+        log.warning(
+            '%s duplicate-identifier document(s) were skipped during migration '
+            'and are NOT present in the SQLite database. The original CodernityDB '
+            'is preserved in database.bak. Run the dedup migration to recover '
+            'them (REG-004).',
+            duplicates,
+        )
     print("  Document types migrated:")
     for doc_type, count in sorted(doc_types.items()):
         print(f"    {doc_type}: {count}")

--- a/couchpotato/core/plugins/release/main.py
+++ b/couchpotato/core/plugins/release/main.py
@@ -144,7 +144,7 @@ class Release(Plugin):
                 # Add movie if it doesn't exist
                 try:
                     media = db.get('media', 'imdb-%s' % group['identifier'], with_doc = True)['doc']
-                except Exception:
+                except (RecordNotFound, KeyError):
                     media = fireEvent('movie.add', params = {
                         'identifier': group['identifier'],
                         'profile_id': None,
@@ -178,7 +178,7 @@ class Release(Plugin):
                     try:
                         r = db.get('release_identifier', release_identifier, with_doc = True)['doc']
                         r['media_id'] = media['_id']
-                    except Exception:
+                    except (RecordNotFound, KeyError):
                         log.debug('Failed updating release by identifier "%s". Inserting new.', release_identifier)
                         r = db.insert(release)
 

--- a/specs/REG-004-p0-data-integrity.md
+++ b/specs/REG-004-p0-data-integrity.md
@@ -138,6 +138,24 @@ correctness bug (`is` vs `==` on a JSON-deserialized string).
   the DB backstop cleaning up after the fact. (Negative control: with the lock
   stubbed to a no-op, the same scenario yields N inserts.)
 
+### Scope boundary / known follow-up (Wave-2 P1)
+
+`media_lock(identifier_key)` in `movie.add()` covers the get-or-insert
+**decision** only — it is released before `m.update(media)` / the
+`force_readd` `db.update(m)`. That fully closes the duplicate-**INSERT** race
+this PR targets (Item 1): no two concurrent `add()`s can both decide "not
+found" and both insert (and the UNIQUE index + `IntegrityError` re-fetch is
+the cross-process backstop).
+
+It does **not** cover the post-lock read-modify-write on an *existing* doc:
+two concurrent found / race-loss re-adds for the same imdb id can still
+interleave their `db.update(m)`, and `SQLiteAdapter.update()` stamps a new
+`_rev` **unconditionally** (no optimistic-concurrency / compare-and-swap
+check), so one update can silently lose the other's field writes. That
+pre-existing RMW race is **out of scope** for this PR and is tracked for the
+Wave-2 P1 work (`_rev` compare-and-swap on `update()` + unifying the media
+lock to span the whole read-modify-write, not just the insert decision).
+
 ## Item 2 — `is 'available'` identity-comparison bug (MED correctness) — VERIFIED
 
 ### Problem

--- a/specs/REG-004-p0-data-integrity.md
+++ b/specs/REG-004-p0-data-integrity.md
@@ -41,12 +41,45 @@ correctness bug (`is` vs `==` on a JSON-deserialized string).
 ### Fix
 
 - `schema.sql`: `idx_media_identifiers_lookup` becomes a `CREATE UNIQUE INDEX`
-  on `media_identifiers(provider, identifier)`. **Fresh installs only** — no
-  migration runs against existing databases (there is no migration runner
-  yet, and historical prod DBs may still contain duplicate rows from the
-  incident above, which would make creating a unique index fail outright).
-  Applying this to existing DBs via a future schema-migration runner is a
-  tracked follow-up, not part of this change.
+  on `media_identifiers(provider, identifier)`. This covers **fresh installs**
+  via `create()` → `_init_schema()`.
+- `sqlite_adapter.py` — **existing-DB self-upgrade** (added in the review
+  follow-up): `open()` never re-runs `schema.sql`, so fresh-install-only
+  coverage would leave every pre-REG-004 database (including prod's live DB —
+  the one from the 77-duplicate incident) permanently unprotected. `open()`
+  now calls `_ensure_unique_media_identifier_index()`, which:
+  - Detects (via `PRAGMA index_list`/`index_info`) whether a UNIQUE index on
+    `media_identifiers(provider, identifier)` already exists; if so, no-op.
+  - Otherwise the install has the legacy **non-unique** index named
+    `idx_media_identifiers_lookup`. Because `CREATE UNIQUE INDEX IF NOT EXISTS`
+    with that same name is a silent no-op, it **`DROP`s** the old index and
+    **`CREATE`s** it UNIQUE (SQLite auto-commits DDL, so a failed CREATE can't
+    be rolled back — the drop+recreate is explicit and deliberate).
+  - If the CREATE fails because **historical duplicate rows still exist**
+    (`sqlite3.IntegrityError`/`OperationalError`), it does **not** auto-dedup
+    (destructive). It recreates the original non-unique index and logs a LOUD
+    `log.warning` (duplicate identifiers present → running with in-process-lock
+    protection only → run the future dedup migration to enable the DB-level
+    backstop), then continues startup. Startup **never bricks**.
+  - Net: clean existing DBs self-upgrade to the backstop the first time they
+    open; dirty DBs keep working in lock-only mode with a loud warning until a
+    dedup migration runs.
+- `sqlite_adapter.py` `_init_schema()` — defensive (review follow-up): the
+  `executescript(schema.sql)` is wrapped so the "dups + a fresh `create()`
+  against an already-populated path" edge can't crash startup uncaught. On
+  `IntegrityError`/`OperationalError` it logs the same warning and retries the
+  script with the UNIQUE index downgraded to a plain index (every schema
+  statement is `IF NOT EXISTS`, so re-running is idempotent).
+- **Future P2 dedup-migration runner (tracked follow-up, NOT in this change).**
+  To enable the DB-level backstop on a DB that still has duplicate rows, that
+  runner must: (1) **dedup** the `media_identifiers` rows (and reconcile the
+  duplicate media documents they point at — merge releases, delete the losing
+  media docs) so each `(provider, identifier)` maps to exactly one media_id;
+  (2) **`DROP INDEX idx_media_identifiers_lookup`** (the surviving non-unique
+  index); (3) **`CREATE UNIQUE INDEX idx_media_identifiers_lookup`**. Steps
+  (2)+(3) are exactly what `_ensure_unique_media_identifier_index()` already
+  does automatically once the data is clean — so in practice the runner only
+  needs the destructive dedup step, then the next `open()` finishes the job.
 - `sqlite_adapter.py`:
   - `_update_denormalized()`: `media_identifiers` rows are now written with a
     plain `INSERT` instead of `INSERT OR REPLACE`. The preceding
@@ -91,6 +124,19 @@ correctness bug (`is` vs `==` on a JSON-deserialized string).
   `SQLiteAdapter.insert()`, and — at the app layer — the `IntegrityError`
   catch-and-refetch path in `movie.add()`) results in **one** media doc, not
   two.
+- **Existing-DB self-upgrade (review follow-up):**
+  - A pre-REG-004-shaped DB (non-unique index) with **no** duplicate rows:
+    after `open()`, a UNIQUE index exists and a duplicate insert raises
+    `IntegrityError`.
+  - A pre-REG-004 DB **with** a duplicate `(provider, identifier)` pair:
+    `open()` does not raise, logs the loud warning, and startup completes with
+    the non-unique index still in place (lock-only mode).
+- **Lock proven in isolation (review follow-up):** with an instantly-consistent
+  in-memory DB that has **no** uniqueness backstop, N real threads racing
+  `MovieBase.add()` for the same imdb id produce exactly **one** insert / one
+  doc — demonstrating `media_lock` serializes the critical section rather than
+  the DB backstop cleaning up after the fact. (Negative control: with the lock
+  stubbed to a no-op, the same scenario yields N inserts.)
 
 ## Item 2 — `is 'available'` identity-comparison bug (MED correctness) — VERIFIED
 
@@ -161,13 +207,43 @@ Copied (not moved — originals stay in place) the following into
 - Originals in `tests/integration/test_duplicate_detection.py` untouched and
   still pass.
 
+## Item 4 — CodernityDB→SQLite migration now silently DROPS duplicates (review follow-up)
+
+### Problem
+
+Once the UNIQUE `(provider, identifier)` index exists, migrating a legacy
+CodernityDB that contains duplicate media (the exact prod state) makes
+`sqlite_db.insert(doc)` raise `sqlite3.IntegrityError` for the second+ doc
+sharing an identifier. `codernity_to_sqlite.py` previously caught **all**
+exceptions in one bucket and reported them with a bare `print`, so this
+**data-loss** on a disaster-recovery path was easy to miss.
+
+### Fix
+
+In the per-document migration loop (`couchpotato/core/migration/codernity_to_sqlite.py`):
+- Catch `sqlite3.IntegrityError` **distinctly** from other errors, count it in
+  a separate `duplicates` tally, and emit a LOUD `CPLog` (`log.warning`, not a
+  bare `print`) naming it a duplicate-identifier skip, stating the row was
+  **not** migrated (data loss), and that the original CodernityDB is preserved
+  in `database.bak`.
+- The end-of-migration summary reports the duplicate count and re-warns via
+  `CPLog` when any were skipped.
+- CodernityDB remains the upgrade path — nothing about *whether* it runs
+  changed; only the logging/counting improved.
+
+### Acceptance
+
+- Migration module imports cleanly; duplicate skips are counted separately and
+  surfaced via `CPLog.warning`, not swallowed into the generic error bucket.
+
 ## Constraints
 
 - No changes to CodernityDB or anything under `libs/` / `couchpotato/lib/`.
   The `codernity` backend keeps working unchanged; only the `sqlite`
-  schema/adapter/call-sites changed.
-- `schema.sql` change is additive/fresh-install only — no ALTER migration
-  against existing databases.
+  schema/adapter/call-sites and the (SQLite-facing) migration logging changed.
+- `schema.sql` covers fresh installs; existing SQLite DBs self-upgrade in
+  `open()` (clean DBs) or run lock-only with a loud warning (dirty DBs) until a
+  future dedup migration. No blind ALTER that could brick startup.
 
 ## Files
 
@@ -175,6 +251,7 @@ Copied (not moved — originals stay in place) the following into
 - `couchpotato/core/db/sqlite_adapter.py`
 - `couchpotato/core/media/movie/_base/main.py`
 - `couchpotato/core/plugins/release/main.py`
+- `couchpotato/core/migration/codernity_to_sqlite.py`
 - `tests/unit/test_sqlite_adapter.py`
 - `tests/unit/test_movie_add_integrity.py` (new)
 

--- a/specs/REG-004-p0-data-integrity.md
+++ b/specs/REG-004-p0-data-integrity.md
@@ -1,0 +1,186 @@
+# REG-004 — P0 data-integrity fixes (duplicate media / stale releases)
+
+## Background
+
+Production already suffered one duplicate-media corruption incident: a bug
+in `SQLiteAdapter._query_index` (fixed separately — see
+`tests/integration/test_duplicate_detection.py`) let a `'media'` index
+lookup ignore its key and return the wrong (or first) document, causing
+`movie.add()` and `release.add()` to create 77 duplicate movie entries after
+a migration + library refresh.
+
+That specific bug is fixed, but nothing stops the *class* of bug from
+recurring: there is no uniqueness backstop at the storage layer, and the
+app-layer get-or-insert path in `movie.add()` treats **any** exception from
+the lookup as "not found", then inserts unconditionally with no lock. This
+spec closes both gaps and fixes one related, independently-discovered
+correctness bug (`is` vs `==` on a JSON-deserialized string).
+
+## Item 1 — No uniqueness backstop + `movie.add` insert race (HIGH)
+
+### Problem
+
+- `couchpotato/core/db/schema.sql`: `media_identifiers(media_id, provider,
+  identifier)` has `PRIMARY KEY (media_id, provider)` and a plain (non-unique)
+  index on `(provider, identifier)`. Two different `media_id`s can each own a
+  row for the same `(provider, identifier)` — e.g. two media docs both
+  claiming `imdb`/`tt1234567`. Nothing in the schema prevents this.
+- `couchpotato/core/media/movie/_base/main.py` `add()`: the get-or-insert
+  block wrapped the lookup in a bare `except Exception:` — any error from
+  `db.get('media', ...)` (including a transient DB error, not just "not
+  found") was treated as "doesn't exist yet" and triggered an unconditional
+  `db.insert(media)`. There was also no lock around the check-then-insert, so
+  two concurrent `add()` calls for the same imdb id could both observe "not
+  found" and both insert.
+- `couchpotato/core/db/sqlite_adapter.py` `_update_denormalized()`: the
+  `media_identifiers` row was written with `INSERT OR REPLACE`. Adding a
+  UNIQUE index on `(provider, identifier)` without changing this would make
+  SQLite's conflict resolution **silently delete the other media doc's row**
+  instead of raising — defeating the whole point of the constraint.
+
+### Fix
+
+- `schema.sql`: `idx_media_identifiers_lookup` becomes a `CREATE UNIQUE INDEX`
+  on `media_identifiers(provider, identifier)`. **Fresh installs only** — no
+  migration runs against existing databases (there is no migration runner
+  yet, and historical prod DBs may still contain duplicate rows from the
+  incident above, which would make creating a unique index fail outright).
+  Applying this to existing DBs via a future schema-migration runner is a
+  tracked follow-up, not part of this change.
+- `sqlite_adapter.py`:
+  - `_update_denormalized()`: `media_identifiers` rows are now written with a
+    plain `INSERT` instead of `INSERT OR REPLACE`. The preceding
+    `DELETE FROM media_identifiers WHERE media_id = ?` already clears any row
+    this same document owned, so a plain insert only conflicts when a
+    *different* doc already owns the identifier — which is exactly the case
+    that must raise, not silently replace.
+  - `insert()` and `update()`: the document write + denormalized-table write
+    now run in a `try/except sqlite3.IntegrityError`, which rolls back the
+    connection (when not already inside an explicit `transaction()`) before
+    re-raising. Without this, a failed insert would leave an uncommitted
+    `documents` row on the connection that a later, unrelated write could
+    accidentally commit alongside.
+- `couchpotato/core/media/movie/_base/main.py` `add()`:
+  - The lookup's `except Exception:` narrows to `except (RecordNotFound,
+    KeyError):` — the two "not found" signals from the codernity and sqlite
+    backends respectively.
+  - The whole get-or-insert block is wrapped in
+    `with media_lock('imdb-%s' % identifier):` (`couchpotato/core/media_lock.py`,
+    already used by `release.add()`), serializing concurrent `add()` calls
+    for the same imdb id within one process.
+  - The insert itself is wrapped in `except sqlite3.IntegrityError:` — if a
+    concurrent insert still wins the race (e.g. across processes, which the
+    in-process lock can't cover), the loser re-fetches the winner's doc via
+    `db.get('media', ...)` instead of failing or duplicating.
+- `couchpotato/core/plugins/release/main.py` `add()`: this method already
+  runs its whole body under `media_lock(group['identifier'])`, so the
+  insert-race scenario doesn't apply here the same way. Its two get-or-insert
+  sites (media lookup at ~145, release lookup at ~178) still had the same
+  "bare except swallows real errors" anti-pattern, so both narrow to
+  `except (RecordNotFound, KeyError):` for consistency. No unique index was
+  added for `release_identifier` (out of scope here), so there's no new
+  `IntegrityError` to catch at these two sites.
+
+### Acceptance
+
+- Inserting two media docs with the same `(provider, identifier)` on a
+  fresh-schema DB raises `sqlite3.IntegrityError`.
+- A failed duplicate insert leaves no orphaned `documents` row, and the
+  connection remains usable for subsequent writes.
+- A simulated concurrent double `movie.add()` (real threads racing
+  `SQLiteAdapter.insert()`, and — at the app layer — the `IntegrityError`
+  catch-and-refetch path in `movie.add()`) results in **one** media doc, not
+  two.
+
+## Item 2 — `is 'available'` identity-comparison bug (MED correctness) — VERIFIED
+
+### Problem
+
+`couchpotato/core/media/movie/_base/main.py:194` (in `add()`) and `:248` (in
+`edit()`) — line numbers as fixed; originally 175/229 — compared
+`rel['status'] is 'available'`. `rel['status']` is a string produced by
+`json.loads()` when the release document is read back out of SQLite, which
+is **never** the same object as the `'available'` string literal compiled
+into this module, so the comparison is effectively always `False`. Stale
+`available` releases were therefore never deleted when a movie was
+re-added or edited. Confirmed independently: CPython itself emits
+`SyntaxWarning: "is" with 'str' literal. Did you mean "=="?` for both lines
+(visible in the `ruff`/`pytest` warning output on current code).
+
+Grepped the whole `couchpotato/` tree (excluding `couchpotato/lib/`, out of
+scope per this task's constraints) for the same `is '<literal>'` /
+`is "<literal>"` pattern: no other occurrences. (One additional hit exists at
+`couchpotato/lib/subliminal/services/__init__.py:132`, inside `libs/`-adjacent
+vendored code that is explicitly out of scope for this change — reported,
+not fixed.)
+
+### Fix
+
+Both comparisons changed from `is` to `==`.
+
+### Acceptance
+
+- New test inserts/mocks a media doc with an `available` release whose
+  `status` string is produced via `json.loads(...)` (not a literal, so it
+  isn't accidentally string-interned the same way CPython interns
+  compile-time literals) and drives the `add()` re-add path with
+  `force_readd=True`. Before the fix, the release is never deleted; after,
+  it is.
+
+## Item 3 — Duplicate-corruption regression tests don't run per-PR (MED testability)
+
+### Problem
+
+`tests/integration/test_duplicate_detection.py` guards the exact
+`_query_index` corruption branches (the `'media'` index-join lookup and the
+`'release_identifier'` lookup) that caused the 77-duplicate-movie incident.
+CI and `make verify` only run `tests/unit/`, so this coverage doesn't run on
+every PR — a regression in these branches could land unnoticed.
+
+### Fix
+
+Copied (not moved — originals stay in place) the following into
+`tests/unit/test_sqlite_adapter.py` under
+`TestSQLiteAdapterDuplicateDetectionRegression`, since they're pure
+`tmp_path`-backed SQLite tests with nothing integration about them:
+
+- `test_media_lookup_returns_correct_movie_among_many` — the `'media'`
+  index-join branch (`sqlite_adapter.py` `_query_index`, `'media'` case),
+  confirmed **not** covered by pre-existing unit tests (all existing
+  `'media'`-adjacent unit tests used a single-movie DB, which can't
+  distinguish "returns the right doc" from "returns the only doc").
+- `test_release_identifier_lookup_finds_matching_release` — a
+  `release_identifier` hit.
+- `test_release_identifier_lookup_raises_keyerror_when_absent` — the
+  `release_identifier`-absent-but-media-exists `KeyError` case (Bug 2's
+  exact reproduction).
+
+### Acceptance
+
+- All three copied tests pass under `tests/unit/`.
+- Originals in `tests/integration/test_duplicate_detection.py` untouched and
+  still pass.
+
+## Constraints
+
+- No changes to CodernityDB or anything under `libs/` / `couchpotato/lib/`.
+  The `codernity` backend keeps working unchanged; only the `sqlite`
+  schema/adapter/call-sites changed.
+- `schema.sql` change is additive/fresh-install only — no ALTER migration
+  against existing databases.
+
+## Files
+
+- `couchpotato/core/db/schema.sql`
+- `couchpotato/core/db/sqlite_adapter.py`
+- `couchpotato/core/media/movie/_base/main.py`
+- `couchpotato/core/plugins/release/main.py`
+- `tests/unit/test_sqlite_adapter.py`
+- `tests/unit/test_movie_add_integrity.py` (new)
+
+## Gate
+
+- `.venv/bin/python -m pytest tests/unit/ -q` fully green.
+- `.venv/bin/ruff check .` clean.
+- Commit locally on `fix/reg-004-p0-data-integrity`. **STOP after
+  committing — do NOT push.**

--- a/tests/unit/test_migration_dup_detection.py
+++ b/tests/unit/test_migration_dup_detection.py
@@ -39,8 +39,9 @@ class _FakeSqliteDB:
     for any doc whose _id is in ``dup_ids`` (mimicking the UNIQUE index
     rejecting a duplicate identifier), and records the rest."""
 
-    def __init__(self, dup_ids):
-        self.dup_ids = set(dup_ids)
+    def __init__(self, errors_by_id):
+        # _id -> IntegrityError message string to raise on insert.
+        self.errors_by_id = dict(errors_by_id)
         self.created = False
         self.inserted = []
 
@@ -48,10 +49,9 @@ class _FakeSqliteDB:
         self.created = True
 
     def insert(self, doc):
-        if doc.get('_id') in self.dup_ids:
-            raise sqlite3.IntegrityError(
-                'UNIQUE constraint failed: media_identifiers.provider, media_identifiers.identifier'
-            )
+        msg = self.errors_by_id.get(doc.get('_id'))
+        if msg is not None:
+            raise sqlite3.IntegrityError(msg)
         self.inserted.append(doc)
         return {'_id': doc.get('_id'), '_rev': 'r1'}
 
@@ -64,7 +64,9 @@ def test_migration_counts_duplicate_separately_and_warns(tmp_path, caplog):
         {'_id': 'm3', '_t': 'media', 'identifiers': {'imdb': 'tt2222222'}},
     ]
     fake_codernity = _FakeCodernity(docs)
-    fake_sqlite = _FakeSqliteDB(dup_ids={'m2'})
+    fake_sqlite = _FakeSqliteDB(errors_by_id={
+        'm2': 'UNIQUE constraint failed: media_identifiers.provider, media_identifiers.identifier',
+    })
 
     with (
         patch.object(codernity_to_sqlite, 'SuperThreadSafeDatabase',
@@ -100,3 +102,47 @@ def test_migration_counts_duplicate_separately_and_warns(tmp_path, caplog):
     )
 
     assert fake_codernity.closed, "the source DB must be closed in the finally block"
+
+
+def test_non_identifier_integrity_error_counted_as_generic_error(tmp_path, caplog):
+    """An IntegrityError that is NOT about media_identifiers (e.g. a
+    documents._id PRIMARY KEY violation from a duplicate/malformed source _id)
+    must be counted as a GENERIC error, not mislabeled as an already-migrated
+    duplicate identifier."""
+    docs = [
+        {'_id': 'm1', '_t': 'media', 'identifiers': {'imdb': 'tt1111111'}},
+        # m2 fails on the documents._id PRIMARY KEY, not the identifier index.
+        {'_id': 'm2', '_t': 'media', 'identifiers': {'imdb': 'tt2222222'}},
+        {'_id': 'm3', '_t': 'media', 'identifiers': {'imdb': 'tt3333333'}},
+    ]
+    fake_codernity = _FakeCodernity(docs)
+    fake_sqlite = _FakeSqliteDB(errors_by_id={
+        'm2': 'UNIQUE constraint failed: documents._id',
+    })
+
+    with (
+        patch.object(codernity_to_sqlite, 'SuperThreadSafeDatabase',
+                     return_value=fake_codernity),
+        patch('couchpotato.core.migration.fix_indexes.fix_index_files',
+              return_value=0),
+        caplog.at_level(logging.WARNING, logger='couchpotato.core.migration.codernity_to_sqlite'),
+    ):
+        migrated = codernity_to_sqlite.migrate_codernity_to_sqlite(
+            str(tmp_path / 'codernity'), str(tmp_path / 'sqlite'), fake_sqlite
+        )
+
+    assert migrated == 2
+    assert [d['_id'] for d in fake_sqlite.inserted] == ['m1', 'm3']
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    # Counted/reported as a GENERIC error...
+    assert any('Failed to migrate document m2' in w for w in warnings), (
+        "a non-identifier IntegrityError must be reported as a generic error"
+    )
+    # ...and NOT as a duplicate-identifier skip (neither per-doc nor summary).
+    assert not any('DROPPED a duplicate-identifier document' in w for w in warnings), (
+        "a _id PRIMARY KEY violation must not be mislabeled as a duplicate identifier"
+    )
+    assert not any('duplicate-identifier document(s) were skipped' in w for w in warnings), (
+        "duplicates must be 0, so no summary duplicate warning should fire"
+    )

--- a/tests/unit/test_migration_dup_detection.py
+++ b/tests/unit/test_migration_dup_detection.py
@@ -1,0 +1,102 @@
+"""Regression test for the CodernityDB->SQLite migration duplicate-detection
+branch (REG-004 Item 4).
+
+Once the UNIQUE (provider, identifier) index exists, migrating a legacy DB
+that contains duplicate media makes sqlite_db.insert() raise
+sqlite3.IntegrityError for the second+ doc sharing an identifier. That is a
+DATA-LOSS event on a disaster-recovery path, so it must be counted separately
+(as a duplicate, NOT a generic error), the surviving docs must still migrate,
+and it must be logged loudly. No real CodernityDB is needed.
+"""
+import logging
+import sqlite3
+from unittest.mock import patch
+
+from couchpotato.core.migration import codernity_to_sqlite
+
+
+class _FakeCodernity:
+    def __init__(self, docs):
+        self._docs = docs
+        self.closed = False
+
+    def exists(self):
+        return True
+
+    def open(self):
+        pass
+
+    def all(self, index):
+        assert index == 'id'
+        return iter(self._docs)
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeSqliteDB:
+    """sqlite_db double: create() is a no-op; insert() raises IntegrityError
+    for any doc whose _id is in ``dup_ids`` (mimicking the UNIQUE index
+    rejecting a duplicate identifier), and records the rest."""
+
+    def __init__(self, dup_ids):
+        self.dup_ids = set(dup_ids)
+        self.created = False
+        self.inserted = []
+
+    def create(self, path):
+        self.created = True
+
+    def insert(self, doc):
+        if doc.get('_id') in self.dup_ids:
+            raise sqlite3.IntegrityError(
+                'UNIQUE constraint failed: media_identifiers.provider, media_identifiers.identifier'
+            )
+        self.inserted.append(doc)
+        return {'_id': doc.get('_id'), '_rev': 'r1'}
+
+
+def test_migration_counts_duplicate_separately_and_warns(tmp_path, caplog):
+    docs = [
+        {'_id': 'm1', '_t': 'media', 'identifiers': {'imdb': 'tt1111111'}},
+        # m2 collides with m1's identifier -> IntegrityError on insert.
+        {'_id': 'm2', '_t': 'media', 'identifiers': {'imdb': 'tt1111111'}},
+        {'_id': 'm3', '_t': 'media', 'identifiers': {'imdb': 'tt2222222'}},
+    ]
+    fake_codernity = _FakeCodernity(docs)
+    fake_sqlite = _FakeSqliteDB(dup_ids={'m2'})
+
+    with (
+        patch.object(codernity_to_sqlite, 'SuperThreadSafeDatabase',
+                     return_value=fake_codernity),
+        patch('couchpotato.core.migration.fix_indexes.fix_index_files',
+              return_value=0),
+        caplog.at_level(logging.WARNING, logger='couchpotato.core.migration.codernity_to_sqlite'),
+    ):
+        migrated = codernity_to_sqlite.migrate_codernity_to_sqlite(
+            str(tmp_path / 'codernity'), str(tmp_path / 'sqlite'), fake_sqlite
+        )
+
+    # The duplicate was NOT counted as a migrated doc; the other two survive.
+    assert migrated == 2
+    assert [d['_id'] for d in fake_sqlite.inserted] == ['m1', 'm3']
+
+    # The duplicate is surfaced loudly (per-doc + summary), naming it a
+    # duplicate skip and pointing at database.bak -- NOT swallowed into the
+    # generic error bucket.
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any('DROPPED a duplicate-identifier document m2' in w for w in warnings), (
+        "expected the per-doc duplicate-skip warning naming m2"
+    )
+    assert any('duplicate-identifier document(s) were skipped' in w for w in warnings), (
+        "expected the migration summary duplicate warning"
+    )
+    assert any('database.bak' in w for w in warnings), (
+        "duplicate warnings must point at the preserved original (database.bak)"
+    )
+    # It must NOT be logged as a generic 'Failed to migrate' error.
+    assert not any('Failed to migrate document m2' in w for w in warnings), (
+        "a duplicate must be counted/reported distinctly from a generic error"
+    )
+
+    assert fake_codernity.closed, "the source DB must be closed in the finally block"

--- a/tests/unit/test_movie_add_integrity.py
+++ b/tests/unit/test_movie_add_integrity.py
@@ -1,0 +1,189 @@
+"""Regression tests for REG-004 (P0 data-integrity fixes) in movie.add().
+
+Covers:
+  - the `rel['status'] is 'available'` identity-comparison bug (never true
+    for a JSON-deserialized status string, so stale available releases were
+    never cleaned up on re-add).
+  - the get-or-insert insert race: movie.add() must not create a duplicate
+    media doc when it loses a concurrent insert race for the same IMDb id
+    (the unique (provider, identifier) index on media_identifiers raises
+    sqlite3.IntegrityError in that case; movie.add() must catch it and
+    re-fetch the winner's doc instead of failing or duplicating).
+"""
+import json
+import sqlite3
+from unittest.mock import patch
+
+from couchpotato.core.media.movie._base.main import MovieBase
+
+
+def _base_params(imdb_id='tt0133093', profile_id='profile-1'):
+    return {
+        'identifier': imdb_id,
+        'info': {'titles': ['The Matrix'], 'title': 'The Matrix'},
+        'profile_id': profile_id,
+    }
+
+
+class _FakeDB:
+    """Minimal db double for an *existing* media doc (the "found" branch)."""
+
+    def __init__(self, existing):
+        self.existing = existing
+        self.deleted = []
+        self.updated = []
+
+    def get(self, index, key, with_doc=False):
+        if index == 'media' and self.existing is not None:
+            return {'doc': dict(self.existing), '_id': self.existing['_id']}
+        raise KeyError('not found: %s/%s' % (index, key))
+
+    def update(self, data):
+        self.updated.append(dict(data))
+        return {'_id': data['_id'], '_rev': 'rev2'}
+
+    def delete(self, data):
+        self.deleted.append(data)
+        return True
+
+
+class _RacingFakeDB:
+    """Simulates losing a concurrent movie.add() insert race: another
+    thread/process inserts the same imdb id between our lookup and our
+    insert, so our db.insert() hits the UNIQUE(provider, identifier) index.
+    """
+
+    def __init__(self, winner_doc):
+        self.winner_doc = winner_doc
+        self.insert_calls = 0
+        self.lookup_calls = 0
+        self.updated = []
+        self.deleted = []
+
+    def get(self, index, key, with_doc=False):
+        if index == 'media':
+            self.lookup_calls += 1
+            if self.lookup_calls == 1:
+                raise KeyError('not found yet')
+            # Re-fetch after losing the insert race: the concurrent
+            # insert has already landed.
+            return {'doc': dict(self.winner_doc), '_id': self.winner_doc['_id']}
+        raise KeyError('not found: %s/%s' % (index, key))
+
+    def insert(self, data):
+        self.insert_calls += 1
+        raise sqlite3.IntegrityError(
+            'UNIQUE constraint failed: media_identifiers.provider, media_identifiers.identifier'
+        )
+
+    def update(self, data):
+        self.updated.append(dict(data))
+        return {'_id': data['_id'], '_rev': 'rev2'}
+
+    def delete(self, data):
+        self.deleted.append(data)
+        return True
+
+
+def _fire_event_returning(releases, media_dict):
+    def fake_fire_event(event, *args, **kwargs):
+        if event == 'release.for_media':
+            return releases
+        if event == 'media.get':
+            return media_dict
+        raise AssertionError('Unexpected fireEvent: %r %r %r' % (event, args, kwargs))
+    return fake_fire_event
+
+
+class TestStaleAvailableReleaseCleanup:
+    """The `is 'available'` bug (main.py:175 in add(), :229 in edit())."""
+
+    def test_stale_available_release_deleted_on_readd(self):
+        plugin = MovieBase.__new__(MovieBase)
+
+        existing_media = {
+            '_id': 'media-1',
+            '_t': 'media',
+            'type': 'movie',
+            'status': 'active',
+            'profile_id': None,
+            'category_id': None,
+            'identifiers': {'imdb': 'tt0133093'},
+            'info': {'titles': ['The Matrix']},
+            'tags': [],
+        }
+
+        # Mirror production: rel['status'] comes from json.loads() of the
+        # stored document -- a freshly-allocated str, never the interned
+        # 'available' literal that appears in the source code. This is
+        # exactly why `is` silently never matches in practice.
+        stale_release = json.loads('{"_id": "rel-1", "status": "available"}')
+
+        fake_db = _FakeDB(existing=existing_media)
+
+        with (
+            patch('couchpotato.core.media.movie._base.main.get_db', return_value=fake_db),
+            patch(
+                'couchpotato.core.media.movie._base.main.fireEvent',
+                side_effect=_fire_event_returning(
+                    [stale_release], {'_id': 'media-1', 'title': 'The Matrix'}
+                ),
+            ),
+        ):
+            result = plugin.add(
+                params=_base_params(),
+                force_readd=True,
+                search_after=False,
+                update_after=False,
+                notify_after=False,
+            )
+
+        assert result is not False
+        assert fake_db.deleted == [stale_release], (
+            "Stale 'available' release was not deleted -- the `is` identity "
+            "comparison bug is active (should be `==`)"
+        )
+
+
+class TestMovieAddInsertRace:
+    """The get-or-insert race: two movie.add() calls for the same imdb id."""
+
+    def test_losing_insert_race_reuses_winner_doc_instead_of_duplicating(self):
+        plugin = MovieBase.__new__(MovieBase)
+
+        winner_doc = {
+            '_id': 'winner-media-id',
+            '_t': 'media',
+            'type': 'movie',
+            'status': 'active',
+            'profile_id': None,
+            'category_id': None,
+            'identifiers': {'imdb': 'tt0133093'},
+            'info': {'titles': ['The Matrix']},
+            'tags': [],
+        }
+        fake_db = _RacingFakeDB(winner_doc)
+
+        with (
+            patch('couchpotato.core.media.movie._base.main.get_db', return_value=fake_db),
+            patch(
+                'couchpotato.core.media.movie._base.main.fireEvent',
+                side_effect=_fire_event_returning(
+                    [], {'_id': 'winner-media-id', 'title': 'The Matrix'}
+                ),
+            ),
+        ):
+            result = plugin.add(
+                params=_base_params(),
+                force_readd=True,
+                search_after=False,
+                update_after=False,
+                notify_after=False,
+            )
+
+        assert result is not False, "add() should recover from the insert race, not fail"
+        assert fake_db.insert_calls == 1, "must attempt the insert exactly once"
+        assert fake_db.lookup_calls == 2, (
+            "must re-fetch the doc the race winner inserted after catching "
+            "IntegrityError, instead of giving up or duplicating"
+        )

--- a/tests/unit/test_movie_add_integrity.py
+++ b/tests/unit/test_movie_add_integrity.py
@@ -360,6 +360,90 @@ class TestMovieAddInsertRace:
             "overwrite it with the losing call's category (cat-B)"
         )
 
+    def _run_genuine_found_readd(self, existing_category, passed_category):
+        """Drive a GENUINE (non-race) found re-add: the movie already exists,
+        db.get('media') succeeds first try (no IntegrityError), force_readd
+        runs. Returns the category_id persisted via db.update."""
+        existing_media = {
+            '_id': 'media-1',
+            '_t': 'media',
+            'type': 'movie',
+            'status': 'active',
+            'profile_id': None,
+            'category_id': existing_category,
+            'identifiers': {'imdb': 'tt0133093'},
+            'info': {'titles': ['The Matrix']},
+            'tags': [],
+        }
+        fake_db = _FakeDB(existing=existing_media)
+
+        plugin = MovieBase.__new__(MovieBase)
+        plugin.conf = lambda *a, **k: False
+
+        params = {
+            'identifier': 'tt0133093',
+            'info': {'titles': ['The Matrix'], 'title': 'The Matrix'},
+            'profile_id': None,
+        }
+        if passed_category is not None:
+            params['category_id'] = passed_category
+
+        with (
+            patch('couchpotato.core.media.movie._base.main.get_db', return_value=fake_db),
+            patch(
+                'couchpotato.core.media.movie._base.main.fireEvent',
+                side_effect=_fire_event_returning(
+                    [], {'_id': 'media-1', 'title': 'The Matrix'}
+                ),
+            ),
+        ):
+            result = plugin.add(
+                params=params,
+                force_readd=True,
+                search_after=False,
+                update_after=False,
+                notify_after=False,
+                status='done',  # skip profile.default fetch; targets category
+            )
+
+        assert result is not False
+        assert fake_db.updated, "force_readd should have persisted via db.update"
+        return fake_db.updated[-1]['category_id']
+
+    def test_genuine_found_readd_honors_explicitly_passed_category(self):
+        """No-API-regression guard: on a GENUINE (non-race) found re-add, an
+        explicitly-passed category_id must WIN over the existing one -- that is
+        master's public movie.add behavior. The race-loss preservation must NOT
+        leak into the genuine-found path (which it did after the over-broad
+        category mirror)."""
+        persisted = self._run_genuine_found_readd(
+            existing_category='cat-existing', passed_category='cat-new'
+        )
+        assert persisted == 'cat-new', (
+            "genuine found re-add must honor the explicitly-passed category "
+            "(new-wins), not silently keep the existing one"
+        )
+
+    def test_genuine_found_readd_without_category_matches_master(self):
+        """Genuine (non-race) found re-add with NO category_id passed must
+        behave exactly as master. On master, `m.update(media)` sets
+        category_id to None (media is built with None when no category is
+        passed) BEFORE the else-fallback `m.get('category_id') or None` runs,
+        so the result is None -- master does NOT actually preserve the existing
+        category here (a pre-existing latent quirk, out of scope for REG-004).
+
+        The point of this guard: the race-loss preservation must NOT leak into
+        the genuine-found path and start preserving the existing category,
+        which would be a behavior change vs master.
+        """
+        persisted = self._run_genuine_found_readd(
+            existing_category='cat-existing', passed_category=None
+        )
+        assert persisted is None, (
+            "genuine found re-add with no category must match master (None); "
+            "race-loss preservation must not leak into the genuine-found path"
+        )
+
     def test_real_threads_racing_add_same_imdb_produce_one_doc(self, tmp_path):
         """REG-004 review: real threads calling MovieBase.add() concurrently
         against a real SQLiteAdapter for the same imdb id must produce exactly

--- a/tests/unit/test_movie_add_integrity.py
+++ b/tests/unit/test_movie_add_integrity.py
@@ -12,8 +12,11 @@ Covers:
 """
 import json
 import sqlite3
+import threading
+import time
 from unittest.mock import patch
 
+from couchpotato.core.db.sqlite_adapter import SQLiteAdapter
 from couchpotato.core.media.movie._base.main import MovieBase
 
 
@@ -187,3 +190,189 @@ class TestMovieAddInsertRace:
             "must re-fetch the doc the race winner inserted after catching "
             "IntegrityError, instead of giving up or duplicating"
         )
+
+    def test_real_threads_racing_add_same_imdb_produce_one_doc(self, tmp_path):
+        """REG-004 review: real threads calling MovieBase.add() concurrently
+        against a real SQLiteAdapter for the same imdb id must produce exactly
+        ONE media doc, with no exception surfacing.
+
+        This is the end-to-end guarantee of the two layers working together:
+        media_lock serializes the get-or-insert critical section, and the
+        UNIQUE (provider, identifier) backstop absorbs the residual window
+        where a late thread's SELECT on the shared SQLite connection hasn't
+        yet observed the winner's just-committed row (a real shared-connection
+        read-visibility race). The lock's serialization is proven in isolation
+        by test_media_lock_serializes_add_without_db_backstop below.
+        """
+        adapter = SQLiteAdapter()
+        adapter.create(str(tmp_path / 'race_db'))
+
+        plugin = MovieBase.__new__(MovieBase)
+        # search_on_add lookup must not touch real settings.
+        plugin.conf = lambda *a, **k: False
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'release.for_media':
+                return []
+            if event == 'media.get':
+                return {'_id': args[0], 'title': 'The Matrix'}
+            return None
+
+        params = {
+            'identifier': 'tt0133093',
+            'info': {'titles': ['The Matrix'], 'title': 'The Matrix'},
+            'profile_id': 'profile-1',
+        }
+
+        n_threads = 4
+        barrier = threading.Barrier(n_threads)
+        errors = []
+
+        def worker():
+            barrier.wait()  # maximize real contention on the critical section
+            try:
+                plugin.add(
+                    params=dict(params),
+                    force_readd=True,
+                    search_after=False,
+                    update_after=False,
+                    notify_after=False,
+                )
+            except Exception as e:  # noqa: BLE001 - surface any thread failure
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        with (
+            patch('couchpotato.core.media.movie._base.main.get_db', return_value=adapter),
+            patch('couchpotato.core.media.movie._base.main.fireEvent', side_effect=fake_fire_event),
+        ):
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=15)
+
+        try:
+            assert not errors, f"add() raised under concurrency: {errors}"
+            assert all(not t.is_alive() for t in threads), "a thread hung"
+
+            media_docs = [d for d in adapter.all('id') if d.get('_t') == 'media']
+            assert len(media_docs) == 1, (
+                f"expected exactly one media doc, got {len(media_docs)}"
+            )
+        finally:
+            adapter.close()
+
+    def test_media_lock_serializes_add_without_db_backstop(self):
+        """REG-004 review: prove media_lock ALONE serializes the get-or-insert,
+        independent of the DB-level UNIQUE backstop.
+
+        Uses an in-memory DB with instantly-consistent reads and NO uniqueness
+        enforcement, whose insert() sleeps to widen the race window. If the
+        lock serializes the critical section, only the first of N racing
+        threads ever reaches insert (the rest find the doc), so there is
+        exactly one insert and one media doc. Without the lock, every thread
+        would miss during the sleep and insert, yielding N docs -- so this
+        test would fail, isolating the lock's contribution.
+        """
+
+        class _ConsistentFakeDB:
+            def __init__(self, insert_delay=0.05):
+                self._docs = {}       # _id -> doc
+                self._by_imdb = {}    # imdb -> _id
+                self._lock = threading.Lock()
+                self.insert_delay = insert_delay
+                self.inserts = 0
+                self._counter = 0
+
+            def get(self, index, key, with_doc=False):
+                if index == 'media':
+                    imdb = key.split('-', 1)[1] if '-' in key else key
+                    with self._lock:
+                        _id = self._by_imdb.get(imdb)
+                    if _id is None:
+                        raise KeyError(key)
+                    return {'doc': dict(self._docs[_id]), '_id': _id}
+                if index == 'id':
+                    with self._lock:
+                        if key in self._docs:
+                            return dict(self._docs[key])
+                    raise KeyError(key)
+                raise KeyError(key)
+
+            def insert(self, data):
+                # Widen the get->insert window so a broken lock would let a
+                # second thread miss and also insert.
+                time.sleep(self.insert_delay)
+                with self._lock:
+                    self.inserts += 1
+                    self._counter += 1
+                    _id = 'media-%d' % self._counter
+                    doc = dict(data)
+                    doc['_id'] = _id
+                    doc['_rev'] = 'r1'
+                    self._docs[_id] = doc  # NO uniqueness enforcement
+                    imdb = data.get('identifiers', {}).get('imdb')
+                    if imdb:
+                        self._by_imdb.setdefault(imdb, _id)
+                    return {'_id': _id, '_rev': 'r1'}
+
+            def update(self, data):
+                with self._lock:
+                    self._docs[data['_id']] = dict(data)
+                return {'_id': data['_id'], '_rev': 'r2'}
+
+            def media_count(self):
+                with self._lock:
+                    return sum(1 for d in self._docs.values() if d.get('_t') == 'media')
+
+        fake_db = _ConsistentFakeDB()
+
+        plugin = MovieBase.__new__(MovieBase)
+        plugin.conf = lambda *a, **k: False
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'release.for_media':
+                return []
+            if event == 'media.get':
+                return {'_id': args[0], 'title': 'The Matrix'}
+            return None
+
+        params = {
+            'identifier': 'tt0133093',
+            'info': {'titles': ['The Matrix'], 'title': 'The Matrix'},
+            'profile_id': 'profile-1',
+        }
+
+        n_threads = 4
+        barrier = threading.Barrier(n_threads)
+        errors = []
+
+        def worker():
+            barrier.wait()
+            try:
+                plugin.add(
+                    params=dict(params),
+                    force_readd=True,
+                    search_after=False,
+                    update_after=False,
+                    notify_after=False,
+                )
+            except Exception as e:  # noqa: BLE001
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        with (
+            patch('couchpotato.core.media.movie._base.main.get_db', return_value=fake_db),
+            patch('couchpotato.core.media.movie._base.main.fireEvent', side_effect=fake_fire_event),
+        ):
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=15)
+
+        assert not errors, f"add() raised under concurrency: {errors}"
+        assert fake_db.inserts == 1, (
+            "media_lock must serialize the get-or-insert so only the first "
+            f"thread inserts; got {fake_db.inserts} inserts (lock not working)"
+        )
+        assert fake_db.media_count() == 1

--- a/tests/unit/test_movie_add_integrity.py
+++ b/tests/unit/test_movie_add_integrity.py
@@ -277,6 +277,89 @@ class TestMovieAddInsertRace:
             "overwrite it with the losing call's profile (profile-B)"
         )
 
+    def test_race_loss_preserves_winners_category_not_losing_calls(self):
+        """PR #152 review: same clobber bug as profile_id, for category_id.
+
+        On a force_readd re-add, m.update(media) overwrites m['category_id']
+        with THIS call's value before the preserve line runs, so the winner's
+        (just-inserted) category must be stashed before that update and
+        restored -- otherwise two concurrent add()s with different categories
+        let the loser overwrite the winner's category.
+        """
+
+        class _RacingCategoryFakeDB:
+            def __init__(self, winner_doc):
+                self.winner_doc = winner_doc
+                self.lookup_calls = 0
+                self.updated = []
+
+            def get(self, index, key, with_doc=False):
+                if index == 'media':
+                    self.lookup_calls += 1
+                    if self.lookup_calls == 1:
+                        raise KeyError('not found yet')
+                    return {'doc': dict(self.winner_doc), '_id': self.winner_doc['_id']}
+                # No profile validated for this test (winner profile is None).
+                raise KeyError('not found: %s/%s' % (index, key))
+
+            def insert(self, data):
+                raise sqlite3.IntegrityError(
+                    'UNIQUE constraint failed: media_identifiers.provider, media_identifiers.identifier'
+                )
+
+            def update(self, data):
+                self.updated.append(dict(data))
+                return {'_id': data['_id'], '_rev': 'rev2'}
+
+            def delete(self, data):
+                return True
+
+        winner_doc = {
+            '_id': 'winner-media-id',
+            '_t': 'media',
+            'type': 'movie',
+            'status': 'active',
+            'profile_id': None,
+            'category_id': 'cat-A',   # the winner's category
+            'identifiers': {'imdb': 'tt0133093'},
+            'info': {'titles': ['The Matrix']},
+            'tags': [],
+        }
+        fake_db = _RacingCategoryFakeDB(winner_doc)
+
+        plugin = MovieBase.__new__(MovieBase)
+        plugin.conf = lambda *a, **k: False
+
+        with (
+            patch('couchpotato.core.media.movie._base.main.get_db', return_value=fake_db),
+            patch(
+                'couchpotato.core.media.movie._base.main.fireEvent',
+                side_effect=_fire_event_returning(
+                    [], {'_id': 'winner-media-id', 'title': 'The Matrix'}
+                ),
+            ),
+        ):
+            result = plugin.add(
+                params={
+                    'identifier': 'tt0133093',
+                    'info': {'titles': ['The Matrix'], 'title': 'The Matrix'},
+                    'profile_id': None,
+                    'category_id': 'cat-B',   # the LOSING call's category
+                },
+                force_readd=True,
+                search_after=False,
+                update_after=False,
+                notify_after=False,
+                status='done',  # skip profile.default fetch; this test targets category
+            )
+
+        assert result is not False
+        assert fake_db.updated, "force_readd should have persisted the movie via db.update"
+        assert fake_db.updated[-1]['category_id'] == 'cat-A', (
+            "race-loss must preserve the winner's category (cat-A), not "
+            "overwrite it with the losing call's category (cat-B)"
+        )
+
     def test_real_threads_racing_add_same_imdb_produce_one_doc(self, tmp_path):
         """REG-004 review: real threads calling MovieBase.add() concurrently
         against a real SQLiteAdapter for the same imdb id must produce exactly

--- a/tests/unit/test_movie_add_integrity.py
+++ b/tests/unit/test_movie_add_integrity.py
@@ -191,6 +191,92 @@ class TestMovieAddInsertRace:
             "IntegrityError, instead of giving up or duplicating"
         )
 
+    def test_race_loss_preserves_winners_profile_not_losing_calls(self):
+        """PR #152 review: when this add() LOSES the insert race, it must
+        preserve the WINNER's profile_id (the just-inserted movie's), exactly
+        as a genuine 'found' re-add does -- not stomp it with this (losing)
+        call's params/default profile.
+
+        A genuine found re-add validates the existing doc's profile and stashes
+        it in previous_profile so the force_readd branch keeps it. The race-loss
+        re-fetch branch must do the same; otherwise two concurrent add()s with
+        different profile_ids let the loser overwrite the winner's profile.
+        """
+
+        class _RacingProfileFakeDB:
+            def __init__(self, winner_doc, valid_profile_id):
+                self.winner_doc = winner_doc
+                self.valid_profile_id = valid_profile_id
+                self.lookup_calls = 0
+                self.updated = []
+
+            def get(self, index, key, with_doc=False):
+                if index == 'media':
+                    self.lookup_calls += 1
+                    if self.lookup_calls == 1:
+                        raise KeyError('not found yet')
+                    return {'doc': dict(self.winner_doc), '_id': self.winner_doc['_id']}
+                if index == 'id':
+                    # The winner's profile resolves to a real profile doc;
+                    # anything else (e.g. the losing call's profile) is absent.
+                    if key == self.valid_profile_id:
+                        return {'_id': key, '_t': 'profile'}
+                    raise KeyError('no profile: %s' % key)
+                raise KeyError('not found: %s/%s' % (index, key))
+
+            def insert(self, data):
+                raise sqlite3.IntegrityError(
+                    'UNIQUE constraint failed: media_identifiers.provider, media_identifiers.identifier'
+                )
+
+            def update(self, data):
+                self.updated.append(dict(data))
+                return {'_id': data['_id'], '_rev': 'rev2'}
+
+            def delete(self, data):
+                return True
+
+        winner_doc = {
+            '_id': 'winner-media-id',
+            '_t': 'media',
+            'type': 'movie',
+            'status': 'active',
+            'profile_id': 'profile-A',   # the winner's profile
+            'category_id': None,
+            'identifiers': {'imdb': 'tt0133093'},
+            'info': {'titles': ['The Matrix']},
+            'tags': [],
+        }
+        fake_db = _RacingProfileFakeDB(winner_doc, valid_profile_id='profile-A')
+
+        plugin = MovieBase.__new__(MovieBase)
+        plugin.conf = lambda *a, **k: False
+
+        with (
+            patch('couchpotato.core.media.movie._base.main.get_db', return_value=fake_db),
+            patch(
+                'couchpotato.core.media.movie._base.main.fireEvent',
+                side_effect=_fire_event_returning(
+                    [], {'_id': 'winner-media-id', 'title': 'The Matrix'}
+                ),
+            ),
+        ):
+            result = plugin.add(
+                # The LOSING call passes a DIFFERENT profile.
+                params=_base_params(profile_id='profile-B'),
+                force_readd=True,
+                search_after=False,
+                update_after=False,
+                notify_after=False,
+            )
+
+        assert result is not False
+        assert fake_db.updated, "force_readd should have persisted the movie via db.update"
+        assert fake_db.updated[-1]['profile_id'] == 'profile-A', (
+            "race-loss must preserve the winner's profile (profile-A), not "
+            "overwrite it with the losing call's profile (profile-B)"
+        )
+
     def test_real_threads_racing_add_same_imdb_produce_one_doc(self, tmp_path):
         """REG-004 review: real threads calling MovieBase.add() concurrently
         against a real SQLiteAdapter for the same imdb id must produce exactly

--- a/tests/unit/test_release_add_lookup_narrowing.py
+++ b/tests/unit/test_release_add_lookup_narrowing.py
@@ -1,0 +1,142 @@
+"""Regression tests for the narrowed lookup excepts in release.add() (REG-004).
+
+release.add() has two get-or-create sites:
+  - media lookup   (~line 147): db.get('media', ...) -> movie.add() on miss
+  - release lookup (~line 181): db.get('release_identifier', ...) -> insert on miss
+
+Both excepts were narrowed from a bare `except Exception:` to
+`except (RecordNotFound, KeyError):`. This locks in that behavior:
+
+  - a GENUINE not-found (RecordNotFound/KeyError) still falls through to the
+    create path (movie.add / db.insert), and
+  - a DIFFERENT error (e.g. a transient sqlite3.OperationalError) is NOT
+    mistaken for "not found" -- it is no longer swallowed into the create
+    path (which could mask a real DB error and spawn duplicates); it
+    propagates to add()'s outer handler, which logs and returns False without
+    creating anything.
+"""
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from CodernityDB.database import RecordNotFound
+from couchpotato.core.plugins.release.main import Release
+
+
+def _group():
+    return {
+        'identifier': 'tt0133093',
+        'meta_data': {
+            'audio': 'DTS',
+            'quality': {'identifier': '720p', 'is_3d': 0},
+        },
+        'files': {'movie': ['/media/The Matrix.mkv']},
+    }
+
+
+class _FakeDB:
+    def __init__(self, media_error=None, release_error=None):
+        self.media_error = media_error
+        self.release_error = release_error
+        self.inserted = []
+        self.updated = []
+
+    def get(self, index, key, with_doc=False):
+        if index == 'media':
+            if self.media_error is not None:
+                raise self.media_error
+            return {'doc': {'_id': 'media-1'}, '_id': 'media-1'}
+        if index == 'release_identifier':
+            if self.release_error is not None:
+                raise self.release_error
+            return {'doc': {'_id': 'rel-1', '_rev': 'r1', 'media_id': 'media-1'},
+                    '_id': 'rel-1'}
+        raise KeyError('unexpected index: %s/%s' % (index, key))
+
+    def insert(self, data):
+        self.inserted.append(dict(data))
+        return {'_id': 'rel-new', '_rev': 'r1'}
+
+    def update(self, data):
+        self.updated.append(dict(data))
+        return {'_id': data.get('_id', 'x'), '_rev': 'r2'}
+
+
+def _make_fire_event(recorder):
+    def fire_event(event, *args, **kwargs):
+        recorder.append(event)
+        if event == 'movie.add':
+            return {'_id': 'media-1'}
+        if event == 'media.restatus':
+            return None
+        return None
+    return fire_event
+
+
+def _run_add(fake_db):
+    plugin = Release.__new__(Release)
+    events = []
+    with (
+        patch('couchpotato.core.plugins.release.main.get_db', return_value=fake_db),
+        patch('couchpotato.core.plugins.release.main.fireEvent',
+              side_effect=_make_fire_event(events)),
+    ):
+        result = plugin.add(_group())
+    return result, events
+
+
+class TestReleaseAddMediaLookupNarrowing:
+    def test_genuine_miss_falls_through_to_movie_add(self):
+        """A real not-found on the media lookup creates the movie via
+        movie.add() and the release proceeds."""
+        fake_db = _FakeDB(media_error=KeyError('not found'))
+        result, events = _run_add(fake_db)
+
+        assert result is True
+        assert 'movie.add' in events, "genuine miss must fall through to movie.add"
+
+    def test_recordnotfound_miss_falls_through_to_movie_add(self):
+        """RecordNotFound (the CodernityDB backend's miss signal) behaves the
+        same as KeyError."""
+        fake_db = _FakeDB(media_error=RecordNotFound('not found'))
+        result, events = _run_add(fake_db)
+
+        assert result is True
+        assert 'movie.add' in events
+
+    def test_non_miss_error_is_not_swallowed_as_missing(self):
+        """A DIFFERENT error (transient OperationalError) must NOT be treated
+        as 'movie missing': movie.add() is never fired and add() returns False
+        (the error propagates to the outer handler)."""
+        fake_db = _FakeDB(media_error=sqlite3.OperationalError('database is locked'))
+        result, events = _run_add(fake_db)
+
+        assert result is False
+        assert 'movie.add' not in events, (
+            "an unexpected DB error must not be mistaken for 'not found' and "
+            "trigger a spurious movie.add() (would mask the error / duplicate)"
+        )
+        assert fake_db.inserted == []
+
+
+class TestReleaseAddReleaseLookupNarrowing:
+    def test_genuine_miss_falls_through_to_insert(self):
+        """A real not-found on the release lookup inserts a new release."""
+        fake_db = _FakeDB(release_error=KeyError('not found'))
+        result, events = _run_add(fake_db)
+
+        assert result is True
+        assert len(fake_db.inserted) == 1, "genuine miss must insert a new release"
+
+    def test_non_miss_error_is_not_swallowed_as_missing(self):
+        """A DIFFERENT error on the release lookup must NOT be treated as
+        'release missing': no insert happens and add() returns False."""
+        fake_db = _FakeDB(release_error=sqlite3.OperationalError('database is locked'))
+        result, events = _run_add(fake_db)
+
+        assert result is False
+        assert fake_db.inserted == [], (
+            "an unexpected DB error must not be mistaken for 'not found' and "
+            "trigger a spurious release insert (would mask the error / duplicate)"
+        )

--- a/tests/unit/test_sqlite_adapter.py
+++ b/tests/unit/test_sqlite_adapter.py
@@ -628,6 +628,71 @@ class TestSQLiteAdapterExistingDbSelfUpgrade:
         finally:
             adapter.close()
 
+    def test_double_ddl_failure_never_bricks_startup(self, tmp_path, caplog):
+        """Compounded failure: BOTH the CREATE UNIQUE INDEX and the fallback
+        CREATE INDEX (recreate-non-unique) fail. Even with no index left at
+        all, _ensure_unique_media_identifier_index() must NOT raise -- the
+        never-brick guarantee has to hold in the worst case.
+        """
+        path = str(tmp_path / 'legacy_double_fail')
+        _make_legacy_sqlite_db(path, with_duplicate=False)
+
+        adapter = SQLiteAdapter()
+        adapter.open(path)  # clean DB -> auto-upgrades to UNIQUE
+        try:
+            # Reset to the legacy non-unique state to exercise the upgrade path.
+            real_conn = adapter._get_conn()
+            real_conn.execute("DROP INDEX idx_media_identifiers_lookup")
+            real_conn.execute(
+                "CREATE INDEX idx_media_identifiers_lookup "
+                "ON media_identifiers(provider, identifier)"
+            )
+            real_conn.commit()
+            assert not adapter._has_unique_identifier_index()
+
+            class _DoubleFlakyConn:
+                """Proxy that fails BOTH CREATE statements (unique AND the
+                non-unique recreate); DROP and PRAGMA still delegate."""
+                def __init__(self, real):
+                    self._real = real
+
+                def execute(self, sql, *args, **kwargs):
+                    if 'CREATE' in sql and 'INDEX' in sql:
+                        raise sqlite3.OperationalError('forced index create failure')
+                    return self._real.execute(sql, *args, **kwargs)
+
+                def commit(self):
+                    return self._real.commit()
+
+                def rollback(self):
+                    return self._real.rollback()
+
+                def __getattr__(self, name):
+                    return getattr(self._real, name)
+
+            adapter._conn = _DoubleFlakyConn(real_conn)
+            try:
+                with caplog.at_level(logging.WARNING, logger='couchpotato.core.db.sqlite_adapter'):
+                    # Must NOT raise even though we can't create ANY index.
+                    adapter._ensure_unique_media_identifier_index()
+            finally:
+                adapter._conn = real_conn
+
+            # Worst case: no index of that name remains, but startup survived.
+            names = [r['name'] for r in
+                     real_conn.execute("PRAGMA index_list('media_identifiers')").fetchall()]
+            assert 'idx_media_identifiers_lookup' not in names
+            assert not adapter._has_unique_identifier_index()
+            assert any(
+                r.levelno >= logging.WARNING and 'REG-004' in r.getMessage()
+                for r in caplog.records
+            ), "expected a warning even in the double-failure case"
+
+            # The DB is still fully usable despite the missing index.
+            assert adapter.get_by_identifier('imdb', 'tt1111111')['title'] == 'The Lost City'
+        finally:
+            adapter.close()
+
 
 def _seed_raw_db_with_duplicate_identifiers_no_index(path):
     """Create a raw couchpotato.db at ``path`` that has the core tables and

--- a/tests/unit/test_sqlite_adapter.py
+++ b/tests/unit/test_sqlite_adapter.py
@@ -629,6 +629,79 @@ class TestSQLiteAdapterExistingDbSelfUpgrade:
             adapter.close()
 
 
+def _seed_raw_db_with_duplicate_identifiers_no_index(path):
+    """Create a raw couchpotato.db at ``path`` that has the core tables and
+    duplicate (provider, identifier) rows in media_identifiers, but NO
+    idx_media_identifiers_lookup index of any kind. This is the state a
+    retried/partial CodernityDB->SQLite migration can leave behind, where
+    create()'s schema.sql then tries to build the UNIQUE index for the first
+    time and hits the duplicate rows.
+
+    (Contrast with _make_legacy_sqlite_db, which keeps a same-named NON-unique
+    index -- there CREATE UNIQUE INDEX IF NOT EXISTS is a silent no-op and the
+    fallback never fires.)
+    """
+    os.makedirs(path, exist_ok=True)
+    db_file = os.path.join(path, 'couchpotato.db')
+    conn = sqlite3.connect(db_file)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS documents (
+                _id TEXT PRIMARY KEY, _rev TEXT NOT NULL, _t TEXT NOT NULL,
+                data JSON NOT NULL, created_at REAL, updated_at REAL
+            );
+            CREATE TABLE IF NOT EXISTS media_identifiers (
+                media_id TEXT NOT NULL, provider TEXT NOT NULL, identifier TEXT NOT NULL,
+                PRIMARY KEY (media_id, provider)
+            );
+            """
+        )
+        conn.execute("INSERT INTO documents VALUES ('m1', 'r1', 'media', '{}', 0, 0)")
+        conn.execute("INSERT INTO documents VALUES ('m2', 'r2', 'media', '{}', 0, 0)")
+        # Same (provider, identifier) owned by two different media docs.
+        conn.execute("INSERT INTO media_identifiers VALUES ('m1', 'imdb', 'tt1111111')")
+        conn.execute("INSERT INTO media_identifiers VALUES ('m2', 'imdb', 'tt1111111')")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class TestSQLiteAdapterInitSchemaFallback:
+    """REG-004 review: _init_schema()'s fallback (create() against an already-
+    populated path whose data has duplicate identifiers) must not crash startup
+    -- it downgrades to the non-unique index and warns. Real trigger:
+    codernity_to_sqlite.py's sqlite_db.create(sqlite_path) on a retried/partial
+    migration."""
+
+    def test_create_over_duplicate_rows_downgrades_and_warns(self, tmp_path, caplog):
+        path = str(tmp_path / 'partial_migration')
+        _seed_raw_db_with_duplicate_identifiers_no_index(path)
+
+        adapter = SQLiteAdapter()
+        with caplog.at_level(logging.WARNING, logger='couchpotato.core.db.sqlite_adapter'):
+            adapter.create(path)  # must NOT raise despite the duplicate rows
+        try:
+            # The rest of the schema still initialized, and the index exists
+            # but as the NON-unique fallback.
+            assert not adapter._has_unique_identifier_index()
+            names = [r['name'] for r in
+                     adapter._get_conn().execute(
+                         "PRAGMA index_list('media_identifiers')").fetchall()]
+            assert 'idx_media_identifiers_lookup' in names, (
+                "the non-unique fallback index must be created"
+            )
+            assert any(
+                'duplicate' in r.getMessage().lower()
+                for r in caplog.records if r.levelno >= logging.WARNING
+            ), "expected the _init_schema duplicate-identifier fallback warning"
+
+            # The DB is usable: the pre-seeded docs are readable.
+            assert len(list(adapter.all('id'))) == 2
+        finally:
+            adapter.close()
+
+
 class TestSQLiteAdapterDuplicateDetectionRegression:
     """Promoted from tests/integration/test_duplicate_detection.py (REG-004
     item 3): these are pure tmp_path SQLite tests with nothing integration

--- a/tests/unit/test_sqlite_adapter.py
+++ b/tests/unit/test_sqlite_adapter.py
@@ -1,5 +1,6 @@
 """Tests for the SQLite database adapter."""
 import json
+import logging
 import os
 import sqlite3
 import tempfile
@@ -448,6 +449,116 @@ class TestSQLiteAdapterUniqueMediaIdentifiers:
 
         media_docs = list(db.all('id'))
         assert len(media_docs) == 1
+
+    def test_double_update_changing_identifiers_does_not_raise(self, db, sample_media):
+        """REG-004 review: prove the double-update path is safe with the
+        plain-INSERT denormalizer. update() DELETEs this doc's own
+        media_identifiers rows before re-inserting, so updating the same doc
+        repeatedly -- even changing its identifier on a later update -- must
+        never trip the UNIQUE (provider, identifier) index on its own rows.
+        """
+        ref = db.insert(sample_media)
+
+        # First update: identifiers unchanged (the self-collision candidate).
+        doc = db.get('id', ref['_id'])
+        doc['status'] = 'done'
+        db.update(doc)
+
+        # Second update: change the imdb identifier.
+        doc = db.get('id', ref['_id'])
+        doc['identifiers'] = {'imdb': 'tt7777777'}
+        db.update(doc)
+
+        updated = db.get('id', ref['_id'])
+        assert updated['identifiers']['imdb'] == 'tt7777777'
+        assert db.get_by_identifier('imdb', 'tt7777777')['_id'] == ref['_id']
+        # The old identifier row must be gone (no orphan / no duplicate).
+        with pytest.raises(KeyError):
+            db.get_by_identifier('imdb', 'tt0133093')
+
+
+def _make_legacy_sqlite_db(path, with_duplicate=False):
+    """Build a *pre-REG-004*-shaped SQLite DB at ``path``: the media
+    identifier index is the old NON-unique one. With ``with_duplicate`` the
+    DB also contains two media docs claiming the same (imdb, tt1111111) pair
+    -- exactly the corrupt state the prod incident left behind. The adapter
+    is closed before returning so a fresh adapter can open() the path.
+    """
+    adapter = SQLiteAdapter()
+    adapter.create(path)  # schema.sql builds the UNIQUE index...
+
+    conn = adapter._get_conn()
+    # ...downgrade it to the legacy non-unique index to mimic an old install.
+    conn.execute("DROP INDEX idx_media_identifiers_lookup")
+    conn.execute(
+        "CREATE INDEX idx_media_identifiers_lookup "
+        "ON media_identifiers(provider, identifier)"
+    )
+    conn.commit()
+    assert not adapter._has_unique_identifier_index()
+
+    adapter.insert({
+        '_t': 'media', 'type': 'movie', 'status': 'active',
+        'title': 'The Lost City', 'identifiers': {'imdb': 'tt1111111'},
+        'info': {}, 'tags': [],
+    })
+    if with_duplicate:
+        # A second, distinct media doc claiming the same identifier -- only
+        # possible because the index is currently non-unique.
+        adapter.insert({
+            '_t': 'media', 'type': 'movie', 'status': 'active',
+            'title': 'The Lost City (dup)', 'identifiers': {'imdb': 'tt1111111'},
+            'info': {}, 'tags': [],
+        })
+
+    adapter.close()
+
+
+class TestSQLiteAdapterExistingDbSelfUpgrade:
+    """REG-004 review: open() must self-upgrade an existing install to the
+    UNIQUE identifier index (open() never re-runs schema.sql), and must do so
+    without ever bricking startup on a DB that still has duplicate rows."""
+
+    def test_open_upgrades_clean_existing_db_to_unique_index(self, tmp_path):
+        path = str(tmp_path / 'legacy_clean')
+        _make_legacy_sqlite_db(path, with_duplicate=False)
+
+        adapter = SQLiteAdapter()
+        adapter.open(path)
+        try:
+            assert adapter._has_unique_identifier_index(), (
+                "open() should have upgraded the non-unique index to UNIQUE"
+            )
+            # The backstop is now live: a duplicate media doc is rejected.
+            with pytest.raises(sqlite3.IntegrityError):
+                adapter.insert({
+                    '_t': 'media', 'type': 'movie', 'status': 'active',
+                    'title': 'The Lost City (dup)',
+                    'identifiers': {'imdb': 'tt1111111'},
+                    'info': {}, 'tags': [],
+                })
+        finally:
+            adapter.close()
+
+    def test_open_with_duplicate_rows_does_not_raise_and_warns(self, tmp_path, caplog):
+        path = str(tmp_path / 'legacy_dirty')
+        _make_legacy_sqlite_db(path, with_duplicate=True)
+
+        adapter = SQLiteAdapter()
+        with caplog.at_level(logging.WARNING, logger='couchpotato.core.db.sqlite_adapter'):
+            adapter.open(path)  # must NOT raise despite the duplicate rows
+        try:
+            # Startup survived and the index stayed non-unique (lock-only mode).
+            assert not adapter._has_unique_identifier_index()
+            assert any(
+                'duplicate' in r.getMessage().lower()
+                for r in caplog.records if r.levelno >= logging.WARNING
+            ), "expected a loud duplicate-identifier warning"
+
+            # The (non-unique) index is still usable, and the DB still works.
+            assert len(list(adapter.all('id'))) == 2
+        finally:
+            adapter.close()
 
 
 class TestSQLiteAdapterDuplicateDetectionRegression:

--- a/tests/unit/test_sqlite_adapter.py
+++ b/tests/unit/test_sqlite_adapter.py
@@ -1,7 +1,10 @@
 """Tests for the SQLite database adapter."""
 import json
 import os
+import sqlite3
 import tempfile
+import threading
+import time
 
 import pytest
 
@@ -172,7 +175,10 @@ class TestSQLiteAdapterCRUD:
 class TestSQLiteAdapterIndexQueries:
     def test_media_status_query(self, db, sample_media):
         db.insert(sample_media)
-        sample2 = dict(sample_media, title='Inception', status='done')
+        # Distinct identifiers: two media docs can no longer share the same
+        # (provider, identifier) pair (REG-004 unique index).
+        sample2 = dict(sample_media, title='Inception', status='done',
+                        identifiers={'imdb': 'tt1375666', 'tmdb': 27205})
         db.insert(sample2)
 
         active = list(db.query('media_status', key='active', with_doc=True))
@@ -368,3 +374,161 @@ class TestSQLiteAdapterCompat:
         db.insert(sample_property)
         doc = db.get('property', 'manage.last_update', with_doc=True)
         assert doc['doc']['value'] == '1700000000.0'
+
+
+class TestSQLiteAdapterUniqueMediaIdentifiers:
+    """REG-004 (P0): (provider, identifier) must be unique across media docs.
+
+    Regression coverage for the prod incident where a lookup race in
+    movie.add() created 77 duplicate movie entries with the same IMDb id.
+    """
+
+    def test_duplicate_provider_identifier_raises_integrity_error(self, db, sample_media):
+        db.insert(sample_media)
+
+        duplicate = dict(sample_media)
+        duplicate.pop('_id', None)
+        with pytest.raises(sqlite3.IntegrityError):
+            db.insert(duplicate)
+
+    def test_failed_duplicate_insert_leaves_no_orphaned_document(self, db, sample_media):
+        """An IntegrityError from the unique index must not leave a
+        lingering, uncommitted 'documents' row behind -- otherwise a later,
+        unrelated commit on the same connection could accidentally persist
+        the half-inserted duplicate."""
+        db.insert(sample_media)
+
+        duplicate = dict(sample_media)
+        duplicate.pop('_id', None)
+        with pytest.raises(sqlite3.IntegrityError):
+            db.insert(duplicate)
+
+        assert len(list(db.all('id'))) == 1
+
+        # A subsequent, unrelated insert must still work normally --
+        # proves the connection wasn't left in a broken transaction state.
+        other = {
+            '_t': 'media',
+            'status': 'active',
+            'title': 'Unrelated Movie',
+            'type': 'movie',
+            'identifiers': {'imdb': 'tt9999999'},
+            'info': {},
+            'tags': [],
+        }
+        db.insert(other)
+        assert len(list(db.all('id'))) == 2
+
+    def test_concurrent_inserts_of_same_identifier_yield_one_media_doc(self, db, sample_media):
+        """Simulated concurrent movie.add(): two threads race to insert a
+        media doc for the same IMDb id. Exactly one must win; the loser
+        must get IntegrityError (which movie.add() catches and re-fetches
+        instead of duplicating -- see test_movie_add_integrity.py)."""
+        results = {'ok': 0}
+        errors = []
+        barrier = threading.Barrier(2)
+
+        def worker():
+            barrier.wait()
+            doc = dict(sample_media)
+            try:
+                db.insert(doc)
+                results['ok'] += 1
+            except sqlite3.IntegrityError as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert results['ok'] == 1
+        assert len(errors) == 1
+
+        media_docs = list(db.all('id'))
+        assert len(media_docs) == 1
+
+
+class TestSQLiteAdapterDuplicateDetectionRegression:
+    """Promoted from tests/integration/test_duplicate_detection.py (REG-004
+    item 3): these are pure tmp_path SQLite tests with nothing integration
+    about them, but only ran under tests/integration/, which isn't part of
+    `make verify` / CI. Copied here (originals kept in place) so the exact
+    corruption branches stay covered on every PR.
+    """
+
+    @staticmethod
+    def _make_movie(imdb_id, title):
+        return {
+            '_t': 'media',
+            'type': 'movie',
+            'title': title,
+            'status': 'done',
+            'identifiers': {'imdb': imdb_id},
+            'info': {'titles': [title], 'year': 2020},
+            'files': {},
+            'tags': [],
+            'last_edit': int(time.time()),
+        }
+
+    @staticmethod
+    def _make_release(media_id, imdb_id, audio='DTS', quality='720p'):
+        return {
+            '_t': 'release',
+            'media_id': media_id,
+            'identifier': f'{imdb_id}.{audio}.{quality}',
+            'quality': quality,
+            'is_3d': 0,
+            'last_edit': int(time.time()),
+            'status': 'done',
+            'files': {},
+        }
+
+    def test_media_lookup_returns_correct_movie_among_many(self, db):
+        """BUG REPRODUCTION (Bug 1, sqlite_adapter._query_index('media')).
+
+        With multiple movies in the database, db.get('media', 'imdb-XXXX')
+        must return the movie matching XXXX, not just the first one
+        inserted. Before the fix, the SQL/params were overwritten and
+        limit=1 silently returned the first media doc in the database.
+        """
+        for movie in [
+            self._make_movie('tt5697572', 'Cats'),
+            self._make_movie('tt3105662', 'Breaking the Bank'),
+            self._make_movie('tt13320622', 'The Lost City'),
+        ]:
+            db.insert(movie)
+
+        result = db.get('media', 'imdb-tt13320622', with_doc=True)
+        doc = result['doc']
+
+        assert doc['identifiers']['imdb'] == 'tt13320622', (
+            f"Expected tt13320622 (The Lost City) but got "
+            f"{doc['identifiers']['imdb']} ({doc['title']})"
+        )
+        assert doc['title'] == 'The Lost City'
+
+    def test_release_identifier_lookup_finds_matching_release(self, db):
+        """db.get('release_identifier', ...) must return the release with
+        the matching identifier, not just any release/document."""
+        movie = db.insert(self._make_movie('tt13320622', 'The Lost City'))
+        db.insert(self._make_release(movie['_id'], 'tt13320622'))
+
+        result = db.get('release_identifier', 'tt13320622.DTS.720p', with_doc=True)
+        doc = result['doc']
+        assert doc['_t'] == 'release'
+        assert doc['identifier'] == 'tt13320622.DTS.720p'
+
+    def test_release_identifier_lookup_raises_keyerror_when_absent(self, db):
+        """BUG REPRODUCTION (Bug 2, sqlite_adapter._query_index('release_identifier')).
+
+        When a media doc exists but no matching release exists, the lookup
+        must raise KeyError -- not fall through to the generic "return all
+        documents" branch and hand back the media doc as if it were a
+        release (which caused release.add() to overwrite the media doc).
+        """
+        db.insert(self._make_movie('tt13320622', 'The Lost City'))
+
+        with pytest.raises(KeyError):
+            db.get('release_identifier', 'tt13320622.DTS.720p', with_doc=True)

--- a/tests/unit/test_sqlite_adapter.py
+++ b/tests/unit/test_sqlite_adapter.py
@@ -560,6 +560,74 @@ class TestSQLiteAdapterExistingDbSelfUpgrade:
         finally:
             adapter.close()
 
+    def test_non_integrity_create_failure_restores_non_unique_index(self, tmp_path, caplog):
+        """If DROP succeeds but CREATE UNIQUE INDEX fails with an UNEXPECTED
+        error (not IntegrityError/OperationalError), the non-unique index must
+        still be restored -- otherwise media_identifiers is left with NO index
+        at all (a lookup perf cliff on a large prod DB). open()/ensure must not
+        raise either.
+        """
+        path = str(tmp_path / 'legacy_clean_flaky')
+        _make_legacy_sqlite_db(path, with_duplicate=False)
+
+        adapter = SQLiteAdapter()
+        adapter.open(path)  # clean DB -> auto-upgrades to UNIQUE
+        try:
+            # Reset to the legacy non-unique state so we exercise the upgrade path.
+            real_conn = adapter._get_conn()
+            real_conn.execute("DROP INDEX idx_media_identifiers_lookup")
+            real_conn.execute(
+                "CREATE INDEX idx_media_identifiers_lookup "
+                "ON media_identifiers(provider, identifier)"
+            )
+            real_conn.commit()
+            assert not adapter._has_unique_identifier_index()
+
+            class _FlakyConn:
+                """Proxy that fails ONLY the CREATE UNIQUE INDEX with a
+                non-Integrity/Operational error; everything else delegates."""
+                def __init__(self, real):
+                    self._real = real
+
+                def execute(self, sql, *args, **kwargs):
+                    if 'CREATE UNIQUE INDEX' in sql:
+                        raise sqlite3.ProgrammingError('forced non-integrity failure')
+                    return self._real.execute(sql, *args, **kwargs)
+
+                def commit(self):
+                    return self._real.commit()
+
+                def rollback(self):
+                    return self._real.rollback()
+
+                def __getattr__(self, name):
+                    return getattr(self._real, name)
+
+            adapter._conn = _FlakyConn(real_conn)
+            try:
+                with caplog.at_level(logging.WARNING, logger='couchpotato.core.db.sqlite_adapter'):
+                    # Must NOT raise despite the unexpected CREATE failure.
+                    adapter._ensure_unique_media_identifier_index()
+            finally:
+                adapter._conn = real_conn
+
+            # Fallback restored the non-unique index (no perf cliff).
+            assert not adapter._has_unique_identifier_index()
+            names = [r['name'] for r in
+                     real_conn.execute("PRAGMA index_list('media_identifiers')").fetchall()]
+            assert 'idx_media_identifiers_lookup' in names, (
+                "the non-unique index must be restored after any CREATE failure"
+            )
+            assert any(
+                'failed creating the unique' in r.getMessage().lower()
+                for r in caplog.records if r.levelno >= logging.WARNING
+            ), "expected the non-integrity create-failure warning"
+
+            # Lookups via the restored index still work.
+            assert adapter.get_by_identifier('imdb', 'tt1111111')['title'] == 'The Lost City'
+        finally:
+            adapter.close()
+
 
 class TestSQLiteAdapterDuplicateDetectionRegression:
     """Promoted from tests/integration/test_duplicate_detection.py (REG-004


### PR DESCRIPTION
Second P0 batch from the nine-dimension review: closes the root cause behind the duplicate-movie incidents. Movie adds had no DB-level uniqueness on `media_identifiers(provider, identifier)` — the exact backstop the 77-duplicate `_query_index` incident lacked — and REG-002's threadpool made read-modify-write races routine.

## Fixes
- **UNIQUE index on `media_identifiers(provider, identifier)`** (schema.sql) — fresh installs get it directly; **existing DBs self-upgrade in `SQLiteAdapter.open()`** via `_ensure_unique_media_identifier_index()` (detect → DROP legacy non-unique → CREATE UNIQUE). This runs against prod's live DB on every startup, so it's heavily guarded: on duplicate rows (or *any* CREATE failure) it restores the non-unique index, logs a loud warning, and continues — it never auto-dedups and never bricks startup.
- **`insert()`/`update()` wrap writes in `try/except sqlite3.IntegrityError`** with correct rollback (only when not inside an explicit `transaction()` — verified `_transaction_depth` is a reliable proxy and sqlite3 does not auto-rollback on IntegrityError).
- **`_update_denormalized()`: `INSERT OR REPLACE` → plain `INSERT`** — OR REPLACE would silently delete a *different* movie's conflicting identifier row. The self-`DELETE` before the insert loop keeps repeated updates safe (proven by test).
- **`movie.add()` wrapped in `media_lock('imdb-%s')`** with an IntegrityError re-fetch for the cross-process case the in-process lock can't cover; narrowed the lookup `except` from bare `Exception` to `(RecordNotFound, KeyError)`.
- **`rel['status'] is 'available'` → `==`** (main.py add/edit) — the identity comparison was always False, so stale releases were never cleaned up.
- **CodernityDB→SQLite migration** now counts duplicate-identifier skips distinctly and warns loudly (data-loss visible on this disaster-recovery path). CodernityDB itself is untouched — it remains the upgrade path for old installs.

## Verification
- 785 unit tests green (incl. a real-thread `movie.add` race test, an in-memory lock-isolation test with a verified negative control, a double-update-changing-identifiers test, and the existing-DB self-upgrade tests — clean + dirty), ruff clean, full E2E 129/130 (sole failure is the known-flaky sidebar-nav test; passes on isolated retry).
- Local review: two full-branch reviewers (one empirically proved the double-update path safe; both flagged the existing-DB gap) + a delta reviewer on the self-upgrade DDL (confirmed it survives a compounded double-failure without bricking).

Spec: `specs/REG-004-p0-data-integrity.md`. Future P2 dedup migration (dedup → DROP → CREATE UNIQUE for dirty prod DBs) documented there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RU1LBHaKDFozqA36bxkeY