### PR TITLE
feat(workflow): guard destructive force_readd re-add of completed (done|downloaded) movies

### DIFF
--- a/couchpotato/core/media/movie/_base/main.py
+++ b/couchpotato/core/media/movie/_base/main.py
@@ -100,7 +100,23 @@ class MovieBase(MovieTypeBase):
             info = fireEvent('movie.info', merge = True, extended = False, identifier = params.get('identifier'))
 
         # Allow force re-add overwrite from param
-        if 'force_readd' in params:
+        # Tracked separately from the resolved `force_readd` bool: this records
+        # whether the CALLER explicitly asked for a (re-)add via params (e.g.
+        # the API's force_readd=1), as opposed to the default. Used below to
+        # protect an already-completed movie from an implicit re-add (a naked
+        # "Add" button click, which never sends force_readd) while still
+        # honoring a deliberate, explicit one.
+        # NB: "explicit" here means the caller passed force_readd through the
+        # params/API surface. An INTERNAL Python caller that passes
+        # force_readd=True as a keyword arg (not via params) against a
+        # done/downloaded movie would still hit the no-op guard below, because
+        # this only inspects params. No such caller exists today (every
+        # keyword-arg caller passes force_readd=False or only runs on the
+        # new-movie path), but a future contributor adding an internal
+        # force-readd of a completed movie must pass it via params (or the
+        # guard will silently no-op their call).
+        force_readd_explicit = 'force_readd' in params
+        if force_readd_explicit:
             fra = params.get('force_readd')
             force_readd = fra.lower() not in ['0', '-1'] if not isinstance(fra, bool) else fra
 
@@ -177,6 +193,12 @@ class MovieBase(MovieTypeBase):
                         previous_profile = self.existingProfileId(db, m)
                         previous_category = m.get('category_id')
 
+            # Capture the pre-existing movie's status BEFORE m.update(media)
+            # overwrites it (media['status'] defaults to 'active' above) --
+            # needed by the completed-movie re-add guard below. Meaningless
+            # (and unused) for a brand-new movie.
+            previous_status = m.get('status')
+
             # Update dict to be usable
             m.update(media)
 
@@ -189,6 +211,25 @@ class MovieBase(MovieTypeBase):
                 if search_after:
                     onComplete = self.createOnComplete(m['_id'])
                 search_after = False
+            elif force_readd and previous_status in ['done', 'downloaded'] and not force_readd_explicit:
+                # Guard (app-wide, not just for the 'downloaded' review gate):
+                # a movie that is already complete (done) or awaiting review
+                # (downloaded) must not be destructively re-added by an
+                # IMPLICIT force_readd -- the live "Add" buttons
+                # (search_results.html, movie_info_modal.html) call movie.add
+                # with no force_readd at all, defaulting True, so a single
+                # stray click used to wipe the completed release(s), reset
+                # profile_id/category_id/tags, and reset status to 'active'.
+                # Treat this exactly like the non-force_readd no-op below:
+                # don't touch releases, don't persist m (db.update is never
+                # called), don't re-search. An EXPLICIT force_readd (e.g. the
+                # API's force_readd=1) still falls through to the destructive
+                # branch and is honored -- this only protects the default.
+                log.info(
+                    'Movie already complete (%s), not re-adding to protect the existing copy; '
+                    'use Mark Failed & re-search to replace it', previous_status
+                )
+                added = False
             elif force_readd:
 
                 # Clean snatched history

--- a/specs/DOWNLOADED-REVIEW-WORKFLOW.md
+++ b/specs/DOWNLOADED-REVIEW-WORKFLOW.md
@@ -248,26 +248,39 @@ feature's completion-path change rather than a separate reconstruction.
      wanted/snatched/late behavior is unchanged.
 3. **UI actions:** Mark Done / Mark Failed&re-search (movie); Skip/Ignore &
    Mark-failed (release); immediate re-search on Fail. Tests + E2E.
