### PR TITLE
feat(workflow): Phase 2 — per-profile manual_confirmation completion routing (Downloaded/review gate)

### DIFF
--- a/couchpotato/core/media/_base/media/main.py
+++ b/couchpotato/core/media/_base/media/main.py
@@ -547,6 +547,21 @@ class MediaPlugin(MediaBase):
 
                             db.delete(media)
                             deleted = True
+                        elif media.get('status') == 'downloaded' and delete_from in ['wanted', 'snatched', 'late']:
+                            # A 'downloaded' movie (workflow phase 2 review gate) must
+                            # survive a wanted/snatched/late delete entirely untouched.
+                            # The generic path below would force it to 'done' and null
+                            # its profile_id (via `new_media_status = 'done'`), or -- for
+                            # delete_from='late' -- delete the movie outright via the
+                            # post-loop `not new_media_status and delete_from == 'late'`
+                            # clause. This is reachable (not theoretical): wanted.html
+                            # bulkDelete() hardcodes delete_from='wanted' with no status
+                            # check (a stale selection can complete to 'downloaded' in the
+                            # background between select and click), and the public
+                            # movie.delete API accepts any delete_from for any id. Treat it
+                            # as a no-op and just recompute status, leaving the review gate,
+                            # its releases, and its profile_id intact.
+                            fireEvent('media.restatus', media.get('_id'), single = True)
                         else:
 
                             total_releases = len(media_releases)

--- a/couchpotato/core/media/_base/media/main.py
+++ b/couchpotato/core/media/_base/media/main.py
@@ -754,7 +754,19 @@ class MediaPlugin(MediaBase):
                             # Check if we are finished with the media
                             for release in done_releases:
                                 if fireEvent('quality.isfinish', {'identifier': release['quality'], 'is_3d': release.get('is_3d', False)}, profile, timedelta(seconds = time.time() - release['last_edit']).days, single = True):
-                                    m['status'] = 'done'
+                                    # Workflow phase 2: a profile with manual_confirmation
+                                    # ON routes a *genuinely new* completion (previous_status
+                                    # wasn't already 'done') to the 'downloaded' review gate
+                                    # instead of 'done'. A movie that's already 'done' (e.g. a
+                                    # later upgrade re-check, or one confirmed via the future
+                                    # "Mark Done" action) stays 'done' -- this never demotes it
+                                    # back to 'downloaded'. A movie already in 'downloaded'
+                                    # never reaches this branch at all: it's handled by the
+                                    # top-level preservation check above.
+                                    if profile.get('manual_confirmation') and previous_status != 'done':
+                                        m['status'] = 'downloaded'
+                                    else:
+                                        m['status'] = 'done'
                                     break
 
                         elif previous_status == 'done':

--- a/couchpotato/core/media/_base/media/main.py
+++ b/couchpotato/core/media/_base/media/main.py
@@ -547,20 +547,25 @@ class MediaPlugin(MediaBase):
 
                             db.delete(media)
                             deleted = True
-                        elif media.get('status') == 'downloaded' and delete_from in ['wanted', 'snatched', 'late']:
+                        elif media.get('status') == 'downloaded' and delete_from in ['wanted', 'snatched', 'late', 'manage']:
                             # A 'downloaded' movie (workflow phase 2 review gate) must
-                            # survive a wanted/snatched/late delete entirely untouched.
-                            # The generic path below would force it to 'done' and null
-                            # its profile_id (via `new_media_status = 'done'`), or -- for
-                            # delete_from='late' -- delete the movie outright via the
-                            # post-loop `not new_media_status and delete_from == 'late'`
-                            # clause. This is reachable (not theoretical): wanted.html
-                            # bulkDelete() hardcodes delete_from='wanted' with no status
-                            # check (a stale selection can complete to 'downloaded' in the
-                            # background between select and click), and the public
+                            # survive a wanted/snatched/late/manage delete entirely
+                            # untouched. The generic path below would force it to 'done'
+                            # and null its profile_id (via `new_media_status = 'done'`),
+                            # or -- for delete_from='late' -- delete the movie outright via
+                            # the post-loop `not new_media_status and delete_from == 'late'`
+                            # clause, or -- for a zero-release delete_from='manage' -- delete
+                            # it via the post-loop `total_releases == 0 and not
+                            # new_media_status` clause. This is reachable (not theoretical):
+                            # wanted.html bulkDelete() hardcodes delete_from='wanted' with no
+                            # status check (a stale selection can complete to 'downloaded' in
+                            # the background between select and click), and the public
                             # movie.delete API accepts any delete_from for any id. Treat it
                             # as a no-op and just recompute status, leaving the review gate,
-                            # its releases, and its profile_id intact.
+                            # its releases, and its profile_id intact. (The manage-branch
+                            # guard inside the loop below is now redundant for a 'downloaded'
+                            # movie, since this top-level branch catches 'manage' first; it's
+                            # kept as harmless defense-in-depth.)
                             fireEvent('media.restatus', media.get('_id'), single = True)
                         else:
 

--- a/couchpotato/core/media/_base/media/main.py
+++ b/couchpotato/core/media/_base/media/main.py
@@ -560,7 +560,12 @@ class MediaPlugin(MediaBase):
                                         total_deleted += 1
                                     new_media_status = 'done'
                                 elif delete_from == 'manage':
-                                    if release.get('status') == 'done' or media.get('status') == 'done':
+                                    # A 'downloaded' movie (workflow phase 2 review gate) has
+                                    # a 'done' release by design while it awaits manual review.
+                                    # Guard it out so the manage-tab bulk delete doesn't sweep
+                                    # its release out from under an in-progress review; a
+                                    # genuinely 'done' movie is unaffected by this check.
+                                    if media.get('status') != 'downloaded' and (release.get('status') == 'done' or media.get('status') == 'done'):
                                         db.delete(release)
                                         total_deleted += 1
 

--- a/couchpotato/core/media/movie/searcher.py
+++ b/couchpotato/core/media/movie/searcher.py
@@ -137,8 +137,11 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
             return
 
         # Update media status and check if it is still not done (due to the stop searching after feature
-        if fireEvent('media.restatus', movie['_id'], single = True) == 'done':
+        restatus_result = fireEvent('media.restatus', movie['_id'], single = True)
+        if restatus_result == 'done':
             log.debug('No better quality found, marking movie %s as done.', default_title)
+        elif restatus_result == 'downloaded':
+            log.debug('Movie %s is awaiting manual review, holding at "downloaded".', default_title)
 
         pre_releases = fireEvent('quality.pre_releases', single = True)
         release_dates = fireEvent('movie.update_release_dates', movie['_id'], merge = True)

--- a/couchpotato/core/plugins/manage.py
+++ b/couchpotato/core/plugins/manage.py
@@ -140,6 +140,15 @@ class Manage(Plugin):
 
                 deleted_releases = []
                 for done_movie in done_movies:
+                    # A 'downloaded' movie (workflow phase 2 review gate) can land
+                    # here via the status_or union above: its *release* is 'done'
+                    # even though the *movie* is still awaiting manual review.
+                    # Exempt it from the cleanup scan entirely -- it's mid-review,
+                    # not offline/missing, and must never be silently purged by a
+                    # normal full library scan.
+                    if done_movie.get('status') == 'downloaded':
+                        continue
+
                     if getIdentifier(done_movie) not in added_identifiers:
                         fireEvent('media.delete', media_id = done_movie['_id'], delete_from = 'all')
                     else:

--- a/couchpotato/core/plugins/profile/main.py
+++ b/couchpotato/core/plugins/profile/main.py
@@ -48,9 +48,14 @@ class ProfilePlugin(Plugin):
 
             self.fill()
 
