### PR TITLE
feat(status): add 'downloaded' review movie status + searcher gating (workflow phase 1)

### DIFF
--- a/couchpotato/core/media/_base/media/main.py
+++ b/couchpotato/core/media/_base/media/main.py
@@ -720,7 +720,14 @@ class MediaPlugin(MediaBase):
                 previous_status = m['status']
 
                 log.debug('Changing status for %s', getTitle(m))
-                if not m['profile_id']:
+                if previous_status == 'downloaded':
+                    # 'downloaded' is the manual-review gate (workflow phase 1):
+                    # a movie awaiting review is terminal for search purposes.
+                    # Don't demote it back to 'active' or auto-promote it to
+                    # 'done' here; phase 2 owns the done/downloaded routing
+                    # decision (via the per-profile manual_confirmation toggle).
+                    m['status'] = 'downloaded'
+                elif not m['profile_id']:
                     m['status'] = 'done'
                 else:
                     m['status'] = 'active'

--- a/couchpotato/core/media/movie/searcher.py
+++ b/couchpotato/core/media/movie/searcher.py
@@ -122,8 +122,11 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
         except SearchSetupError:
             return
 
-        if not movie['profile_id'] or (movie['status'] == 'done' and not manual):
-            log.debug('Movie doesn\'t have a profile or already done, assuming in manage tab.')
+        # 'downloaded' is the manual-review gate (workflow phase 1): treat it like
+        # 'done' for gating purposes so a movie awaiting review is never searched
+        # or upgraded, unless a manual/forced search explicitly overrides it.
+        if not movie['profile_id'] or (movie['status'] in ('done', 'downloaded') and not manual):
+            log.debug('Movie doesn\'t have a profile, is already done, or is awaiting review, assuming in manage tab.')
             fireEvent('media.restatus', movie['_id'], single = True)
             return
 

--- a/couchpotato/ui/templates/partials/movie_cards.html
+++ b/couchpotato/ui/templates/partials/movie_cards.html
@@ -71,7 +71,7 @@
         {% elif status == 'done' %}
         <span class="px-1.5 py-0.5 rounded text-[9px] font-medium lowercase bg-cp-success/20 text-cp-success backdrop-blur-sm">done</span>
         {% elif status == 'downloaded' %}
-        <span class="px-1.5 py-0.5 rounded text-[9px] font-medium lowercase bg-cp-blue/20 text-cp-blue backdrop-blur-sm">downloaded / review</span>
+        <span class="px-1.5 py-0.5 rounded text-[9px] font-medium lowercase bg-cp-warning/20 text-cp-warning backdrop-blur-sm">downloaded / review</span>
         {% else %}
         <span class="px-1.5 py-0.5 rounded text-[9px] font-medium lowercase bg-white/10 text-white/80 backdrop-blur-sm">{{ status }}</span>
         {% endif %}

--- a/couchpotato/ui/templates/partials/movie_cards.html
+++ b/couchpotato/ui/templates/partials/movie_cards.html
@@ -70,6 +70,8 @@
         <span class="px-1.5 py-0.5 rounded text-[9px] font-medium lowercase bg-cp-blue/20 text-cp-blue backdrop-blur-sm">wanted</span>
         {% elif status == 'done' %}
         <span class="px-1.5 py-0.5 rounded text-[9px] font-medium lowercase bg-cp-success/20 text-cp-success backdrop-blur-sm">done</span>
+        {% elif status == 'downloaded' %}
+        <span class="px-1.5 py-0.5 rounded text-[9px] font-medium lowercase bg-cp-blue/20 text-cp-blue backdrop-blur-sm">downloaded / review</span>
         {% else %}
         <span class="px-1.5 py-0.5 rounded text-[9px] font-medium lowercase bg-white/10 text-white/80 backdrop-blur-sm">{{ status }}</span>
         {% endif %}