-   **Also fold in here — the re-add guard (deferred from Phase 2, found in the
-   round-3 completeness sweep):** `MovieBase.add()` defaults `force_readd=True`,
+   **Re-add guard — IMPLEMENTED (Phase 3a):** `MovieBase.add()`
+   (`couchpotato/core/media/movie/_base/main.py`) defaults `force_readd=True`,
    and the live "Add" buttons (`ui/templates/partials/search_results.html`,
-   `movie_info_modal.html`) call `movie.add` with no `force_readd`, so re-adding
-   an already-present movie hits the `elif force_readd:` branch — it deletes the
-   movie's completed release (`['downloaded','snatched','seeding','done']`),
-   nulls `profile_id`/`category_id`/`tags`, resets `status` to `active`, and
-   re-searches. For a `downloaded` (review-gated) movie a single stray "Add"
-   click thus destroys the confirmed copy and the gate. **Important scope note:**
-   this is *not* a Phase-2 regression — the exact same destruction already
-   happens to a `done` movie today (all existing `done` movies share it), because
-   Phase 2 never touched `add()`; it is a pre-existing, app-wide property of the
-   `force_readd` default + an ungated Add button. The correct fix is therefore
-   app-wide, not `downloaded`-only (guarding only `downloaded` would create a
-   confusing asymmetry with `done`): treat re-adding an already-*completed*
-   movie (`done` **or** `downloaded`) as a no-op or require explicit
-   confirmation, so a naked "Add" can't silently wipe a completed/under-review
-   copy. Belongs with the UI actions since the real fix is UI-level (the Add
-   surface should reflect "already in library / under review" state). Tests
-   mirroring `TestWantedDeleteExemptsDownloadedMovies`.
+   `movie_info_modal.html`) call `movie.add` with no `force_readd`, so
+   re-adding an already-present movie used to hit the `elif force_readd:`
+   branch — it deleted the movie's completed release
+   (`['downloaded','snatched','seeding','done']`), nulled
+   `profile_id`/`category_id`/`tags`, reset `status` to `active`, and
+   re-searched. For a `downloaded` (review-gated) movie a single stray "Add"
+   click thus destroyed the confirmed copy and the gate; the exact same
+   destruction already happened to a `done` movie (pre-existing, app-wide —
+   Phase 2 never touched `add()`).
+
+   Fixed app-wide (not `downloaded`-only, which would create a confusing
+   asymmetry with `done`): `add()` now tracks the pre-existing movie's
+   `previous_status` (captured before `m.update(media)` overwrites it) and
+   whether `force_readd` was **explicitly** requested by the caller
+   (`force_readd_explicit = 'force_readd' in params`, e.g. the API's
+   `force_readd=1`) versus left at the default. When `previous_status` is
+   `done` or `downloaded` **and** `force_readd` was not explicit, the
+   destructive branch is skipped entirely — no release wipe, no
+   profile/category/tags reset, no persisted status change (`db.update` is
+   never called, so the confirmed/review-gated doc is untouched), no
+   re-search — identical to the pre-existing non-force_readd no-op branch. An
+   **explicit** `force_readd` still runs the full destructive re-add
+   unchanged (regression-locked). A non-completed existing movie (`active`,
+   `wanted`, etc.) and a brand-new movie are both unaffected and keep
+   force-readding by default exactly as before.
+   Tests: `tests/unit/test_readd_guard_completed_movies.py` — implicit re-add
+   of `done`/`downloaded` is a no-op (no wipe, no re-search); explicit
+   `force_readd` on a `done` movie still wipes + resets (regression lock); an
+   `active` movie is still destructively re-added by default (guard doesn't
+   broaden); a brand-new movie is unaffected.
    **Minor (defense-in-depth) — fixed in Phase 2:** a `downloaded` movie with
    **zero** releases + `delete_from='manage'` used to fall to the full
    `db.delete(media)` via the generic loop's post-loop `total_releases == 0 and

