### PR TITLE
docs: make the local-review-first gate unmissable (CLAUDE.md + AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,7 @@ docker build -t couchpotato:test .
 ```
 
 For release or dependency changes, also run the repository's release-quality checks and audit commands where available. For browser-facing workflow changes, add or update Playwright coverage where practical and verify the affected flow on a mobile-sized viewport.
+
+## Local Review Gate (before pushing)
+
+Passing the checks above is necessary but **not sufficient**. A change is not pushed until a **clean-agent local review is clean**: spawn ≥2 independent `general-purpose` review agents against the branch diff (vs `master`), applying the Review Guidelines above, and **iterate locally — fix every real finding, re-verify, re-review — until the review comes back clean. Only then push.** Running the review agents *is* the gate; self-verifying the diff yourself is not a substitute. This holds for every push: the initial PR, **each fix commit** made in response to a cloud `claude-review` finding (fix → local review again until clean → push), and policy-doc (`CLAUDE.md`/`AGENTS.md`) or `specs/**` changes. See CLAUDE.md → *Path to Production* for the full flow and rationale (the cloud reviewer is stateless per push, so pushing before the local review is clean just dribbles the findings out one round at a time).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,27 @@ make setup → code → make verify → LOCAL agent review (must pass) → push/
   cloud claude-review → (findings? fix → LOCAL review again → push) → merge → release → deploy
 ```
 
+> **The rule, stated plainly — never skip it: any push that needs the gate does
+> not happen until its clean-agent local review is clean.** ("Needs the gate" =
+> any code change, or a change touching `CLAUDE.md`/`AGENTS.md` or a `specs/**`
+> file; **pure docs-only prose may skip** — see the carve-out in the bullet just
+> below.) For a gated push the loop is: run the local review → fix every real
+> finding → re-verify → **re-run the local review** → repeat **until it comes
+> back clean**, and only *then* `git push`. Running the review agents *is* the
+> gate — self-verifying the diff yourself does **not** substitute for it. This
+> governs **every** gated push, not just the first:
+> - the **initial** PR push;
+> - **every fix commit** pushed in response to a cloud `claude-review` finding —
+>   fix → local review again until clean → push; never fix-and-push without
+>   re-reviewing. (But apply the **Exit condition** below for a genuine false
+>   alarm / marginal nit: reject it with evidence and stop — don't chase forever.)
+> - any push touching `CLAUDE.md`/`AGENTS.md` or a `specs/**` file.
+>
+> Pushing before the local review is clean defeats the point: the cloud reviewer
+> is stateless per push, so it dribbles out — one push at a time — the findings a
+> single local pass would have surfaced together (Rationale in the gate bullet
+> below).
+
 - **Local agent review gate (MANDATORY for code changes, before every push to the
   cloud review; docs-only changes may skip it and push directly):**
   *"Docs-only"* means the diff touches **only** documentation prose — `*.md`


### PR DESCRIPTION
## What

State the local-review gate plainly and unmissably, in response to the observation that although the rule was already documented, it was buried in a dense paragraph and wasn't reliably followed (fix commits and policy-doc changes were sometimes pushed without a fresh local review).

- **CLAUDE.md** (*Path to Production*): add a boxed rule right after the flow diagram — *a PR is not pushed until its clean-agent local review is clean; iterate locally (fix → re-verify → re-review) until clean, then push* — scoped precisely ("needs the gate" = code / CLAUDE.md·AGENTS.md / `specs/**`; pure docs-only prose may skip), cross-referencing the existing docs-only carve-out and Exit condition so it sharpens rather than contradicts them.
- **AGENTS.md**: add a *Local Review Gate* section noting the ruff/pytest/e2e checks are necessary but **not sufficient**, and deferring to CLAUDE.md for the full flow.

## Why

Running the review agents *is* the gate; self-verifying the diff is not a substitute. The cloud `claude-review` is stateless per push, so pushing before the local review is clean dribbles findings out one round at a time — the local loop front-loads that discovery.

## Gate

Docs-only content (policy docs, so the gate applies). Taken through the local-review gate it documents: two independent `general-purpose` review agents on the branch diff; one flagged a real contradiction (the opening sentence read as absolute, abutting the docs-only carve-out) — fixed, re-reviewed, both confirmed clean before this push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)