-        # Get all active movies without profile
+        # Get all active (or review-gated) movies without a valid profile.
+        # 'downloaded' (workflow phase 2) movies still carry a profile_id that
+        # restatus() and the future "mark failed & re-search" action depend
+        # on, so a dangling reference needs the same repair-to-default an
+        # 'active' movie gets -- otherwise a review-gated movie whose profile
+        # was deleted would be stuck with an unusable profile_id forever.
         try:
-            medias = fireEvent('media.with_status', 'active', single = True)
+            medias = fireEvent('media.with_status', ['active', 'downloaded'], single = True)
 
             profile_ids = [x.get('_id') for x in self.all()]
             default_id = profile_ids[0]
@@ -99,6 +104,13 @@ class ProfilePlugin(Plugin):
                 'order': tryInt(kwargs.get('order', 999)),
                 'core': kwargs.get('core', False),
                 'minimum_score': tryInt(kwargs.get('minimum_score', 1)),
+                # Workflow phase 2 (specs/DOWNLOADED-REVIEW-WORKFLOW.md): when
+                # truthy, a completing download for a movie on this profile is
+                # routed to the 'downloaded' review gate instead of 'done'
+                # (see MediaPlugin.restatus). Defaults False so existing/legacy
+                # profiles (and every caller that doesn't mention the field)
+                # keep today's auto-upgrade-to-done behavior unchanged.
+                'manual_confirmation': tryInt(kwargs.get('manual_confirmation', 0)) == 1,
                 'qualities': [],
                 'wait_for': [],
                 'stop_after': [],

--- a/couchpotato/core/plugins/profile/main.py
+++ b/couchpotato/core/plugins/profile/main.py
@@ -132,6 +132,12 @@ class ProfilePlugin(Plugin):
             try:
                 p = db.get('id', id)
                 profile['order'] = tryInt(kwargs.get('order', p.get('order', 999)))
+                # Fall back to the persisted value when the key is omitted, same
+                # idiom as 'order' above. Without this, editing an existing
+                # profile without resending manual_confirmation (as the live
+                # profile editor always does today) silently resets it to False
+                # on every save -- a blocking bug (workflow phase 2 review).
+                profile['manual_confirmation'] = tryInt(kwargs.get('manual_confirmation', 1 if p.get('manual_confirmation') else 0)) == 1
             except Exception:
                 p = db.insert(profile)
 

--- a/couchpotato/core/plugins/release/main.py
+++ b/couchpotato/core/plugins/release/main.py
@@ -115,7 +115,11 @@ class Release(Plugin):
         del media_exist
 
         # get movies last_edit more than a week ago
-        medias = fireEvent('media.with_status', ['done', 'active'], single = True)
+        # 'downloaded' (workflow phase 2 review gate) is included so a
+        # review-gated movie's stale/duplicate releases still get cleaned up
+        # like a 'done' movie's would -- it's not being searched, but it's
+        # not exempt from this stale-release hygiene pass either.
+        medias = fireEvent('media.with_status', ['done', 'active', 'downloaded'], single = True)
 
         for media in medias:
             if media.get('last_edit', 0) > (now - week):

--- a/specs/DOWNLOADED-REVIEW-WORKFLOW.md
+++ b/specs/DOWNLOADED-REVIEW-WORKFLOW.md
@@ -104,6 +104,18 @@ Add to the profile model/editor a boolean, e.g.
 (default **off** = current auto-upgrade behavior). Surfaced in the profile
 editor UI. `media.restatus` / searcher read it via the movie's `profile_id`.
 