--- a/couchpotato/ui/templates/partials/movie_detail.html
+++ b/couchpotato/ui/templates/partials/movie_detail.html
@@ -101,7 +101,7 @@
         {% elif status == 'active' %}
         <span class="px-2 py-0.5 rounded text-[10px] font-medium lowercase bg-cp-blue/10 text-cp-blue">wanted</span>
         {% elif status == 'downloaded' %}
-        <span class="px-2 py-0.5 rounded text-[10px] font-medium lowercase bg-cp-blue/10 text-cp-blue">downloaded / review</span>
+        <span class="px-2 py-0.5 rounded text-[10px] font-medium lowercase bg-cp-warning/10 text-cp-warning">downloaded / review</span>
         {% else %}
         <span class="px-2 py-0.5 rounded text-[10px] font-medium lowercase bg-white/10 text-white/80">{{ status }}</span>
         {% endif %}

--- a/couchpotato/ui/templates/partials/movie_detail.html
+++ b/couchpotato/ui/templates/partials/movie_detail.html
@@ -100,6 +100,8 @@
         <span class="px-2 py-0.5 rounded text-[10px] font-medium lowercase bg-cp-success/10 text-cp-success">done</span>
         {% elif status == 'active' %}
         <span class="px-2 py-0.5 rounded text-[10px] font-medium lowercase bg-cp-blue/10 text-cp-blue">wanted</span>
+        {% elif status == 'downloaded' %}
+        <span class="px-2 py-0.5 rounded text-[10px] font-medium lowercase bg-cp-blue/10 text-cp-blue">downloaded / review</span>
         {% else %}
         <span class="px-2 py-0.5 rounded text-[10px] font-medium lowercase bg-white/10 text-white/80">{{ status }}</span>
         {% endif %}

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -137,7 +137,7 @@ All examples use existing Tailwind/`cp.*` tokens. Hover/focus states are require
 **Settings row layout:** label + hint on the left, control right-aligned; rows divided by `border-white/[0.04]`.
 
 ### Status & quality badges
-Pill `px-1.5 py-0.5 rounded text-[9px] font-medium`: wanted `bg-cp-blue/20 text-cp-blue` · done `bg-cp-success/20 text-cp-success` · snatched `bg-cp-warning/20 text-cp-warning` · quality `bg-white/10 text-white/80 backdrop-blur-sm`.
+Pill `px-1.5 py-0.5 rounded text-[9px] font-medium`: wanted `bg-cp-blue/20 text-cp-blue` · done `bg-cp-success/20 text-cp-success` · snatched `bg-cp-warning/20 text-cp-warning` · quality `bg-white/10 text-white/80 backdrop-blur-sm` · downloaded/review `bg-cp-warning/20 text-cp-warning`.
 
 ### Toasts
 Global Alpine `toast(msg, type, duration)` queue, top-right, `aria-live="polite"`. `bg-green-600`/`bg-red-600`/`bg-cp-accent text-cp-bg` for success/error/info. Auto-dismiss (default 3000ms) + manual close.