--- a/tests/unit/test_readd_guard_completed_movies.py
+++ b/tests/unit/test_readd_guard_completed_movies.py
@@ -1,0 +1,373 @@
+"""Tests for the force_readd re-add guard (specs/DOWNLOADED-REVIEW-WORKFLOW.md
+Phase 3a, "the re-add guard" item).
+
+Problem: `MovieBase.add()` (couchpotato/core/media/movie/_base/main.py)
+defaults `force_readd=True`. The live "Add" buttons
+(ui/templates/partials/search_results.html, movie_info_modal.html) call
+`movie.add` with NO `force_readd`, so a single stray click on a movie that is
+already `done` or `downloaded` (review-gated) used to hit the destructive
+`elif force_readd:` branch: it deletes the movie's completed release(s),
+resets profile_id/category_id/tags, resets status to 'active', and
+re-searches -- silently destroying a confirmed copy. This is pre-existing and
+app-wide (it already harmed `done` movies before the `downloaded` status
+existed).
+
+Fix: an IMPLICIT force_readd (the caller never passed `force_readd` in
+params at all -- the default) against an already-completed movie (`done` or
+`downloaded`) is now a no-op, identical to the pre-existing non-force_readd
+branch: no release wipe, no profile/category/tags reset, no persisted status
+change, no re-search. An EXPLICIT force_readd (e.g. the API's
+`force_readd=1`) still falls through to the destructive branch and is
+honored -- this guard only protects the default.
+
+Re-search plumbing these tests exercise (main.py ~198-264): a genuine
+force_readd sets `do_search = True`; after the release cleanup, the block
+`if do_search and search_after: onComplete = self.createOnComplete(...); onComplete()`
+fires. `createOnComplete().onComplete()` (couchpotato/core/media/__init__.py)
+does `fireEvent('media.get', ...)` then
+`fireEventAsync('%s.searcher.single' % media['type'], ...)`. So a real
+re-search surfaces as a `movie.searcher.single` fireEventAsync call -- but
+ONLY when `search_after` is truthy, which requires
+`conf('search_on_add', ...)` to be True (main.py:198). The harness below
+therefore stubs conf -> True so the "no re-search" assertions are
+discriminating rather than vacuously satisfied by search_after=False.
+"""
+from unittest.mock import patch
+
+from couchpotato.core.media.movie._base.main import MovieBase
+
+
+def _base_params(imdb_id='tt0133093', profile_id='profile-1', force_readd=None):
+    params = {
+        'identifier': imdb_id,
+        'info': {'titles': ['The Matrix'], 'title': 'The Matrix'},
+        'profile_id': profile_id,
+    }
+    if force_readd is not None:
+        params['force_readd'] = force_readd
+    return params
+
+
+class _FakeExistingMovieDB:
+    """A db double for an *existing* media doc (the "found" branch)."""
+
+    def __init__(self, existing):
+        self.existing = existing
+        self.deleted = []
+        self.updated = []
+
+    def get(self, index, key, with_doc=False):
+        if index == 'media':
+            return {'doc': dict(self.existing), '_id': self.existing['_id']}
+        raise KeyError('not found: %s/%s' % (index, key))
+
+    def update(self, data):
+        self.updated.append(dict(data))
+        return {'_id': data['_id'], '_rev': 'rev2'}
+
+    def delete(self, data):
+        self.deleted.append(data)
+        return True
+
+
+class _FakeNewMovieDB:
+    """A db double for a brand-new movie (the "not found" -> insert branch)."""
+
+    def __init__(self):
+        self.inserted = None
+        self.updated = []
+        self.deleted = []
+
+    def get(self, index, key, with_doc=False):
+        raise KeyError('not found: %s/%s' % (index, key))
+
+    def insert(self, data):
+        doc = dict(data)
+        doc['_id'] = 'new-media-id'
+        self.inserted = doc
+        return doc
+
+    def update(self, data):
+        self.updated.append(dict(data))
+        return {'_id': data['_id'], '_rev': 'rev2'}
+
+    def delete(self, data):
+        self.deleted.append(data)
+        return True
+
+
+def _run_add(fake_db, params, releases, media_dict, event_calls,
+             search_after=True, update_after=False, notify_after=False,
+             search_on_add=True):
+    """Runs MovieBase.add() with get_db/fireEvent/fireEventAsync patched, and
+    self.conf stubbed to return `search_on_add` for the
+    conf('search_on_add', ...) lookup at main.py:198.
+
+    CRUCIAL: search_on_add defaults True here (unlike a False stub that would
+    force search_after=False in every branch and make "no re-search"
+    assertions vacuous). With it True, a genuine force_readd re-add actually
+    calls onComplete() -> fireEventAsync('movie.searcher.single', ...), so a
+    guarded no-op's ABSENCE of that call is a real, discriminating signal --
+    proven by the active-movie positive-control test below, which fires it.
+
+    `event_calls` records every fireEvent/fireEventAsync call as
+    (event_name, args, kwargs).
+    """
+    plugin = MovieBase.__new__(MovieBase)
+    plugin.conf = lambda *a, **k: search_on_add
+
+    def fake_fire_event(event, *args, **kwargs):
+        event_calls.append((event, args, kwargs))
+        if event == 'release.for_media':
+            return releases
+        if event == 'media.get':
+            return media_dict
+        if event in ('release.delete', 'release.update_status', 'notify.frontend'):
+            return True
+        raise AssertionError('Unexpected fireEvent: %r %r %r' % (event, args, kwargs))
+
+    def fake_fire_event_async(event, *args, **kwargs):
+        event_calls.append((event, args, kwargs))
+        return True
+
+    # The re-search path routes through createOnComplete() ->
+    # onComplete(), which lives in couchpotato.core.media (MediaBase) and
+    # binds fireEvent/fireEventAsync in THAT module's namespace -- so those
+    # must be patched too, or the movie.searcher.single dispatch would run
+    # the real (unhandled) event and be swallowed, silently defeating the
+    # positive-control assertion.
+    with (
+        patch('couchpotato.core.media.movie._base.main.get_db', return_value=fake_db),
+        patch('couchpotato.core.media.movie._base.main.fireEvent', side_effect=fake_fire_event),
+        patch('couchpotato.core.media.movie._base.main.fireEventAsync', side_effect=fake_fire_event_async),
+        patch('couchpotato.core.media.fireEvent', side_effect=fake_fire_event),
+        patch('couchpotato.core.media.fireEventAsync', side_effect=fake_fire_event_async),
+    ):
+        result = plugin.add(
+            params=params,
+            search_after=search_after,
+            update_after=update_after,
+            notify_after=notify_after,
+        )
+
+    return result
+
+
+def _completed_movie(status, media_id='media-1', profile_id='existing-profile'):
+    return {
+        '_id': media_id,
+        '_t': 'media',
+        'type': 'movie',
+        'status': status,
+        'profile_id': profile_id,
+        'category_id': 'cat-existing',
+        'identifiers': {'imdb': 'tt0133093'},
+        'info': {'titles': ['The Matrix']},
+        'tags': ['keep-me'],
+    }
+
+
+def _searcher_single_calls(event_calls):
+    return [(args, kwargs) for name, args, kwargs in event_calls
+            if name == 'movie.searcher.single']
+
+
+def _release_delete_calls(event_calls):
+    return [(args, kwargs) for name, args, kwargs in event_calls
+            if name == 'release.delete']
+
+
+class TestImplicitReaddOfCompletedMovieIsNoOp:
+    """Add-button style calls (no force_readd in params) against a movie
+    that is already 'done' or 'downloaded' must be a no-op -- with
+    search_on_add=True, so the "no re-search" assertion is real."""
+
+    def test_readd_done_movie_without_force_readd_does_not_wipe_or_research(self):
+        existing = _completed_movie('done')
+        completed_release = {'_id': 'rel-1', 'status': 'done'}
+        fake_db = _FakeExistingMovieDB(existing)
+        event_calls = []
+
+        result = _run_add(
+            fake_db,
+            params=_base_params(),  # no 'force_readd' key -> implicit default
+            releases=[completed_release],
+            media_dict={'_id': 'media-1', 'type': 'movie', 'status': 'done', 'title': 'The Matrix'},
+            event_calls=event_calls,
+        )
+
+        assert result is not False
+        # DB state untouched.
+        assert fake_db.deleted == [], (
+            "implicit re-add of a 'done' movie must not delete its completed release"
+        )
+        assert fake_db.updated == [], (
+            "implicit re-add of a 'done' movie must not persist any change "
+            "(status/profile/category/tags reset)"
+        )
+        # No destructive-branch side effects.
+        assert _release_delete_calls(event_calls) == []
+        assert [n for n, _a, _k in event_calls if n == 'release.update_status'] == []
+        # The KEY assertion, now discriminating (search_on_add=True): the
+        # re-search path (do_search -> onComplete() -> movie.searcher.single)
+        # is NOT taken for the guarded no-op.
+        assert _searcher_single_calls(event_calls) == [], (
+            "implicit re-add of a completed movie must not trigger a re-search "
+            "(no movie.searcher.single) even with search_on_add=True"
+        )
+
+    def test_readd_downloaded_movie_without_force_readd_does_not_wipe_or_research(self):
+        existing = _completed_movie('downloaded')
+        review_release = {'_id': 'rel-1', 'status': 'downloaded'}
+        fake_db = _FakeExistingMovieDB(existing)
+        event_calls = []
+
+        result = _run_add(
+            fake_db,
+            params=_base_params(),
+            releases=[review_release],
+            media_dict={'_id': 'media-1', 'type': 'movie', 'status': 'downloaded', 'title': 'The Matrix'},
+            event_calls=event_calls,
+        )
+
+        assert result is not False
+        assert fake_db.deleted == [], (
+            "implicit re-add of a 'downloaded' (review-gated) movie must not "
+            "delete its release"
+        )
+        assert fake_db.updated == [], (
+            "implicit re-add of a 'downloaded' movie must not persist any "
+            "change -- the review gate must stay intact"
+        )
+        assert _release_delete_calls(event_calls) == []
+        assert [n for n, _a, _k in event_calls if n == 'release.update_status'] == []
+        assert _searcher_single_calls(event_calls) == [], (
+            "implicit re-add of a 'downloaded' movie must not trigger a re-search"
+        )
+
+
+class TestExplicitForceReaddStillHonored:
+    """Regression lock: an EXPLICIT force_readd must still perform the full
+    destructive re-add, proving the guard only blocks the implicit default
+    and doesn't over-block deliberate requests."""
+
+    def test_readd_done_movie_with_explicit_force_readd_wipes_and_researches(self):
+        existing = _completed_movie('done')
+        completed_release = {'_id': 'rel-1', 'status': 'done'}
+        fake_db = _FakeExistingMovieDB(existing)
+        event_calls = []
+
+        result = _run_add(
+            fake_db,
+            params=_base_params(force_readd='1'),  # explicit, e.g. API force_readd=1
+            releases=[completed_release],
+            media_dict={'_id': 'media-1', 'type': 'movie', 'status': 'active', 'title': 'The Matrix'},
+            event_calls=event_calls,
+        )
+
+        assert result is not False
+        assert _release_delete_calls(event_calls) == [(('rel-1',), {'single': True})], (
+            "an EXPLICIT force_readd against a 'done' movie must still fire "
+            "release.delete for its completed release (regression lock -- "
+            "guard must not over-block a deliberate re-add)"
+        )
+        assert len(fake_db.updated) == 1
+        updated = fake_db.updated[0]
+        assert updated['tags'] == [], "explicit force_readd must still reset tags"
+        assert updated['status'] == 'active', (
+            "explicit force_readd must still reset status to active "
+            "(media['status'] default from m.update(media))"
+        )
+        # Deliberate re-add DOES re-search.
+        assert len(_searcher_single_calls(event_calls)) == 1, (
+            "explicit force_readd must still trigger the re-search"
+        )
+
+    def test_readd_done_movie_with_explicit_force_readd_zero_is_noop(self):
+        """Explicit force_readd=0 resolves force_readd to False, so add()
+        falls through to the pre-existing non-force_readd `else` no-op branch:
+        the completed copy must survive untouched (closes the reviewer's noted
+        gap that only force_readd=1 was covered on the explicit path)."""
+        existing = _completed_movie('done')
+        completed_release = {'_id': 'rel-1', 'status': 'done'}
+        fake_db = _FakeExistingMovieDB(existing)
+        event_calls = []
+
+        result = _run_add(
+            fake_db,
+            params=_base_params(force_readd='0'),  # explicit disable
+            releases=[completed_release],
+            media_dict={'_id': 'media-1', 'type': 'movie', 'status': 'done', 'title': 'The Matrix'},
+            event_calls=event_calls,
+        )
+
+        assert result is not False
+        assert fake_db.deleted == []
+        assert fake_db.updated == []
+        assert _release_delete_calls(event_calls) == []
+        assert _searcher_single_calls(event_calls) == [], (
+            "explicit force_readd=0 must not re-search a 'done' movie"
+        )
+
+
+class TestNonCompletedMovieUnaffectedByGuard:
+    """The guard only protects 'done'/'downloaded'. A non-completed existing
+    movie must still force-readd by default exactly as before. This is ALSO
+    the positive control proving the guarded tests' "no movie.searcher.single"
+    assertion is discriminating (this one DOES fire it under the same
+    search_on_add=True harness)."""
+
+    def test_readd_active_movie_without_force_readd_still_destructive_and_researches(self):
+        existing = _completed_movie('active')
+        snatched_release = {'_id': 'rel-1', 'status': 'snatched'}
+        fake_db = _FakeExistingMovieDB(existing)
+        event_calls = []
+
+        result = _run_add(
+            fake_db,
+            params=_base_params(),  # implicit default force_readd=True
+            releases=[snatched_release],
+            media_dict={'_id': 'media-1', 'type': 'movie', 'status': 'active', 'title': 'The Matrix'},
+            event_calls=event_calls,
+        )
+
+        assert result is not False
+        assert _release_delete_calls(event_calls) == [(('rel-1',), {'single': True})], (
+            "the guard must not broaden to non-completed movies -- an "
+            "'active' movie must still force-readd (wipe) by default, "
+            "unchanged from before this fix"
+        )
+        assert len(fake_db.updated) == 1
+        assert fake_db.updated[0]['tags'] == []
+        # POSITIVE CONTROL: under the identical search_on_add=True harness, an
+        # 'active' implicit re-add DOES fire movie.searcher.single. This proves
+        # the guarded no-op tests' `_searcher_single_calls == []` assertion is
+        # discriminating (it can fail), not vacuously true.
+        assert len(_searcher_single_calls(event_calls)) == 1, (
+            "positive control: a destructive re-add MUST fire movie.searcher.single "
+            "so the guarded tests' 'no re-search' assertion is meaningful"
+        )
+
+
+class TestBrandNewMovieUnaffectedByGuard:
+    """A movie that doesn't exist yet must be unaffected: no previous_status
+    exists, so the guard branch can never apply."""
+
+    def test_add_brand_new_movie_is_unchanged(self):
+        fake_db = _FakeNewMovieDB()
+        event_calls = []
+
+        result = _run_add(
+            fake_db,
+            params=_base_params(),
+            releases=[],
+            media_dict={'_id': 'new-media-id', 'type': 'movie', 'status': 'active', 'title': 'The Matrix'},
+            event_calls=event_calls,
+        )
+
+        assert result is not False
+        assert fake_db.inserted is not None
+        assert fake_db.inserted['status'] == 'active'
+        # New-movie path never touches db.update/db.delete in add() itself.
+        assert fake_db.updated == []
+        assert fake_db.deleted == []