+**Phase 2 status:** the field exists, persists (`ProfilePlugin.save()`,
+`couchpotato/core/plugins/profile/main.py`), defaults `False` for profiles
+that don't set it, and is read by `restatus()` for completion routing.
+**UI exposure deferred:** the new-UI profile editor
+(`couchpotato/ui/templates/partials/settings/profiles.html` +
+`couchpotato/static/scripts/ui/profile-editor.js`) is a large, 100%-mutation-
+tested surface (`TEST-001`) with its own a11y-parity follow-up already
+tracked; adding a checkbox there (plus the matching Alpine state, save-payload
+wiring, unit/mutation tests, and any conformance/E2E touch-up) is left for a
+Phase 3 follow-up rather than folded into this phase. Until then the toggle
+is settable only via the `profile.save` API directly.
+
 ### Notification
 
 On entering `downloaded`, fire `notify.frontend` (and the configured
@@ -131,21 +143,66 @@ feature's completion-path change rather than a separate reconstruction.
 
 ## Phased plan (each its own reviewed PR)
 
-1. **Status + gating (no behavior change yet):** register the `downloaded` movie
-   status + label/filter; make the searcher gate on it (skip like `done`).
-   Tests: searcher does not select/act on a `downloaded` movie.
-2. **Per-profile toggle + completion routing:** add `manual_confirmation` to the
-   profile; teach `media.restatus`/completion to route release+movie to
-   `downloaded` vs `done` by the toggle. Tests: auto profile → `done` (unchanged);
-   manual profile → `downloaded` + no further search.
-   **Forward-looking (found in Phase 1 review — must handle here):** two call
-   sites key off a fixed movie-status list and would silently *exclude* a
-   `downloaded` movie once this phase starts producing them —
-   `couchpotato/core/plugins/release/main.py:117`
-   (`media.with_status(['done','active'])`, the weekly stale-release cleanup) and
-   `couchpotato/core/plugins/profile/main.py:53` (`media.with_status('active')`).
-   Audit these (and any other hardcoded status lists) and include `downloaded`
-   where a review-gated movie should still be considered.
+1. ✅ **DONE (#168).** **Status + gating (no behavior change yet):** register
+   the `downloaded` movie status + label/filter; make the searcher gate on it
+   (skip like `done`). Tests: searcher does not select/act on a `downloaded`
+   movie.
+2. ✅ **DONE.** **Per-profile toggle + completion routing:** add
+   `manual_confirmation` to the profile; teach `media.restatus`/completion to
+   route release+movie to `downloaded` vs `done` by the toggle. Tests: auto
+   profile → `done` (unchanged); manual profile → `downloaded` + no further
+   search.
+
+   **Completion-path decision point (traced for this phase):** a completed
+   release drives `couchpotato/core/plugins/release/main.py`'s `download()`
+   (renamer-disabled path, ~line 361-372) or `renamer/scanner.py`'s
+   `checkSnatched()` to set the *release* to `done`/`downloaded`/etc., which
+   then calls `fireEvent('media.restatus', ...)`. `MediaPlugin.restatus()`
+   (`couchpotato/core/media/_base/media/main.py`) is the single funnel that
+   decides the *movie* status: the one insertion point is the branch where a
+   `done` release satisfies `quality.isfinish` and the movie was about to be
+   set to `done` (~line 757). That branch now checks
+   `profile.get('manual_confirmation')` and, only for a genuinely new
+   completion (`previous_status != 'done'`), sets the movie to `downloaded`
+   instead. The Phase-1 top-level preservation check
+   (`previous_status == 'downloaded'` stays `downloaded`) runs first and is
+   untouched, so an already-gated movie never reaches the new branch and is
+   never auto-advanced to `done`. Release-level status is unchanged by this
+   phase (the release itself still ends up `done`); only the movie's status
+   field is routed differently. Scope note: this phase only touches
+   `restatus()`'s existing decision point, not the full per-release
+   `downloaded` routing sketched in the Design section above — that nuance
+   (if still wanted) is Phase 3/4 territory.
+
+   **Status-list sites fixed (found in Phase 1 review):**
+   - `couchpotato/core/plugins/release/main.py:118` (weekly stale-release
+     cleanup): `media.with_status(['done','active'])` →
+     `media.with_status(['done','active','downloaded'])` — a review-gated
+     movie's stale/duplicate releases still get cleaned up like a `done`
+     movie's would.
+   - `couchpotato/core/plugins/profile/main.py:53` (`forceDefaults()` orphan
+     profile-reference repair): `media.with_status('active')` →
+     `media.with_status(['active','downloaded'])` — a `downloaded` movie still
+     depends on a working `profile_id` (read by every `restatus()` call, and
+     by the future "mark failed & re-search" action), so a dangling reference
+     needs the same repair-to-default an `active` movie gets.
+   - Audited and **left unchanged** (each is a deliberate exclusion, not an
+     oversight): `couchpotato/core/plugins/dashboard.py:48`
+     (`media.with_status('active', ...)` for the "Coming Soon" widget — a
+     `downloaded` movie isn't coming soon, it already landed); the searcher's
+     own `media.with_status('active', ...)` batch-search selects
+     (`movie/searcher.py:80`, `profile/main.py`'s `dashboard`-adjacent uses —
+     these are exactly the Phase-1 gating points and must keep excluding
+     `downloaded`); `couchpotato/core/plugins/manage.py:139`
+     (`status='done', release_status='done'` cleanup-scan deletion of
+     library movies whose files vanished from disk) — deliberately **not**
+     extended to `downloaded`, since that path does a full `delete_from='all'`
+     removal and a movie mid-review shouldn't be silently purged just because
+     on-disk state doesn't match; `release/main.py:196`
+     (`allowed_restatus=['done']` in the library-scan `release.add()` path) —
+     unreachable for `downloaded` since that path always adds movies with
+     `profile_id=None`, which `restatus()` routes to `done` regardless of any
+     profile toggle.
 3. **UI actions:** Mark Done / Mark Failed&re-search (movie); Skip/Ignore &
    Mark-failed (release); immediate re-search on Fail. Tests + E2E.
 4. **Notification + renamer enrichment hook:** fire notify + `renamer.after`

--- a/specs/DOWNLOADED-REVIEW-WORKFLOW.md
+++ b/specs/DOWNLOADED-REVIEW-WORKFLOW.md
@@ -268,13 +268,17 @@ feature's completion-path change rather than a separate reconstruction.
    copy. Belongs with the UI actions since the real fix is UI-level (the Add
    surface should reflect "already in library / under review" state). Tests
    mirroring `TestWantedDeleteExemptsDownloadedMovies`.
-   **Minor (defense-in-depth, note for this phase):** a `downloaded` movie with
-   **zero** releases + `delete_from='manage'` would still fall to the full
-   `db.delete(media)` (the Phase-2 top-level `wanted/snatched/late` guard covers
-   it regardless of release count, but the `manage` path relies on the
-   "≥1 release" invariant). No reachable live caller sends `delete_from='manage'`
-   post-#148, and the invariant holds in practice; widen the top-level guard to
-   include `manage` for symmetry when convenient.
+   **Minor (defense-in-depth) — fixed in Phase 2:** a `downloaded` movie with
+   **zero** releases + `delete_from='manage'` used to fall to the full
+   `db.delete(media)` via the generic loop's post-loop `total_releases == 0 and
+   not new_media_status` clause (the top-level guard originally covered only
+   `wanted/snatched/late`). The cloud review flagged it; the top-level guard now
+   includes `manage` (`delete_from in ['wanted','snatched','late','manage']`), so
+   a `downloaded` movie is a no-op restatus regardless of release count and the
+   zero-release case is covered. The in-loop manage guard is now redundant for a
+   `downloaded` movie (the top-level branch catches `manage` first) but is kept
+   as harmless defense-in-depth. Locked by
+   `TestManageDeleteExemptsDownloadedMovies.test_downloaded_movie_with_zero_releases_survives_manage_delete`.
 4. **Notification + renamer enrichment hook:** fire notify + `renamer.after`
    enrichment on entering `downloaded`; wire the dead listeners
    (per `specs/RENAMER-EVENT-CHAIN.md`). Tests: listeners fire once, only on

--- a/specs/DOWNLOADED-REVIEW-WORKFLOW.md
+++ b/specs/DOWNLOADED-REVIEW-WORKFLOW.md
@@ -193,16 +193,35 @@ feature's completion-path change rather than a separate reconstruction.
      own `media.with_status('active', ...)` batch-search selects
      (`movie/searcher.py:80`, `profile/main.py`'s `dashboard`-adjacent uses —
      these are exactly the Phase-1 gating points and must keep excluding
-     `downloaded`); `couchpotato/core/plugins/manage.py:139`
-     (`status='done', release_status='done'` cleanup-scan deletion of
-     library movies whose files vanished from disk) — deliberately **not**
-     extended to `downloaded`, since that path does a full `delete_from='all'`
-     removal and a movie mid-review shouldn't be silently purged just because
-     on-disk state doesn't match; `release/main.py:196`
-     (`allowed_restatus=['done']` in the library-scan `release.add()` path) —
-     unreachable for `downloaded` since that path always adds movies with
-     `profile_id=None`, which `restatus()` routes to `done` regardless of any
-     profile toggle.
+     `downloaded`); `release/main.py:196` (`allowed_restatus=['done']` in the
+     library-scan `release.add()` path) — mostly moot for `downloaded` since
+     that path adds a *brand-new* movie with `profile_id=None` (routed to
+     `done` regardless of any profile toggle), but it is reachable for a
+     **pre-existing** movie already carrying a `manual_confirmation` profile
+     (a rescan hits the "release already tracked" branch and keeps the
+     existing `profile_id`); in that case the `allowed_restatus=['done']`
+     filter simply skips persisting the `db.update(m)` write when `restatus()`
+     computes `'downloaded'` — harmless (the in-memory return value isn't used
+     by this caller) and not a regression introduced by this phase, so left
+     as-is.
+   - **Blocking finding from the phase-2 local review, now fixed (not left
+     safe as originally audited):** `couchpotato/core/plugins/manage.py:139`
+     (`fireEvent('media.list', status='done', release_status='done',
+     status_or=True, ...)`) is an **OR union** (`status_or=True` in
+     `MediaPlugin.list()`), so a `downloaded` movie whose release is `done`
+     (the normal state for a movie awaiting review) was landing in
+     `done_movies` and could be silently `fireEvent('media.delete', ...,
+     delete_from='all')`-ed by a routine full library scan (`cleanup` config
+     defaults on). The same OR-exposure existed in
+     `MediaPlugin.delete(delete_from='manage')`
+     (`couchpotato/core/media/_base/media/main.py`), which deletes a release
+     when `release.status == 'done' OR media.status == 'done'` — a
+     `downloaded` movie's `done` release qualified via the first arm. Both are
+     now guarded: the manage cleanup loop `continue`s past any `done_movie`
+     whose `status == 'downloaded'` before the deletion/dedup logic runs, and
+     the manage-delete release loop adds `media.get('status') != 'downloaded'`
+     to its condition so a review-gated movie's release is never swept up by
+     that path. Neither guard changes behavior for a genuinely `done` movie.
 3. **UI actions:** Mark Done / Mark Failed&re-search (movie); Skip/Ignore &
    Mark-failed (release); immediate re-search on Fail. Tests + E2E.
 4. **Notification + renamer enrichment hook:** fire notify + `renamer.after`

--- a/specs/DOWNLOADED-REVIEW-WORKFLOW.md
+++ b/specs/DOWNLOADED-REVIEW-WORKFLOW.md
@@ -222,8 +222,59 @@ feature's completion-path change rather than a separate reconstruction.
      the manage-delete release loop adds `media.get('status') != 'downloaded'`
      to its condition so a review-gated movie's release is never swept up by
      that path. Neither guard changes behavior for a genuinely `done` movie.
+   - **Second blocking gap in `MediaPlugin.delete`, found in the phase-2
+     re-review, now fixed:** the sibling branch `if delete_from in
+     ['wanted','snatched','late']` was also unguarded. For a `downloaded`
+     movie with a `done` release (the feature's steady state) the release
+     survives (`status == 'done'`), but that iteration unconditionally set
+     `new_media_status = 'done'`; after the loop `total_releases(1) !=
+     total_deleted(0)` fell to `elif new_media_status:`, which overwrote
+     `media['status']` to `done` **and** nulled `profile_id` — silently
+     bypassing the review gate. For `delete_from='late'` it was worse: the
+     post-loop `(not new_media_status and delete_from == 'late')` clause would
+     delete the movie doc outright. Reachable (not theoretical):
+     `couchpotato/ui/templates/wanted.html` `bulkDelete()` hardcodes
+     `delete_from='wanted'` with no status check (stale-selection race — a
+     movie can complete to `downloaded` in the background between select and
+     click), and the documented public API `movie.delete?delete_from=wanted`
+     reaches it directly. Fixed by adding a top-level branch **before** the
+     generic release loop: `elif media.get('status') == 'downloaded' and
+     delete_from in ['wanted','snatched','late']:` → treat as a no-op that
+     only calls `media.restatus`, leaving the movie in `downloaded` with its
+     releases and `profile_id` intact. A guard inside the loop (a `continue`)
+     would have been insufficient for `late`, since `new_media_status` staying
+     falsy makes the post-loop `late` clause fire — the top-level branch
+     sidesteps that entirely. A genuinely non-`downloaded` movie's
+     wanted/snatched/late behavior is unchanged.
 3. **UI actions:** Mark Done / Mark Failed&re-search (movie); Skip/Ignore &
    Mark-failed (release); immediate re-search on Fail. Tests + E2E.
+   **Also fold in here — the re-add guard (deferred from Phase 2, found in the
+   round-3 completeness sweep):** `MovieBase.add()` defaults `force_readd=True`,
+   and the live "Add" buttons (`ui/templates/partials/search_results.html`,
+   `movie_info_modal.html`) call `movie.add` with no `force_readd`, so re-adding
+   an already-present movie hits the `elif force_readd:` branch — it deletes the
+   movie's completed release (`['downloaded','snatched','seeding','done']`),
+   nulls `profile_id`/`category_id`/`tags`, resets `status` to `active`, and
+   re-searches. For a `downloaded` (review-gated) movie a single stray "Add"
+   click thus destroys the confirmed copy and the gate. **Important scope note:**
+   this is *not* a Phase-2 regression — the exact same destruction already
+   happens to a `done` movie today (all existing `done` movies share it), because
+   Phase 2 never touched `add()`; it is a pre-existing, app-wide property of the
+   `force_readd` default + an ungated Add button. The correct fix is therefore
+   app-wide, not `downloaded`-only (guarding only `downloaded` would create a
+   confusing asymmetry with `done`): treat re-adding an already-*completed*
+   movie (`done` **or** `downloaded`) as a no-op or require explicit
+   confirmation, so a naked "Add" can't silently wipe a completed/under-review
+   copy. Belongs with the UI actions since the real fix is UI-level (the Add
+   surface should reflect "already in library / under review" state). Tests
+   mirroring `TestWantedDeleteExemptsDownloadedMovies`.
+   **Minor (defense-in-depth, note for this phase):** a `downloaded` movie with
+   **zero** releases + `delete_from='manage'` would still fall to the full
+   `db.delete(media)` (the Phase-2 top-level `wanted/snatched/late` guard covers
+   it regardless of release count, but the `manage` path relies on the
+   "≥1 release" invariant). No reachable live caller sends `delete_from='manage'`
+   post-#148, and the invariant holds in practice; widen the top-level guard to
+   include `manage` for symmetry when convenient.
 4. **Notification + renamer enrichment hook:** fire notify + `renamer.after`
    enrichment on entering `downloaded`; wire the dead listeners
    (per `specs/RENAMER-EVENT-CHAIN.md`). Tests: listeners fire once, only on

--- a/tests/unit/test_downloaded_review_workflow_phase2.py
+++ b/tests/unit/test_downloaded_review_workflow_phase2.py
@@ -1,0 +1,264 @@
+"""Tests for workflow Phase 2 (specs/DOWNLOADED-REVIEW-WORKFLOW.md): a
+per-profile `manual_confirmation` toggle that routes a completing download to
+the movie-level 'downloaded' review gate (added in Phase 1) instead of 'done'.
+
+Decision point: `MediaPlugin.restatus()`
+(couchpotato/core/media/_base/media/main.py), specifically the branch that
+already promotes a movie from 'active' to 'done' once one of its releases
+satisfies `quality.isfinish` for the owning profile. When the owning
+profile's `manual_confirmation` is truthy AND this is a genuinely new
+completion (the movie wasn't already 'done'), that branch now sets
+'downloaded' instead of 'done'. The Phase-1 top-level preservation check
+(previous_status == 'downloaded' -> stays 'downloaded') is untouched and
+still runs *before* this branch, so an already-'downloaded' movie never
+reaches this logic at all.
+"""
+from unittest.mock import patch
+
+from couchpotato.core.media._base.media.main import MediaPlugin
+from couchpotato.core.plugins.profile.main import ProfilePlugin
+from couchpotato.core.plugins.release.main import Release
+
+
+# --- media.restatus(): completion routing driven by profile.manual_confirmation
+
+class TestRestatusManualConfirmationRouting:
+
+    def _run_restatus(self, media_doc, profile_doc, releases):
+        plugin = MediaPlugin.__new__(MediaPlugin)
+        updated = []
+
+        class FakeDB:
+            def get(self, index, key, **kwargs):
+                if index == 'id' and key == media_doc['_id']:
+                    return dict(media_doc)
+                if index == 'id' and key == profile_doc['_id']:
+                    return dict(profile_doc)
+                raise AssertionError('Unexpected db.get call: %r %r' % (index, key))
+
+            def update(self, doc):
+                updated.append(dict(doc))
+                return doc
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'release.for_media':
+                return releases
+            if event == 'quality.isfinish':
+                return True
+            raise AssertionError('Unexpected fireEvent call: %r' % (event,))
+
+        with (
+            patch('couchpotato.core.media._base.media.main.get_db', return_value=FakeDB()),
+            patch('couchpotato.core.media._base.media.main.fireEvent', side_effect=fake_fire_event),
+        ):
+            result = plugin.restatus(media_doc['_id'], tag_recent=False)
+
+        return result, updated
+
+    def test_auto_profile_missing_flag_completes_to_done_unchanged(self):
+        """Regression lock: a profile that doesn't carry 'manual_confirmation'
+        at all (the pre-Phase-2 shape, or a freshly created one that never
+        touched the toggle) must behave exactly as today: a finishing
+        release drives the movie straight to 'done'."""
+        movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1'}
+        profile = {'_id': 'profile-1', 'qualities': ['1080p']}
+        releases = [{'status': 'done', 'quality': '1080p', 'last_edit': 0, 'is_3d': False}]
+
+        result, updated = self._run_restatus(movie, profile, releases)
+
+        assert result == 'done'
+        assert len(updated) == 1
+        assert updated[0]['status'] == 'done'
+
+    def test_auto_profile_explicit_false_completes_to_done_unchanged(self):
+        """Same regression lock, but with the flag explicitly persisted as
+        False (the normal post-Phase-2 shape for an auto profile)."""
+        movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1'}
+        profile = {'_id': 'profile-1', 'qualities': ['1080p'], 'manual_confirmation': False}
+        releases = [{'status': 'done', 'quality': '1080p', 'last_edit': 0, 'is_3d': False}]
+
+        result, updated = self._run_restatus(movie, profile, releases)
+
+        assert result == 'done'
+        assert len(updated) == 1
+        assert updated[0]['status'] == 'done'
+
+    def test_manual_profile_routes_completion_to_downloaded_not_done(self):
+        """A profile with manual_confirmation ON routes the SAME completion
+        (same release, same quality.isfinish outcome) to 'downloaded'
+        instead of 'done'."""
+        movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1'}
+        profile = {'_id': 'profile-1', 'qualities': ['1080p'], 'manual_confirmation': True}
+        releases = [{'status': 'done', 'quality': '1080p', 'last_edit': 0, 'is_3d': False}]
+
+        result, updated = self._run_restatus(movie, profile, releases)
+
+        assert result == 'downloaded'
+        assert len(updated) == 1
+        assert updated[0]['status'] == 'downloaded'
+
+    def test_manual_profile_does_not_demote_an_already_done_movie(self):
+        """A movie that is already 'done' (e.g. confirmed earlier, or from
+        before the profile ever had manual_confirmation set) must not be
+        pulled back down to 'downloaded' by a later restatus recompute, even
+        though its profile now has manual_confirmation ON. Only a genuinely
+        new completion (previous_status != 'done') gets gated."""
+        movie = {'_id': 'movie-1', 'status': 'done', 'profile_id': 'profile-1'}
+        profile = {'_id': 'profile-1', 'qualities': ['1080p'], 'manual_confirmation': True}
+        releases = [{'status': 'done', 'quality': '1080p', 'last_edit': 0, 'is_3d': False}]
+
+        result, updated = self._run_restatus(movie, profile, releases)
+
+        assert result == 'done'
+        # Status didn't change ('done' -> 'done'), so no DB write.
+        assert updated == []
+
+    def test_downloaded_movie_stays_downloaded_regardless_of_manual_confirmation(self):
+        """Defensive test: the Phase-1 top-level preservation branch
+        (previous_status == 'downloaded' -> stays 'downloaded') must still
+        run *before* the manual_confirmation branch and win outright --
+        confirming the routing decision was correctly placed only inside the
+        active-with-a-finishing-release branch, not somewhere that could
+        re-evaluate an already-gated movie."""
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
+        profile = {'_id': 'profile-1', 'qualities': ['1080p'], 'manual_confirmation': True}
+        releases = [{'status': 'done', 'quality': '1080p', 'last_edit': 0, 'is_3d': False}]
+
+        result, updated = self._run_restatus(movie, profile, releases)
+
+        assert result == 'downloaded'
+        assert updated == []
+
+
+# --- profile field persistence -----------------------------------------
+
+class TestProfileManualConfirmationPersistence:
+
+    def _run_save(self, kwargs, existing_profile=None):
+        plugin = ProfilePlugin.__new__(ProfilePlugin)
+        updated = []
+
+        class FakeDB:
+            def get(self, index, key, **kw):
+                if existing_profile and index == 'id' and key == existing_profile['_id']:
+                    return dict(existing_profile)
+                raise Exception('not found')
+
+            def insert(self, data):
+                data = dict(data)
+                data['_id'] = 'new-profile'
+                return data
+
+            def update(self, doc):
+                updated.append(dict(doc))
+                return doc
+
+        with patch('couchpotato.core.plugins.profile.main.get_db', return_value=FakeDB()):
+            result = plugin.save(**kwargs)
+
+        return result, updated
+
+    def test_save_persists_manual_confirmation_true(self):
+        result, updated = self._run_save({
+            'id': 'profile-1',
+            'label': 'Manual Review',
+            'types': [{'quality': '1080p', 'finish': 1, '3d': 0}],
+            'manual_confirmation': 1,
+        }, existing_profile={'_id': 'profile-1', 'label': 'Manual Review'})
+
+        assert result['success'] is True
+        assert len(updated) == 1
+        assert updated[0]['manual_confirmation'] is True
+
+    def test_save_defaults_manual_confirmation_false_when_omitted(self):
+        """A save() call that never mentions manual_confirmation (e.g. every
+        pre-Phase-2 caller, or a brand new profile created before the UI
+        exposes the toggle) must persist it as False, not leave it unset in
+        a way that could be misread as truthy."""
+        result, updated = self._run_save({
+            'id': 'profile-1',
+            'label': 'Auto',
+            'types': [{'quality': '1080p', 'finish': 1, '3d': 0}],
+        }, existing_profile={'_id': 'profile-1', 'label': 'Auto'})
+
+        assert result['success'] is True
+        assert len(updated) == 1
+        assert updated[0]['manual_confirmation'] is False
+
+    def test_profile_doc_lacking_the_key_reads_as_false(self):
+        """A profile document persisted before Phase 2 existed simply has no
+        'manual_confirmation' key at all. Every consumer must read it via
+        .get(..., False) so it defaults safely -- this test locks in that
+        contract at the data level."""
+        legacy_profile = {'_id': 'profile-legacy', 'label': 'Old Profile', 'qualities': ['720p']}
+
+        assert legacy_profile.get('manual_confirmation', False) is False
+        assert bool(legacy_profile.get('manual_confirmation')) is False
+
+
+# --- Step D: hardcoded movie-status lists must include 'downloaded' -----
+
+class TestStaleReleaseCleanupIncludesDownloaded:
+    """couchpotato/core/plugins/release/main.py Release.cleanDone() (the
+    weekly stale-release cleanup) used to hardcode media.with_status(['done',
+    'active']). Now that manual-review profiles produce 'downloaded' movies,
+    omitting that status would silently exempt review-gated movies from
+    having their stale/duplicate releases cleaned up."""
+
+    def test_weekly_cleanup_queries_downloaded_alongside_done_and_active(self):
+        plugin = Release.__new__(Release)
+
+        class FakeDB:
+            def all(self, table, with_doc=False):
+                return []
+
+        calls = []
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'media.with_status':
+                calls.append(args[0])
+                return []
+            raise AssertionError('Unexpected fireEvent call: %r' % (event,))
+
+        with (
+            patch('couchpotato.core.plugins.release.main.get_db', return_value=FakeDB()),
+            patch('couchpotato.core.plugins.release.main.fireEvent', side_effect=fake_fire_event),
+        ):
+            plugin.cleanDone()
+
+        assert calls == [['done', 'active', 'downloaded']]
+
+
+class TestProfileOrphanRepairIncludesDownloaded:
+    """ProfilePlugin.forceDefaults() reassigns movies with a dangling
+    profile_id to the default profile. It used to only look at 'active'
+    movies. A 'downloaded' (review-gated) movie still needs a working
+    profile_id (restatus() reads it every call, and the future "mark failed
+    & re-search" action needs it too), so it must be covered by the same
+    orphan repair or a deleted-profile reference would strand it."""
+
+    def test_orphan_profile_repair_queries_downloaded_alongside_active(self):
+        plugin = ProfilePlugin.__new__(ProfilePlugin)
+
+        class FakeDB:
+            def count(self, func, table):
+                return 1  # pretend profiles already exist, skip self.fill()
+
+            def all(self, table, with_doc=False):
+                return [{'doc': {'_id': 'profile-default', 'qualities': ['1080p']}}]
+
+        calls = []
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'media.with_status':
+                calls.append(args[0])
+                return []
+            raise AssertionError('Unexpected fireEvent call: %r' % (event,))
+
+        with (
+            patch('couchpotato.core.plugins.profile.main.get_db', return_value=FakeDB()),
+            patch('couchpotato.core.plugins.profile.main.fireEvent', side_effect=fake_fire_event),
+        ):
+            plugin.forceDefaults()
+
+        assert calls == [['active', 'downloaded']]

--- a/tests/unit/test_downloaded_review_workflow_phase2.py
+++ b/tests/unit/test_downloaded_review_workflow_phase2.py
@@ -456,6 +456,123 @@ class TestManageDeleteExemptsDownloadedMovies:
         assert 'movie-2' in deleted_ids
 
 
+class TestWantedDeleteExemptsDownloadedMovies:
+    """BLOCKING gap (phase 2 re-review): the SIBLING branch
+    `if delete_from in ['wanted','snatched','late']` in MediaPlugin.delete()
+    was unguarded. For a 'downloaded' movie with a 'done' release (the
+    feature's steady state), the release survives but `new_media_status =
+    'done'` was set that iteration, so the post-loop `elif new_media_status:`
+    overwrote the movie status to 'done' AND nulled profile_id -- silently
+    bypassing the review gate. Reachable via wanted.html bulkDelete()
+    (hardcodes delete_from='wanted', stale-selection race) and the public
+    movie.delete?delete_from=wanted API. For delete_from='late' the post-loop
+    `(not new_media_status and delete_from == 'late')` clause would even
+    delete the movie outright."""
+
+    def _run_delete(self, media, releases, delete_from):
+        plugin = MediaPlugin.__new__(MediaPlugin)
+
+        db_deletes = []
+        db_updates = []
+        restatus_calls = []
+
+        class FakeDB:
+            def get(self, index, key, **kwargs):
+                if index == 'id' and key == media['_id']:
+                    return dict(media)
+                raise AssertionError('Unexpected db.get call: %r %r' % (index, key))
+
+            def delete(self, doc):
+                db_deletes.append(dict(doc))
+
+            def update(self, doc):
+                db_updates.append(dict(doc))
+                return doc
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'release.for_media':
+                return [dict(r) for r in releases]
+            if event == 'media.restatus':
+                restatus_calls.append(args)
+                return media.get('status')
+            if event in ('media.untag', 'notify.frontend'):
+                return None
+            raise AssertionError('Unexpected fireEvent call: %r' % (event,))
+
+        with (
+            patch('couchpotato.core.media._base.media.main.get_db', return_value=FakeDB()),
+            patch('couchpotato.core.media._base.media.main.fireEvent', side_effect=fake_fire_event),
+        ):
+            plugin.delete(media['_id'], delete_from=delete_from)
+
+        return db_deletes, db_updates, restatus_calls
+
+    def test_downloaded_movie_survives_wanted_delete_untouched(self):
+        """A review-gated movie deleted via delete_from='wanted' must stay
+        'downloaded' with profile_id intact and its 'done' release NOT
+        deleted -- the movie doc must not be written to 'done' nor purged."""
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
+        releases = [{'_id': 'release-1', 'status': 'done'}]
+
+        db_deletes, db_updates, restatus_calls = self._run_delete(movie, releases, 'wanted')
+
+        assert db_deletes == [], "no release or media doc may be deleted"
+        assert db_updates == [], "movie status/profile_id must not be rewritten"
+        assert len(restatus_calls) == 1, "the movie is just restatus'd, left in place"
+
+    def test_downloaded_movie_survives_snatched_delete_untouched(self):
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
+        releases = [{'_id': 'release-1', 'status': 'done'}]
+
+        db_deletes, db_updates, _ = self._run_delete(movie, releases, 'snatched')
+
+        assert db_deletes == []
+        assert db_updates == []
+
+    def test_downloaded_movie_survives_late_delete_untouched(self):
+        """The 'late' case is the sharpest: the post-loop
+        `(not new_media_status and delete_from == 'late')` clause would
+        delete the movie doc outright if the branch weren't guarded."""
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
+        releases = [{'_id': 'release-1', 'status': 'done'}]
+
+        db_deletes, db_updates, _ = self._run_delete(movie, releases, 'late')
+
+        assert db_deletes == [], "a downloaded movie must not be purged by a late-delete"
+        assert db_updates == []
+
+    def test_active_movie_wanted_delete_behavior_unchanged(self):
+        """Over-exemption guard: a genuinely non-'downloaded' movie's
+        wanted-delete path is unchanged. An 'active' movie with a single
+        non-done release: the release is deleted (total_deleted == 1 ==
+        total_releases), so the movie doc is deleted too, exactly as before
+        the guard was added."""
+        movie = {'_id': 'movie-2', 'status': 'active', 'profile_id': 'profile-1'}
+        releases = [{'_id': 'release-2', 'status': 'snatched'}]
+
+        db_deletes, db_updates, _ = self._run_delete(movie, releases, 'wanted')
+
+        deleted_ids = [d.get('_id') for d in db_deletes]
+        assert 'release-2' in deleted_ids
+        assert 'movie-2' in deleted_ids
+
+    def test_active_movie_with_done_release_wanted_delete_marks_done_unchanged(self):
+        """Over-exemption guard, second shape: an 'active' movie whose only
+        release is already 'done' -- the wanted-delete keeps the release
+        (status == 'done') and sets the movie to 'done' with profile_id
+        nulled. This is the exact behavior the 'downloaded' guard must NOT
+        trigger, verified here as still intact for a normal active movie."""
+        movie = {'_id': 'movie-3', 'status': 'active', 'profile_id': 'profile-1'}
+        releases = [{'_id': 'release-3', 'status': 'done'}]
+
+        db_deletes, db_updates, _ = self._run_delete(movie, releases, 'wanted')
+
+        assert db_deletes == [], "the done release is kept"
+        assert len(db_updates) == 1
+        assert db_updates[0]['status'] == 'done'
+        assert db_updates[0]['profile_id'] is None
+
+
 # --- End-to-end composition: manual-confirmation routing + searcher gate --
 
 class TestManualConfirmationRoutingGatesSearcher:

--- a/tests/unit/test_downloaded_review_workflow_phase2.py
+++ b/tests/unit/test_downloaded_review_workflow_phase2.py
@@ -13,9 +13,12 @@ completion (the movie wasn't already 'done'), that branch now sets
 still runs *before* this branch, so an already-'downloaded' movie never
 reaches this logic at all.
 """
+import threading
 from unittest.mock import patch
 
 from couchpotato.core.media._base.media.main import MediaPlugin
+from couchpotato.core.media.movie.searcher import MovieSearcher
+from couchpotato.core.plugins.manage import Manage
 from couchpotato.core.plugins.profile.main import ProfilePlugin
 from couchpotato.core.plugins.release.main import Release
 
@@ -170,30 +173,71 @@ class TestProfileManualConfirmationPersistence:
         assert len(updated) == 1
         assert updated[0]['manual_confirmation'] is True
 
-    def test_save_defaults_manual_confirmation_false_when_omitted(self):
-        """A save() call that never mentions manual_confirmation (e.g. every
-        pre-Phase-2 caller, or a brand new profile created before the UI
-        exposes the toggle) must persist it as False, not leave it unset in
+    def test_save_defaults_manual_confirmation_false_when_omitted_on_new_profile(self):
+        """A save() call that never mentions manual_confirmation AND has no
+        existing doc to fall back to (a brand new profile, or a caller whose
+        id doesn't resolve) must persist it as False, not leave it unset in
         a way that could be misread as truthy."""
         result, updated = self._run_save({
-            'id': 'profile-1',
+            'id': 'profile-new',
             'label': 'Auto',
             'types': [{'quality': '1080p', 'finish': 1, '3d': 0}],
-        }, existing_profile={'_id': 'profile-1', 'label': 'Auto'})
+        }, existing_profile=None)
 
         assert result['success'] is True
         assert len(updated) == 1
         assert updated[0]['manual_confirmation'] is False
 
-    def test_profile_doc_lacking_the_key_reads_as_false(self):
-        """A profile document persisted before Phase 2 existed simply has no
-        'manual_confirmation' key at all. Every consumer must read it via
-        .get(..., False) so it defaults safely -- this test locks in that
-        contract at the data level."""
-        legacy_profile = {'_id': 'profile-legacy', 'label': 'Old Profile', 'qualities': ['720p']}
+    def test_save_omitting_key_on_existing_true_profile_preserves_true(self):
+        """BLOCKING bug (workflow phase 2 review): the live profile editor
+        never sends manual_confirmation in its save payload -- it only sends
+        label/order/types/etc for a routine rename or quality edit. Before
+        the fix, save() unconditionally recomputed manual_confirmation from
+        kwargs with a bare `0` default, silently flipping an existing True
+        profile back to False on every such edit. The fix mirrors the
+        sibling 'order' field, which already falls back to the persisted
+        value (`p.get('order', 999)`) when the key is omitted."""
+        result, updated = self._run_save({
+            'id': 'profile-1',
+            'label': 'Manual Review (renamed)',
+            'types': [{'quality': '1080p', 'finish': 1, '3d': 0}],
+        }, existing_profile={'_id': 'profile-1', 'label': 'Manual Review', 'manual_confirmation': True})
 
-        assert legacy_profile.get('manual_confirmation', False) is False
-        assert bool(legacy_profile.get('manual_confirmation')) is False
+        assert result['success'] is True
+        assert len(updated) == 1
+        assert updated[0]['manual_confirmation'] is True
+
+    def test_save_legacy_profile_without_key_omitting_payload_key_persists_as_false(self):
+        """Replaces a prior tautological test that only asserted dict.get()
+        on a local literal. A profile doc persisted before Phase 2 existed
+        carries no 'manual_confirmation' key at all. Saving it (e.g. a
+        rename) via a payload that also omits the key must exercise the real
+        save() fallback and persist an explicit False, not leave the key
+        unset or misread as truthy."""
+        result, updated = self._run_save({
+            'id': 'profile-legacy',
+            'label': 'Old Profile (renamed)',
+            'types': [{'quality': '720p', 'finish': 1, '3d': 0}],
+        }, existing_profile={'_id': 'profile-legacy', 'label': 'Old Profile', 'qualities': ['720p']})
+
+        assert result['success'] is True
+        assert len(updated) == 1
+        assert updated[0]['manual_confirmation'] is False
+
+    def test_save_explicit_true_on_existing_false_profile_turns_it_on(self):
+        """Sanity check alongside the fallback fix: explicitly sending the
+        key must still win over the persisted value (the fallback only
+        applies when the key is omitted)."""
+        result, updated = self._run_save({
+            'id': 'profile-1',
+            'label': 'Now Manual',
+            'types': [{'quality': '1080p', 'finish': 1, '3d': 0}],
+            'manual_confirmation': 1,
+        }, existing_profile={'_id': 'profile-1', 'label': 'Now Manual', 'manual_confirmation': False})
+
+        assert result['success'] is True
+        assert len(updated) == 1
+        assert updated[0]['manual_confirmation'] is True
 
 
 # --- Step D: hardcoded movie-status lists must include 'downloaded' -----
@@ -262,3 +306,215 @@ class TestProfileOrphanRepairIncludesDownloaded:
             plugin.forceDefaults()
 
         assert calls == [['active', 'downloaded']]
+
+
+# --- BLOCKING 1: a review-gated ('downloaded') movie must be exempt from
+# manage/cleanup deletion, even though its release is 'done'. -------------
+#
+# `Manage.updateLibrary()`'s cleanup scan queries
+# `fireEvent('media.list', status='done', release_status='done', status_or=True, ...)`.
+# `status_or=True` makes MediaPlugin.list() treat this as an OR union: a movie
+# whose *movie* status is 'done' OR whose *release* status is 'done'. A
+# 'downloaded' movie (workflow phase 2 review gate) always has a 'done'
+# release while it awaits review, so it landed in done_movies and could be
+# silently deleted (delete_from='all') by a routine full library scan
+# (the 'cleanup' config defaults on). The sibling manage-tab delete path
+# (MediaPlugin.delete(delete_from='manage')) has the same OR exposure via
+# `release.status == 'done' or media.status == 'done'`.
+
+class TestManageCleanupExemptsDownloadedMovies:
+
+    def _run_update_library(self, done_movies):
+        manage = Manage.__new__(Manage)
+        manage._progress_lock = threading.Lock()
+        manage.in_progress = False
+
+        delete_calls = []
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'media.list':
+                return len(done_movies), done_movies
+            if event == 'media.delete':
+                delete_calls.append(dict(kwargs))
+                return True
+            if event == 'notify.frontend':
+                return None
+            raise AssertionError('Unexpected fireEvent call: %r' % (event,))
+
+        class FakeDB:
+            def reindex(self):
+                pass
+
+        with (
+            patch.object(Manage, 'conf', return_value=True),
+            patch.object(Manage, 'isDisabled', return_value=False),
+            patch.object(Manage, 'directories', return_value=[]),
+            patch.object(Manage, 'shuttingDown', return_value=False),
+            patch('couchpotato.core.plugins.manage.fireEvent', side_effect=fake_fire_event),
+            patch('couchpotato.core.plugins.manage.get_db', return_value=FakeDB()),
+            patch('couchpotato.core.plugins.manage.Env.prop',
+                  side_effect=lambda identifier, value=None, default=None: default if value is None else None),
+        ):
+            manage.updateLibrary(full=True)
+
+        return delete_calls
+
+    def test_downloaded_movie_with_done_release_is_not_deleted_by_cleanup(self):
+        """The BLOCKING bug scenario: a review-gated movie (movie status
+        'downloaded') whose release is 'done' lands in done_movies via the
+        status_or union, but must never be swept up by the cleanup scan's
+        delete_from='all' path."""
+        downloaded_movie = {
+            '_id': 'movie-downloaded',
+            'status': 'downloaded',
+            'identifiers': {'imdb': 'tt1'},
+            'releases': [],
+        }
+
+        delete_calls = self._run_update_library([downloaded_movie])
+
+        assert delete_calls == []
+
+    def test_genuinely_done_movie_missing_from_disk_is_still_cleaned_up(self):
+        """Regression lock: the exemption must not change behavior for a
+        movie that's actually 'done' -- if it wasn't found on this scan
+        (not in added_identifiers), it's still deleted exactly as before."""
+        done_movie = {
+            '_id': 'movie-done',
+            'status': 'done',
+            'identifiers': {'imdb': 'tt2'},
+            'releases': [],
+        }
+
+        delete_calls = self._run_update_library([done_movie])
+
+        assert delete_calls == [{'media_id': 'movie-done', 'delete_from': 'all'}]
+
+
+class TestManageDeleteExemptsDownloadedMovies:
+
+    def _run_delete(self, media, releases):
+        plugin = MediaPlugin.__new__(MediaPlugin)
+
+        db_deletes = []
+        db_updates = []
+
+        class FakeDB:
+            def get(self, index, key, **kwargs):
+                if index == 'id' and key == media['_id']:
+                    return dict(media)
+                raise AssertionError('Unexpected db.get call: %r %r' % (index, key))
+
+            def delete(self, doc):
+                db_deletes.append(dict(doc))
+
+            def update(self, doc):
+                db_updates.append(dict(doc))
+                return doc
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'release.for_media':
+                return [dict(r) for r in releases]
+            if event == 'media.restatus':
+                return media.get('status')
+            if event in ('media.untag', 'notify.frontend'):
+                return None
+            raise AssertionError('Unexpected fireEvent call: %r' % (event,))
+
+        with (
+            patch('couchpotato.core.media._base.media.main.get_db', return_value=FakeDB()),
+            patch('couchpotato.core.media._base.media.main.fireEvent', side_effect=fake_fire_event),
+        ):
+            plugin.delete(media['_id'], delete_from='manage')
+
+        return db_deletes, db_updates
+
+    def test_downloaded_movie_release_survives_manage_delete(self):
+        """The BLOCKING bug scenario for MediaPlugin.delete(): a
+        review-gated movie's release is 'done' by design, so the manage
+        path's `release.status == 'done' or media.status == 'done'` check
+        used to delete it out from under an in-progress review. Must now
+        survive untouched."""
+        movie = {'_id': 'movie-1', 'status': 'downloaded'}
+        releases = [{'_id': 'release-1', 'status': 'done'}]
+
+        db_deletes, _ = self._run_delete(movie, releases)
+
+        assert db_deletes == []
+
+    def test_genuinely_done_movie_release_is_still_deleted_by_manage_delete(self):
+        """Regression lock: unchanged behavior for a movie that's actually
+        'done' -- its release is still deleted, and since every release
+        ended up deleted the movie itself is deleted too."""
+        movie = {'_id': 'movie-2', 'status': 'done'}
+        releases = [{'_id': 'release-2', 'status': 'done'}]
+
+        db_deletes, _ = self._run_delete(movie, releases)
+
+        deleted_ids = [d.get('_id') for d in db_deletes]
+        assert 'release-2' in deleted_ids
+        assert 'movie-2' in deleted_ids
+
+
+# --- End-to-end composition: manual-confirmation routing + searcher gate --
+
+class TestManualConfirmationRoutingGatesSearcher:
+    """Ties Phase 2 (restatus() routes a manual-confirmation completion to
+    'downloaded') to Phase 1 (the searcher gate skips a 'downloaded' movie)
+    instead of testing each in isolation."""
+
+    def test_manual_confirmation_completion_is_then_skipped_by_searcher(self):
+        movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1'}
+        profile = {'_id': 'profile-1', 'qualities': ['1080p'], 'manual_confirmation': True}
+        releases = [{'status': 'done', 'quality': '1080p', 'last_edit': 0, 'is_3d': False}]
+
+        media_plugin = MediaPlugin.__new__(MediaPlugin)
+
+        class FakeMediaDB:
+            def get(self, index, key, **kwargs):
+                if index == 'id' and key == movie['_id']:
+                    return dict(movie)
+                if index == 'id' and key == profile['_id']:
+                    return dict(profile)
+                raise AssertionError('Unexpected db.get call: %r %r' % (index, key))
+
+            def update(self, doc):
+                movie.update(doc)
+                return doc
+
+        def fake_restatus_fire_event(event, *args, **kwargs):
+            if event == 'release.for_media':
+                return releases
+            if event == 'quality.isfinish':
+                return True
+            raise AssertionError('Unexpected fireEvent call: %r' % (event,))
+
+        with (
+            patch('couchpotato.core.media._base.media.main.get_db', return_value=FakeMediaDB()),
+            patch('couchpotato.core.media._base.media.main.fireEvent', side_effect=fake_restatus_fire_event),
+        ):
+            routed_status = media_plugin.restatus(movie['_id'], tag_recent=False)
+
+        # Phase 2: the manual-confirmation profile routed the completion to
+        # 'downloaded', not 'done'.
+        assert routed_status == 'downloaded'
+        assert movie['status'] == 'downloaded'
+
+        # Phase 1: feed that same (now 'downloaded') movie into the
+        # searcher's gate and confirm it's skipped outright.
+        searcher = MovieSearcher.__new__(MovieSearcher)
+        event_names = []
+
+        def fake_searcher_fire_event(event, *args, **kwargs):
+            event_names.append(event)
+            if event == 'media.restatus':
+                return movie['status']
+            raise AssertionError('Unexpected fireEvent call past the downloaded gate: %r' % (event,))
+
+        with patch('couchpotato.core.media.movie.searcher.fireEvent', side_effect=fake_searcher_fire_event):
+            searcher.single(movie, search_protocols=['torrent'], manual=False)
+
+        assert event_names == ['media.restatus'], (
+            "a 'downloaded' movie must be skipped before any search-related "
+            "event fires"
+        )

--- a/tests/unit/test_downloaded_review_workflow_phase2.py
+++ b/tests/unit/test_downloaded_review_workflow_phase2.py
@@ -455,6 +455,21 @@ class TestManageDeleteExemptsDownloadedMovies:
         assert 'release-2' in deleted_ids
         assert 'movie-2' in deleted_ids
 
+    def test_downloaded_movie_with_zero_releases_survives_manage_delete(self):
+        """Defense-in-depth hole flagged by the cloud review: a 'downloaded'
+        movie with NO releases + delete_from='manage'. Before the top-level
+        guard included 'manage', this flowed to the generic loop where the
+        post-loop `total_releases == 0 and not new_media_status` clause did a
+        full `db.delete(media)` -- purging a review-gated movie. The movie doc
+        must survive and stay 'downloaded'."""
+        movie = {'_id': 'movie-3', 'status': 'downloaded', 'profile_id': 'profile-1'}
+        releases = []
+
+        db_deletes, db_updates = self._run_delete(movie, releases)
+
+        assert db_deletes == [], "a review-gated movie must not be purged"
+        assert db_updates == [], "status/profile_id must not be rewritten"
+
 
 class TestWantedDeleteExemptsDownloadedMovies:
     """BLOCKING gap (phase 2 re-review): the SIBLING branch


### PR DESCRIPTION
Part of #14 (Downloaded/review manual-confirmation workflow). Phase 1 (the `downloaded` movie status + searcher gating) shipped earlier; this is **Phase 2: the per-profile toggle + completion routing**. Spec: `specs/DOWNLOADED-REVIEW-WORKFLOW.md`.

## What

- **New per-profile boolean `manual_confirmation`** ("stop after first download for manual review", default **off** = today's auto-upgrade behavior).
- **Completion routing** (`media.restatus`): a manual-review profile routes a completed download to the movie status `downloaded` (review gate) instead of `done`; the searcher then stops (Phase 1 gating). Auto profiles are **byte-for-byte unchanged**.
- Step-D status-list sites updated so a `downloaded` movie is correctly included where a review-gated movie should still be considered (`release/main.py` stale-cleanup, `profile/main.py` forceDefaults).

## Three blocking bugs caught by the local-review gate (fixed before this push)

Two local-review rounds surfaced three real defects — all fixed and locked with regression tests:

1. **Silent deletion of a review-gated movie via the default-on library cleanup** — `manage.py`'s cleanup used a `status_or` union (`movie done OR release done`); a `downloaded` movie (release still `done`) landed in `done_movies` and could be `media.delete(delete_from='all')`d on a normal full scan. Exempted.
2. **Manage bulk-delete** (`MediaPlugin.delete(delete_from='manage')`) could delete a `downloaded` movie's release. Guarded.
3. **Wanted/snatched/late delete** (`MediaPlugin.delete(delete_from in ['wanted','snatched','late'])`) force-completed a `downloaded` movie to `done` and nulled `profile_id`. Guarded via a top-level no-op branch (chosen over an in-loop `continue`, which would let the `late` clause delete the movie doc).
4. **Profile toggle silently reset** — `profile.save()` overwrote `manual_confirmation` to `False` on any save omitting it (the live editor omits it every save). Now falls back to the persisted value, mirroring the `order` field.

## Deferred to Phase 3 (documented in the spec)

A round-3 completeness sweep found `MovieBase.add(force_readd=True)` (default) lets an explicit "Add" re-add wipe a `downloaded` movie's confirmed release + re-search. **Not a Phase-2 regression** — it already does this to `done` movies (Phase 2 never touched `add()`); it's a pre-existing, app-wide property of the `force_readd` default + an ungated Add button. The correct fix is app-wide (guard re-add of any already-*completed* movie, `done` or `downloaded`) and UI-level, so it's folded into Phase 3's UI-actions work. See the Phase-3 entry in the spec.

## Tests

1118 unit tests pass (+ the new `test_downloaded_review_workflow_phase2.py` suite), ruff clean, `make verify` green (incl. E2E). Each fix is locked by a scratch-revert-verified regression test; auto-profile parity and no-over-exemption are both asserted.

## Local-review gate

Taken fully through the gate: implementation agent committed locally (no push); **two** parallel `general-purpose` review rounds (correctness + tests) caught the three blocking bugs above; fixes re-reviewed each round until a third round confirmed the code correct and complete for Phase-2 scope. Only then pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)