--- a/specs/DOWNLOADED-REVIEW-WORKFLOW.md
+++ b/specs/DOWNLOADED-REVIEW-WORKFLOW.md
@@ -1,0 +1,167 @@
+# Manual-Confirmation Download Workflow ("Downloaded / review" gate)
+
+> Status: **DRAFT for review** (Scott to approve before implementation).
+> Supersedes the open question in `specs/RENAMER-EVENT-CHAIN.md` about whether to
+> auto-mark releases `done` — the answer is **no; introduce a review gate**.
+
+## Problem / motivation
+
+The downloader frequently fetches a bad copy of a movie (wrong cut, bad
+encode, mislabeled). Today the searcher has no "stop and let a human confirm"
+state: a movie is either `active` (searching **and upgrading**) or `done`.
+Because the profile drives an *upgrade-until-finish-quality* loop
+(`couchpotato/core/media/movie/searcher.py:125,188-200`), a movie keeps
+grabbing higher-quality candidates after the first successful download — the
+"continuously downloads unnecessarily" behavior. There is no first-class way to:
+
+1. Stop after the first good download and wait for manual confirmation.
+2. Reject a specific bad copy and have the searcher find another.
+3. Skip a known-bad release/link so the searcher never grabs it again.
+
+## Key finding — most of this already exists
+
+Verified against `origin/master`:
+
+- **`downloaded` is already a first-class release status** — set by the scanner
+  (`couchpotato/core/plugins/renamer/scanner.py:137`
+  `release.update_status(..., status='downloaded')`), and already treated as a
+  "completed" status in the UI (`ui/templates/partials/movie_cards.html:13`,
+  `movie_detail.html:19`). It does **not** currently exist at the *movie* level.
+- **`ignored` and `failed` release statuses already exist**, and the searcher
+  **already excludes them from being re-grabbed**: `searcher.py:188` only
+  reconsiders releases whose status is in `['available','ignored','failed']`
+  for the *has-better-quality* comparison, and a `snatched`/`downloaded`/`done`
+  release already counts as "have it" and stops the search for that quality and
+  below. So the *blacklist* mechanism for point 3 is already written.
+- `release.update_status` (`couchpotato/core/plugins/release/main.py`) already
+  supports transitioning a release to `done` / `failed` / `ignored`.
+- Movie statuses currently observed in production: only `active` (13) and
+  `done` (1078); 0 releases sit in `snatched`/`downloaded` (no stuck backlog).
+
+**Implication:** point 3 ("skip a link") is largely a UI exposure of the
+existing `ignored` status; the genuinely new work is the movie-level review
+gate + the searcher-stop + a per-profile setting + the UI actions.
+
+## Decisions (confirmed with Scott)
+
+- **Scope of the gate: per-profile toggle.** A profile option controls whether
+  its movies auto-upgrade-to-done (current default) or stop at first download
+  for manual review. Lets "auto" and "manual review" profiles coexist.
+- **On "Mark Failed": re-search immediately** (don't wait for the next cycle).
+- **Notify** when a movie enters "Downloaded / review".
+
+## Design
+
+### New movie status: `downloaded` (review gate)
+
+Add `downloaded` as a movie (`media`) status meaning "a copy has landed and is
+awaiting the user's confirmation". Behavior:
+
+- The searcher treats a movie in `downloaded` like `done` for **gating** — it is
+  NOT selected by the `active`-only batch search (`searcher.py:80`) and
+  `single()` skips it — so **no upgrade loop, no further grabbing**.
+- Visually distinct from `done` (label "Downloaded / review"), filterable in the
+  wanted/manage lists.
+- Reached only when the owning profile has the manual-review toggle ON.
+
+### Completion path change
+
+Where a completed download currently drives the movie toward `done`
+(`media.restatus`, `couchpotato/core/media/_base/media/main.py:723-742`, and the
+scanner completion path):
+
+- **Auto profile (default):** unchanged — release → `done`, movie → `done` via
+  `restatus` (preserves everyone else's behavior).
+- **Manual-review profile:** release → `downloaded`, movie → `downloaded`
+  (review gate). Do **not** advance to `done` automatically. Fire the
+  notification + the renamer enrichment events (see below) at this point.
+
+`media.restatus` must learn the profile toggle and choose `downloaded` vs `done`
+accordingly, and must treat `downloaded` as a terminal-for-search state (don't
+demote it back to `active`).
+
+### User actions (UI)
+
+Per-movie (when in `downloaded`):
+- **Mark Done** → movie `done`, owning release `done`. Terminal.
+- **Mark Failed & re-search** → current release `failed`; movie back to
+  `active`; **immediately** trigger `searcher.single(movie, manual=True)` so it
+  finds the next candidate (the `failed` release is already excluded by
+  `searcher.py:188`).
+
+Per-release / link (in the releases panel):
+- **Skip / Ignore link** → `release.update_status(id, 'ignored')` (already
+  excluded from future grabs).
+- **Mark failed** → `release.update_status(id, 'failed')`.
+
+These call existing `release.update_status`; the work is exposing buttons +
+htmx endpoints + wiring the immediate re-search.
+
+### Per-profile setting
+
+Add to the profile model/editor a boolean, e.g.
+`manual_confirmation` / "Stop after first download for manual review"
+(default **off** = current auto-upgrade behavior). Surfaced in the profile
+editor UI. `media.restatus` / searcher read it via the movie's `profile_id`.
+
+### Notification
+
+On entering `downloaded`, fire `notify.frontend` (and the configured
+notification providers) with a "‹title› downloaded — awaiting review" message.
+This rides on the renamer-completion hook.
+
+### Ties into renamer #13 (enrichment)
+
+The dead `renamer.before`/`renamer.after` chain (subtitles, trailers,
+notifications, metadata — see `specs/RENAMER-EVENT-CHAIN.md`) should fire at the
+**completion/`downloaded`** point, NOT at an auto-`done`. Since production shows
+**no stuck backlog** (0 releases moved-but-unfinalized), the feared
+"storm on upgrade" is moot — enrichment fires only for genuinely-new
+completions going forward. Wiring the enrichment events is folded into this
+feature's completion-path change rather than a separate reconstruction.
+
+## Rollout / safety
+
+- Ship behind `-beta`; the default profile setting is OFF so nothing changes for
+  existing users until a profile opts in.
+- Test against a **copy** of production data before deploying (the media/release
+  state machine is being touched on a live server).
+- Existing 1078 `done` movies are unaffected (the change only alters how *new*
+  completions behave under a manual-review profile).
+
+## Phased plan (each its own reviewed PR)
+
+1. **Status + gating (no behavior change yet):** register the `downloaded` movie
+   status + label/filter; make the searcher gate on it (skip like `done`).
+   Tests: searcher does not select/act on a `downloaded` movie.
+2. **Per-profile toggle + completion routing:** add `manual_confirmation` to the
+   profile; teach `media.restatus`/completion to route release+movie to
+   `downloaded` vs `done` by the toggle. Tests: auto profile → `done` (unchanged);
+   manual profile → `downloaded` + no further search.
+   **Forward-looking (found in Phase 1 review — must handle here):** two call
+   sites key off a fixed movie-status list and would silently *exclude* a
+   `downloaded` movie once this phase starts producing them —
+   `couchpotato/core/plugins/release/main.py:117`
+   (`media.with_status(['done','active'])`, the weekly stale-release cleanup) and
+   `couchpotato/core/plugins/profile/main.py:53` (`media.with_status('active')`).
+   Audit these (and any other hardcoded status lists) and include `downloaded`
+   where a review-gated movie should still be considered.
+3. **UI actions:** Mark Done / Mark Failed&re-search (movie); Skip/Ignore &
+   Mark-failed (release); immediate re-search on Fail. Tests + E2E.
+4. **Notification + renamer enrichment hook:** fire notify + `renamer.after`
+   enrichment on entering `downloaded`; wire the dead listeners
+   (per `specs/RENAMER-EVENT-CHAIN.md`). Tests: listeners fire once, only on
+   genuine completion.
+5. **Docs + beta + prod-copy validation**, then release.
+
+## Acceptance criteria
+
+- A profile with `manual_confirmation` ON: a completed download leaves the movie
+  in `downloaded` (not `done`), the searcher stops (no upgrade grabs), and a
+  notification fires once.
+- **Mark Done** → `done` (terminal). **Mark Failed** → release `failed`, movie
+  re-searches immediately and does not re-grab the failed release.
+- **Skip/Ignore** a release → excluded from future grabs.
+- A profile with the toggle OFF behaves exactly as today (auto-upgrade → `done`).
+- Existing `done` movies unchanged; no mass reprocessing on upgrade.
+- Full unit + E2E suites green; ruff clean.

--- a/tests/unit/test_downloaded_review_status_phase1.py
+++ b/tests/unit/test_downloaded_review_status_phase1.py
@@ -123,6 +123,12 @@ class TestSingleGatesOnDownloadedStatus:
             for e, kw in events
         ), "a downloaded movie must never start a search"
 
+    # NOTE: this test documents the manual=True override precedent only. It does
+    # NOT by itself prove 'downloaded' is in the gating tuple, since
+    # `status in (...) and not manual` short-circuits to False whenever
+    # manual=True regardless of the tuple's contents. That gating is proven by
+    # the sibling test `test_skips_downloaded_movie_when_not_manual` above,
+    # which would fail if 'downloaded' were removed from the tuple.
     def test_manual_true_overrides_the_downloaded_gate(self):
         """A manual/forced search (manual=True) must still be able to act on
         a 'downloaded' movie -- mirrors the existing 'done' + manual=True

--- a/tests/unit/test_downloaded_review_status_phase1.py
+++ b/tests/unit/test_downloaded_review_status_phase1.py
@@ -1,0 +1,293 @@
+"""Tests for workflow Phase 1 (specs/DOWNLOADED-REVIEW-WORKFLOW.md): introduce
+the movie-level 'downloaded' ("Downloaded / review") status and make the
+searcher treat it as a search-stop state, same as 'done'.
+
+Phase 1 is additive only: nothing in this phase *sets* a movie to
+'downloaded' (that is Phase 2's per-profile completion routing). These tests
+lock in the gating/preservation behavior so Phase 2 can rely on it safely.
+"""
+import threading
+from unittest.mock import patch
+
+import pytest
+
+from couchpotato.core.media._base.media.main import MediaPlugin
+from couchpotato.core.media.movie.searcher import MovieSearcher
+
+
+# --- searchAll(): batch search must not select 'downloaded' movies --------
+
+class TestSearchAllExcludesDownloaded:
+
+    def _make_searcher(self):
+        searcher = MovieSearcher.__new__(MovieSearcher)
+        searcher._progress_lock = threading.Lock()
+        searcher.in_progress = False
+        return searcher
+
+    def test_batch_search_only_requests_active_status(self):
+        """searchAll must query media.with_status('active', ...) -- a
+        'downloaded' movie is never even fetched for the batch loop."""
+        searcher = self._make_searcher()
+        with_status_calls = []
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'media.with_status':
+                with_status_calls.append((args, kwargs))
+                return []
+            if event == 'notify.frontend':
+                return None
+            if event == 'searcher.protocols':
+                return ['torrent']
+            raise AssertionError('Unexpected fireEvent call: %r' % (event,))
+
+        with patch('couchpotato.core.media.movie.searcher.fireEvent', side_effect=fake_fire_event):
+            searcher.searchAll(manual=False)
+
+        assert len(with_status_calls) == 1
+        args, kwargs = with_status_calls[0]
+        assert args[0] == 'active', "batch search must only select 'active' movies"
+        assert kwargs.get('types') == 'movie'
+
+    def test_downloaded_movie_is_never_passed_to_single(self):
+        """Given a mixed fixture of active/done/downloaded movies, only the
+        active one reaches self.single() -- 'downloaded' is excluded exactly
+        like 'done' already is, because media.with_status('active', ...)
+        filters it out upstream."""
+        searcher = self._make_searcher()
+
+        fixture = {
+            'movie-active': {'_id': 'movie-active', 'status': 'active'},
+            'movie-done': {'_id': 'movie-done', 'status': 'done'},
+            'movie-downloaded': {'_id': 'movie-downloaded', 'status': 'downloaded'},
+        }
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'media.with_status':
+                status_arg = args[0]
+                statuses = status_arg if isinstance(status_arg, (list, tuple)) else [status_arg]
+                return [{'_id': mid} for mid, doc in fixture.items() if doc['status'] in statuses]
+            if event == 'notify.frontend':
+                return None
+            if event == 'searcher.protocols':
+                return ['torrent']
+            if event == 'media.get':
+                return fixture.get(args[0])
+            raise AssertionError('Unexpected fireEvent call: %r' % (event,))
+
+        singled_ids = []
+        with (
+            patch('couchpotato.core.media.movie.searcher.fireEvent', side_effect=fake_fire_event),
+            patch.object(searcher, 'single', side_effect=lambda media, *a, **k: singled_ids.append(media['_id'])),
+            patch.object(searcher, 'shuttingDown', return_value=False),
+        ):
+            searcher.searchAll(manual=False)
+
+        assert singled_ids == ['movie-active']
+        assert 'movie-downloaded' not in singled_ids
+        assert 'movie-done' not in singled_ids
+
+
+# --- single(): per-movie gating on 'downloaded' ----------------------------
+
+class TestSingleGatesOnDownloadedStatus:
+
+    def _make_searcher(self):
+        return MovieSearcher.__new__(MovieSearcher)
+
+    def test_skips_downloaded_movie_when_not_manual(self):
+        """A 'downloaded' movie must be skipped (no search, no upgrade) just
+        like a 'done' movie -- confirmed by never reaching the
+        'movie.searcher.started' notification that only fires past the gate."""
+        searcher = self._make_searcher()
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1', 'title': 'Test Movie'}
+
+        events = []
+
+        def fake_fire_event(event, *args, **kwargs):
+            events.append((event, kwargs))
+            if event == 'media.restatus':
+                return 'downloaded'
+            return None
+
+        with patch('couchpotato.core.media.movie.searcher.fireEvent', side_effect=fake_fire_event):
+            result = searcher.single(movie, search_protocols=['torrent'], manual=False)
+
+        assert result is None
+        event_names = [e for e, _ in events]
+        assert event_names == ['media.restatus'], (
+            "skip path must only call media.restatus and return immediately"
+        )
+        assert not any(
+            e == 'notify.frontend' and kw.get('type') == 'movie.searcher.started'
+            for e, kw in events
+        ), "a downloaded movie must never start a search"
+
+    def test_manual_true_overrides_the_downloaded_gate(self):
+        """A manual/forced search (manual=True) must still be able to act on
+        a 'downloaded' movie -- mirrors the existing 'done' + manual=True
+        precedent (media_id gating uses `and not manual`)."""
+        searcher = self._make_searcher()
+        movie = {
+            '_id': 'movie-1',
+            'status': 'downloaded',
+            'profile_id': 'profile-1',
+            'title': 'Test Movie',
+        }
+
+        events = []
+
+        def fake_fire_event(event, *args, **kwargs):
+            events.append((event, kwargs))
+            if event == 'media.restatus':
+                return 'downloaded'
+            if event == 'quality.pre_releases':
+                return []
+            if event == 'movie.update_release_dates':
+                return {}
+            if event == 'notify.frontend':
+                return None
+            raise AssertionError('Unexpected fireEvent call: %r' % (event,))
+
+        fake_profile = {'_id': 'profile-1', 'qualities': [], 'finish': [], 'wait_for': []}
+
+        class FakeDB:
+            def get(self, index, key, **kwargs):
+                if index == 'id' and key == 'profile-1':
+                    return dict(fake_profile)
+                raise AssertionError('Unexpected db.get call: %r %r' % (index, key))
+
+        with (
+            patch('couchpotato.core.media.movie.searcher.fireEvent', side_effect=fake_fire_event),
+            patch('couchpotato.core.media.movie.searcher.get_db', return_value=FakeDB()),
+            patch.object(MovieSearcher, 'conf', return_value=True),
+            patch.object(MovieSearcher, 'shuttingDown', return_value=False),
+        ):
+            result = searcher.single(movie, search_protocols=['torrent'], manual=True)
+
+        assert result is False, "empty profile qualities means nothing to grab, but the call must proceed"
+        event_names = [e for e, _ in events]
+        assert 'quality.pre_releases' in event_names, (
+            "manual=True must bypass the downloaded gate and reach the search body"
+        )
+        assert any(
+            e == 'notify.frontend' and kw.get('type') == 'movie.searcher.started'
+            for e, kw in events
+        ), "manual search on a downloaded movie must still start"
+
+
+# --- media.restatus(): must preserve an existing 'downloaded' status ------
+
+class TestRestatusPreservesDownloaded:
+
+    def _run_restatus(self, media_doc, releases=None):
+        plugin = MediaPlugin.__new__(MediaPlugin)
+        updated = []
+
+        class FakeDB:
+            def get(self, index, key, **kwargs):
+                if index == 'id' and key == media_doc['_id']:
+                    return dict(media_doc)
+                raise AssertionError('Unexpected db.get call: %r %r' % (index, key))
+
+            def update(self, doc):
+                updated.append(dict(doc))
+                return doc
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'release.for_media':
+                return releases or []
+            if event == 'quality.isfinish':
+                return False
+            raise AssertionError('Unexpected fireEvent call: %r' % (event,))
+
+        with (
+            patch('couchpotato.core.media._base.media.main.get_db', return_value=FakeDB()),
+            patch('couchpotato.core.media._base.media.main.fireEvent', side_effect=fake_fire_event),
+        ):
+            result = plugin.restatus(media_doc['_id'], tag_recent=False)
+
+        return result, updated
+
+    def test_downloaded_movie_stays_downloaded_with_no_releases(self):
+        """A movie already awaiting review, with no 'done' releases (the
+        upgrade-quality release check hasn't found anything better), must
+        stay 'downloaded' -- restatus must not fall through to the
+        active/done branch and demote it."""
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
+
+        result, updated = self._run_restatus(movie)
+
+        assert result == 'downloaded'
+        # Status didn't change, so restatus should not have written to the DB.
+        assert updated == []
+
+    def test_downloaded_movie_stays_downloaded_even_with_a_done_release(self):
+        """Even if the owning release happens to carry a 'done' status (e.g.
+        a stale record), a movie already in the review gate must not be
+        auto-promoted to 'done' by restatus in this phase -- Phase 2 owns
+        that transition via the per-profile toggle."""
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
+        releases = [{'status': 'done', 'quality': '1080p', 'last_edit': 0, 'is_3d': False}]
+
+        result, updated = self._run_restatus(movie, releases=releases)
+
+        assert result == 'downloaded'
+        assert updated == []
+
+    def test_downloaded_movie_without_profile_still_preserved(self):
+        """Guard applies before the 'no profile -> done' branch too."""
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': None}
+
+        result, updated = self._run_restatus(movie)
+
+        assert result == 'downloaded'
+        assert updated == []
+
+    def test_active_movie_without_profile_still_becomes_done(self):
+        """Regression guard: the new 'downloaded' branch must not change
+        existing behavior for movies that were never in the review gate."""
+        movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': None}
+
+        result, updated = self._run_restatus(movie)
+
+        assert result == 'done'
+        assert len(updated) == 1
+        assert updated[0]['status'] == 'done'
+
+    def test_active_movie_with_done_release_still_promotes_to_done(self):
+        """Regression guard: unrelated existing behavior (active -> done via
+        a finished release) is untouched by the new preservation branch."""
+        movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1'}
+        releases = [{'status': 'done', 'quality': '1080p', 'last_edit': 0, 'is_3d': False}]
+
+        plugin = MediaPlugin.__new__(MediaPlugin)
+        updated = []
+
+        class FakeDB:
+            def get(self, index, key, **kwargs):
+                if index == 'id' and key == movie['_id']:
+                    return dict(movie)
+                if index == 'id' and key == 'profile-1':
+                    return {'_id': 'profile-1', 'qualities': ['1080p']}
+                raise AssertionError('Unexpected db.get call: %r %r' % (index, key))
+
+            def update(self, doc):
+                updated.append(dict(doc))
+                return doc
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'release.for_media':
+                return releases
+            if event == 'quality.isfinish':
+                return True
+            raise AssertionError('Unexpected fireEvent call: %r' % (event,))
+
+        with (
+            patch('couchpotato.core.media._base.media.main.get_db', return_value=FakeDB()),
+            patch('couchpotato.core.media._base.media.main.fireEvent', side_effect=fake_fire_event),
+        ):
+            result = plugin.restatus(movie['_id'], tag_recent=False)
+
+        assert result == 'done'
+        assert len(updated) == 1

--- a/tests/unit/test_fastapi_web.py
+++ b/tests/unit/test_fastapi_web.py
@@ -469,6 +469,53 @@ class TestTemplateRendering:
         assert 'data-has-releases="false"' in resp.text
         assert 'data-has-releases="true"' in resp.text
 
+    def test_movie_card_labels_downloaded_status_as_review_gate(self, client):
+        """A movie in the 'downloaded' review-gate status (workflow phase 1)
+        must render a distinct 'downloaded / review' badge on the card grid,
+        not fall through to the generic done/wanted branches."""
+        def media_list_handler(**kwargs):
+            return {
+                'movies': [
+                    {'_id': 'm1', 'status': 'downloaded', 'info': {'titles': ['Awaiting Review']}, 'releases': []},
+                ]
+            }
+
+        old_handler = api.get('media.list')
+        api['media.list'] = media_list_handler
+        api_locks['media.list'] = __import__('threading').Lock()
+
+        try:
+            resp = client.get('/partial/movies?status=downloaded')
+        finally:
+            if old_handler:
+                api['media.list'] = old_handler
+            else:
+                api.pop('media.list', None)
+
+        assert resp.status_code == 200
+        assert 'downloaded / review' in resp.text
+        assert 'data-status="downloaded"' in resp.text
+
+    def test_movie_detail_labels_downloaded_status_as_review_gate(self, client):
+        """Same review-gate label on the movie detail partial."""
+        def media_get_handler(**kwargs):
+            return {'media': {'_id': 'm1', 'status': 'downloaded', 'info': {'titles': ['Awaiting Review']}, 'releases': []}}
+
+        old_handler = api.get('media.get')
+        api['media.get'] = media_get_handler
+        api_locks['media.get'] = __import__('threading').Lock()
+
+        try:
+            resp = client.get('/partial/movie/m1')
+        finally:
+            if old_handler:
+                api['media.get'] = old_handler
+            else:
+                api.pop('media.get', None)
+
+        assert resp.status_code == 200
+        assert 'downloaded / review' in resp.text
+
 
 # --- FastAPI App Creation Tests ---
 


### PR DESCRIPTION
Phase 1 of `specs/DOWNLOADED-REVIEW-WORKFLOW.md` (the manual-confirmation download workflow). **Additive, no behavior change yet** — nothing sets a movie to `downloaded` in this phase; that arrives in Phase 2.

## What
- New movie (`media`) status **`downloaded`** ("Downloaded / review") — a resting state meaning "a copy landed, awaiting the user's confirmation".
- **Searcher gating:** `single()` now early-returns for `movie['status'] in ('done','downloaded') and not manual` (a faithful superset of the prior `done` handling; `manual=True` still overrides). Batch `searchAll` already only selects `active` movies, so `downloaded` is excluded there too.
- **`media.restatus` preserves `downloaded`** — never demotes it to `active` or auto-promotes to `done` (Phase 2 owns the transitions out).
- **UI badge** in `movie_cards.html`/`movie_detail.html` — "downloaded / review", using the `cp-warning` token (same "needs attention" colour as `snatched`; design-system doc updated to match).

## Why additive/safe
Verified (and confirmed by two independent local reviews): nothing in the tree sets a movie's status to `downloaded`, so every new branch is inert in production today. Existing `active`/`done` paths are untouched, with regression tests locking them.

## Tests
`tests/unit/test_downloaded_review_status_phase1.py` (batch excludes `downloaded`; `single()` skips it unless `manual`; `restatus` preserves it; `active`→`done` regression guards) + `test_fastapi_web.py` badge-render tests. 1063 unit tests pass; ruff + conformance clean.

Spec included: `specs/DOWNLOADED-REVIEW-WORKFLOW.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)