### PR DESCRIPTION
Part of #14 (Downloaded/review workflow), Phase 3a. Implements the re-add guard that was **deferred from Phase 2** (#171) per the round-3 completeness sweep.

## Problem (data loss on a normal click)

`MovieBase.add()` defaults `force_readd=True`, and the live "Add" buttons (`search_results.html`, `movie_info_modal.html`) call `movie.add` with **no** `force_readd`. So re-adding a movie already in the library at a **completed** status hits the `elif force_readd:` branch — it deletes the completed release(s), nulls `profile_id`/`category_id`/`tags`, resets status to `active`, and re-searches. A single stray "Add" click thus destroys a confirmed copy (or a movie mid-review under `downloaded`). This is **pre-existing and app-wide** — it already harms `done` movies today; Phase 2 never touched `add()`.

## Fix (protect the implicit case, honor the explicit)

- Capture the existing movie's `previous_status` before `m.update(media)` overwrites it.
- New guard branch: an **implicit** re-add (caller did NOT pass `force_readd` via the params/API surface) of a movie at status `done` or `downloaded` is a **no-op** — no release wipe, no reset, no re-search, DB doc untouched. Logged at info.
- An **explicit** `force_readd` (API `force_readd=1`) is still honored — deliberate re-add still wipes + re-searches. The explicit param is the "confirmation."
- Non-completed movies (`active`/`wanted`) and brand-new adds are **unchanged**.

Applies app-wide (protects `done` and `downloaded`), avoiding a confusing done-vs-downloaded asymmetry.

## Tests (6, `tests/unit/test_readd_guard_completed_movies.py`)

Implicit re-add of `done`/`downloaded` → no wipe / no re-search (with `search_on_add=True` so the no-re-search assertion is **discriminating**, proven by a positive-control active-movie test that DOES re-search under the same harness); explicit `force_readd=1` still wipes; explicit `force_readd=0` no-ops; active-movie implicit re-add unchanged; new-movie add unchanged. 1125 unit tests pass, ruff clean, `make verify` green.

## Local-review gate

Through the gate: implementation agent committed locally; **two** `general-purpose` review agents (correctness/caller-impact + tests) confirmed no blocking findings — the caller sweep verified **no live caller** relies on destructive implicit re-add of a completed movie (Add buttons = the target; automation/database pass `force_readd=False`; `release/main.py` only on the new-movie path; legacy `MA.Readd` is dead code retired in #148). Two non-blocking improvements (the params-scope comment + the strengthened no-re-search assertions) folded in and the delta verified before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)