### PR TITLE
feat(workflow): Phase 3b review-action API views (mark-done completes release, mark-failed & re-search, release.failed)

### DIFF
--- a/couchpotato/core/media/_base/media/main.py
+++ b/couchpotato/core/media/_base/media/main.py
@@ -645,6 +645,22 @@ class MediaPlugin(MediaBase):
             log.error('Unexpected error marking media %s done: %s', id, traceback.format_exc())
             return {'success': False, 'error': 'Database error'}
 
+        # Workflow Phase 3 "Mark Done" (specs/DOWNLOADED-REVIEW-WORKFLOW.md):
+        # a movie in the 'downloaded' review gate has a landed-but-not-yet-
+        # finalized release (status 'downloaded'/'snatched'/'seeding'). Now
+        # that the movie itself is confirmed 'done', complete that release
+        # too so it doesn't linger behind the movie. Already-terminal
+        # releases ('done'/'available'/'failed'/'ignored') are left alone.
+        # Best-effort: the movie write already succeeded above, so a failure
+        # here (e.g. release lookup error) must not turn this into an
+        # overall failure response.
+        try:
+            for rel in fireEvent('release.for_media', id, single = True) or []:
+                if rel.get('status') in ('downloaded', 'snatched', 'seeding'):
+                    fireEvent('release.update_status', rel.get('_id'), status = 'done', single = True)
+        except Exception:
+            log.error('Failed completing landed release for media %s after marking done: %s', id, traceback.format_exc())
+
         return {'success': True}
 
     def _utcNow(self):

--- a/couchpotato/core/media/movie/searcher.py
+++ b/couchpotato/core/media/movie/searcher.py
@@ -436,40 +436,65 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
     def markFailedAndResearch(self, media_id):
         """Downloaded/review workflow (specs/DOWNLOADED-REVIEW-WORKFLOW.md)
         "Mark Failed & re-search" action: the user rejected the copy that
-        landed for a movie awaiting review. Mark that landed release
+        landed for a movie awaiting review. Reset the movie back to 'active'
+        so the searcher will consider it again, mark the landed release(s)
         'failed' (distinct from tryNextRelease's 'ignored' -- a review-gate
         rejection is a stronger signal than a routine "try the next
-        candidate"), reset the movie back to 'active' so the searcher will
-        consider it again, and immediately trigger a manual re-search rather
-        than waiting for the next scheduled cycle. The 'failed' release is
-        already excluded from re-grabbing by the has-better-quality check in
-        single() (searcher.py:~191).
+        candidate"), and immediately trigger a manual re-search rather than
+        waiting for the next scheduled cycle. The 'failed' release is already
+        excluded from re-grabbing by the has-better-quality check in single()
+        (searcher.py:~191).
+
+        Ordering matters: the movie CAS reset happens FIRST and only its
+        success unlocks the release-failing step (mirrors
+        MediaPlugin.markDone, which updates the movie before touching
+        releases). If the reset were done last and failed, we'd be left in a
+        half-done state -- the landed release already marked 'failed' but the
+        movie still stuck in 'downloaded' with no landed copy and no
+        auto-recovery.
+
+        Scope guard: this action is spec-scoped to a movie *in the review
+        gate* ('downloaded'). The reset only proceeds when the current status
+        is 'downloaded'; any other status (incl. a confirmed 'done' movie
+        reached via a stale tab / double-submit / direct API call) is a
+        no-op -- so we never reopen and re-search a movie the user already
+        confirmed as finished, nor fail its confirmed release.
         """
         try:
             db = get_db()
 
-            rels = fireEvent('release.for_media', media_id, single = True) or []
-            for rel in rels:
-                if rel.get('status') in ('downloaded', 'snatched', 'seeding', 'done'):
-                    fireEvent('release.update_status', rel.get('_id'), status = 'failed', single = True)
-
             # Read-modify-write on the movie doc -- route through the CAS
             # retry helper (same pattern as MediaPlugin.markDone/markWatched)
             # rather than a bare get()+update() so a lost update can't
-            # silently drop a concurrent change to this media doc.
-            def _reset_active(media):
-                if media.get('status') == 'active':
+            # silently drop a concurrent change to this media doc. The
+            # mutator returns False (-> update_with_retry returns None, no
+            # write) for any non-'downloaded' movie, enforcing the scope
+            # guard atomically against the freshly re-read doc on every retry.
+            def _reset_if_downloaded(media):
+                if media.get('status') != 'downloaded':
                     return False
                 media['status'] = 'active'
+                return media
 
             try:
-                db.update_with_retry(_reset_active, media_id)
+                updated = db.update_with_retry(_reset_if_downloaded, media_id)
             except (RecordNotFound, RecordDeleted, KeyError):
                 log.error('Media not found while resetting to active for re-search: %s', media_id)
                 return False
             except ConflictError:
                 log.warning('Gave up resetting media %s to active after retries due to persistent contention', media_id)
                 return False
+
+            # None => the guard short-circuited (movie was not 'downloaded'):
+            # don't touch releases, don't search, report no-op.
+            if not updated:
+                return False
+
+            # Movie is now 'active'. NOW fail the landed release(s) -- only
+            # reached because the reset actually succeeded.
+            for rel in fireEvent('release.for_media', media_id, single = True) or []:
+                if rel.get('status') in ('downloaded', 'snatched', 'seeding', 'done'):
+                    fireEvent('release.update_status', rel.get('_id'), status = 'failed', single = True)
 
             # Re-fetch the fully-enriched doc (with 'releases' attached) via
             # the same event tryNextRelease uses, so single() sees the

--- a/couchpotato/core/media/movie/searcher.py
+++ b/couchpotato/core/media/movie/searcher.py
@@ -5,8 +5,11 @@ import threading
 import time
 import traceback
 
+from CodernityDB.database import RecordDeleted, RecordNotFound
+
 from couchpotato import get_db
 from couchpotato.api import addApiView
+from couchpotato.core.db.sqlite_adapter import ConflictError
 from couchpotato.core.event import addEvent, fireEvent, fireEventAsync
 from couchpotato.core.helpers.encoding import simplifyString
 from couchpotato.core.helpers.variable import getTitle, possibleTitles, getImdb, getIdentifier, tryInt
@@ -40,6 +43,15 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
 
         addApiView('movie.searcher.try_next', self.tryNextReleaseView, docs = {
             'desc': 'Marks the snatched results as ignored and try the next best release',
+            'params': {
+                'media_id': {'desc': 'The id of the media'},
+            },
+        })
+
+        addApiView('movie.searcher.mark_failed', self.markFailedView, docs = {
+            'desc': "Downloaded/review workflow 'Mark Failed & re-search': marks the "
+                    "movie's landed release as failed, resets the movie to active, and "
+                    "immediately triggers a manual re-search.",
             'params': {
                 'media_id': {'desc': 'The id of the media'},
             },
@@ -411,6 +423,67 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
             return False
         except Exception:
             log.error('Failed searching for next release: %s', traceback.format_exc())
+            return False
+
+    def markFailedView(self, media_id = None, **kwargs):
+
+        success = self.markFailedAndResearch(media_id)
+
+        return {
+            'success': success
+        }
+
+    def markFailedAndResearch(self, media_id):
+        """Downloaded/review workflow (specs/DOWNLOADED-REVIEW-WORKFLOW.md)
+        "Mark Failed & re-search" action: the user rejected the copy that
+        landed for a movie awaiting review. Mark that landed release
+        'failed' (distinct from tryNextRelease's 'ignored' -- a review-gate
+        rejection is a stronger signal than a routine "try the next
+        candidate"), reset the movie back to 'active' so the searcher will
+        consider it again, and immediately trigger a manual re-search rather
+        than waiting for the next scheduled cycle. The 'failed' release is
+        already excluded from re-grabbing by the has-better-quality check in
+        single() (searcher.py:~191).
+        """
+        try:
+            db = get_db()
+
+            rels = fireEvent('release.for_media', media_id, single = True) or []
+            for rel in rels:
+                if rel.get('status') in ('downloaded', 'snatched', 'seeding', 'done'):
+                    fireEvent('release.update_status', rel.get('_id'), status = 'failed', single = True)
+
+            # Read-modify-write on the movie doc -- route through the CAS
+            # retry helper (same pattern as MediaPlugin.markDone/markWatched)
+            # rather than a bare get()+update() so a lost update can't
+            # silently drop a concurrent change to this media doc.
+            def _reset_active(media):
+                if media.get('status') == 'active':
+                    return False
+                media['status'] = 'active'
+
+            try:
+                db.update_with_retry(_reset_active, media_id)
+            except (RecordNotFound, RecordDeleted, KeyError):
+                log.error('Media not found while resetting to active for re-search: %s', media_id)
+                return False
+            except ConflictError:
+                log.warning('Gave up resetting media %s to active after retries due to persistent contention', media_id)
+                return False
+
+            # Re-fetch the fully-enriched doc (with 'releases' attached) via
+            # the same event tryNextRelease uses, so single() sees the
+            # just-updated 'failed' status and 'active' movie status.
+            media = fireEvent('media.get', media_id, single = True)
+            if not media:
+                return False
+
+            log.info('Marked failed release(s) for %s, triggering immediate re-search', getTitle(media))
+            fireEvent('movie.searcher.single', media, manual = True, single = True)
+
+            return True
+        except Exception:
+            log.error('Failed marking media %s failed for re-search: %s', media_id, traceback.format_exc())
             return False
 
     def getSearchTitle(self, media):

--- a/couchpotato/core/plugins/release/main.py
+++ b/couchpotato/core/plugins/release/main.py
@@ -48,6 +48,12 @@ class Release(Plugin):
                 'id': {'type': 'id', 'desc': 'ID of the release object in release-table'}
             }
         })
+        addApiView('release.failed', self.failedView, docs = {
+            'desc': 'Mark a release as failed (Downloaded/review workflow per-release "Mark failed" action)',
+            'params': {
+                'id': {'type': 'id', 'desc': 'ID of the release object in release-table'}
+            }
+        })
 
         addEvent('release.add', self.add)
         addEvent('release.download', self.download)
@@ -266,6 +272,28 @@ class Release(Plugin):
 
             return {
                 'success': True
+            }
+        except Exception:
+            log.error('Failed: %s', traceback.format_exc())
+
+        return {
+            'success': False
+        }
+
+    def failedView(self, id = None, **kwargs):
+        """Downloaded/review workflow per-release "Mark failed" action
+        (specs/DOWNLOADED-REVIEW-WORKFLOW.md): exposes updateStatus() as an
+        API view for a specific bad release/link, mirroring ignore()'s
+        shape. Unlike ignore(), which always reports success once no
+        exception is raised, this surfaces updateStatus()'s own True/False
+        return value -- updateStatus() already swallows a persistent CAS
+        conflict internally and returns False rather than raising, so a
+        contended write is reported as {'success': False} instead of a
+        false positive.
+        """
+        try:
+            return {
+                'success': bool(id) and self.updateStatus(id, 'failed')
             }
         except Exception:
             log.error('Failed: %s', traceback.format_exc())

--- a/specs/DOWNLOADED-REVIEW-WORKFLOW.md
+++ b/specs/DOWNLOADED-REVIEW-WORKFLOW.md
@@ -80,22 +80,44 @@ scanner completion path):
 accordingly, and must treat `downloaded` as a terminal-for-search state (don't
 demote it back to `active`).
 
-### User actions (UI)
+### User actions (backend) — Phase 3b: DONE
+
+The three API views below (all `addApiView`, so reachable at `/api/<route>`)
+are implemented and unit-tested
+(`tests/unit/test_review_actions_backend.py`); wiring the UI buttons + htmx
+endpoints + E2E coverage is the remaining Phase-3 piece (a separate PR).
 
 Per-movie (when in `downloaded`):
-- **Mark Done** → movie `done`, owning release `done`. Terminal.
-- **Mark Failed & re-search** → current release `failed`; movie back to
-  `active`; **immediately** trigger `searcher.single(movie, manual=True)` so it
-  finds the next candidate (the `failed` release is already excluded by
-  `searcher.py:188`).
+- **Mark Done** → `media.done` (existing route,
+  `MediaPlugin.markDone`, `couchpotato/core/media/_base/media/main.py`) —
+  extended so that after the movie CAS-updates to `done`, it also fires
+  `release.update_status(rel_id, status='done')` for each of the movie's
+  releases currently `downloaded`/`snatched`/`seeding` (the landed-but-not-
+  yet-finalized copy). Already-`done`/`available`/`failed`/`ignored`
+  releases, and the no-release case, are left alone; the release-completion
+  step is best-effort and never turns an already-successful movie update
+  into a failure response.
+- **Mark Failed & re-search** → new `movie.searcher.mark_failed` route
+  (`MovieSearcher.markFailedView` / `.markFailedAndResearch`,
+  `couchpotato/core/media/movie/searcher.py`). For each of the movie's
+  releases currently `downloaded`/`snatched`/`seeding`/`done`, fires
+  `release.update_status(rel_id, status='failed')` (a stronger signal than
+  the pre-existing `movie.searcher.try_next`'s `'ignored'`); resets the
+  movie to `active` via the CAS `update_with_retry` helper (same pattern as
+  `markDone`/`markWatched`); then immediately fires
+  `fireEvent('movie.searcher.single', media, manual=True)` so the searcher
+  finds the next candidate right away rather than waiting for the next
+  cycle (the `failed` release is already excluded by the has-better-quality
+  check at `searcher.py:~191`).
 
 Per-release / link (in the releases panel):
-- **Skip / Ignore link** → `release.update_status(id, 'ignored')` (already
-  excluded from future grabs).
-- **Mark failed** → `release.update_status(id, 'failed')`.
-
-These call existing `release.update_status`; the work is exposing buttons +
-htmx endpoints + wiring the immediate re-search.
+- **Skip / Ignore link** → existing `release.ignore` route
+  (`release.update_status(id, 'ignored')`, already excluded from future
+  grabs) — unchanged.
+- **Mark failed** → new `release.failed` route (`Release.failedView`,
+  `couchpotato/core/plugins/release/main.py`), calling
+  `self.updateStatus(id, 'failed')` and mirroring `release.ignore`'s
+  request/response shape.
 
 ### Per-profile setting
 
@@ -248,6 +270,13 @@ feature's completion-path change rather than a separate reconstruction.
      wanted/snatched/late behavior is unchanged.
 3. **UI actions:** Mark Done / Mark Failed&re-search (movie); Skip/Ignore &
    Mark-failed (release); immediate re-search on Fail. Tests + E2E.
+   **Phase 3b (backend API views) is DONE** — see "User actions (backend)"
+   above for the three routes (`media.done` extended, new
+   `movie.searcher.mark_failed`, new `release.failed`) and
+   `tests/unit/test_review_actions_backend.py`. **Still remaining for this
+   phase:** the UI buttons + htmx wiring that call these routes, and E2E
+   coverage — a separate PR.
+
    **Re-add guard — IMPLEMENTED (Phase 3a):** `MovieBase.add()`
    (`couchpotato/core/media/movie/_base/main.py`) defaults `force_readd=True`,
    and the live "Add" buttons (`ui/templates/partials/search_results.html`,

--- a/tests/unit/test_review_actions_backend.py
+++ b/tests/unit/test_review_actions_backend.py
@@ -142,21 +142,46 @@ class TestMarkDoneCompletesLandedRelease:
 
 class TestMarkFailedAndResearch:
 
-    def _run(self, media_doc, releases, media_get_result=None, update_with_retry_result='write'):
+    def _run(self, media_doc, releases, update_with_retry_result='write', media_get_returns_none=False):
+        """Faithful harness for the movie-status CAS reset.
+
+        `FakeDB.update_with_retry` actually invokes the mutator on the stored
+        movie doc and *persists* the result (matching the real
+        SQLiteAdapter.update_with_retry contract: returns the updated doc on a
+        write, or None if the mutator returns False and no write happens).
+        This is deliberate: an earlier version discarded the mutated doc and
+        the production code re-read a hardcoded `media.get` fixture, which
+        meant gutting the reset mutator to a permanent no-op still passed --
+        a tautology. Persisting here lets a test assert the movie actually
+        became 'active', and lets a reverted guard/reset be *caught* (see the
+        revert-proof notes on each test).
+
+        Returns the FakeDB instance too so tests can inspect the persisted
+        movie doc (`fake_db.stored`).
+        """
         searcher = MovieSearcher.__new__(MovieSearcher)
 
         release_status_calls = []
         single_search_calls = []
 
         class FakeDB:
+            def __init__(self):
+                self.stored = dict(media_doc)
+
             def update_with_retry(self, mutator, doc_id, retries=3):
                 assert doc_id == media_doc['_id']
-                doc = dict(media_doc)
+                doc = dict(self.stored)
                 if mutator(doc) is False:
+                    # No write -- movie left exactly as stored.
                     return None
                 if update_with_retry_result == 'conflict':
+                    # Mutator wanted to write, but the CAS lost every retry;
+                    # nothing is persisted.
                     raise ConflictError(doc_id)
+                self.stored = doc
                 return doc
+
+        fake_db = FakeDB()
 
         def fake_fire_event(event, *args, **kwargs):
             if event == 'release.for_media':
@@ -166,19 +191,23 @@ class TestMarkFailedAndResearch:
                 release_status_calls.append((args[0], kwargs.get('status')))
                 return True
             if event == 'media.get':
-                return media_get_result
+                if media_get_returns_none:
+                    return None
+                enriched = dict(fake_db.stored)
+                enriched['releases'] = [dict(r) for r in releases]
+                return enriched
             if event == 'movie.searcher.single':
                 single_search_calls.append((args[0], kwargs.get('manual')))
                 return None
             raise AssertionError('Unexpected fireEvent call: %r' % (event,))
 
         with (
-            patch('couchpotato.core.media.movie.searcher.get_db', return_value=FakeDB()),
+            patch('couchpotato.core.media.movie.searcher.get_db', return_value=fake_db),
             patch('couchpotato.core.media.movie.searcher.fireEvent', side_effect=fake_fire_event),
         ):
             result = searcher.markFailedAndResearch(media_doc['_id'])
 
-        return result, release_status_calls, single_search_calls
+        return result, release_status_calls, single_search_calls, fake_db
 
     def test_landed_release_marked_failed_not_ignored(self):
         """BLOCKING distinction from the pre-existing try_next/tryNextRelease
@@ -186,28 +215,28 @@ class TestMarkFailedAndResearch:
         bad copy to be marked 'failed' here instead."""
         movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
         releases = [{'_id': 'release-1', 'status': 'downloaded'}]
-        refreshed_movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1', 'releases': releases}
 
-        result, release_status_calls, single_search_calls = self._run(
-            movie, releases, media_get_result=refreshed_movie,
-        )
+        result, release_status_calls, _, _ = self._run(movie, releases)
 
         assert result is True
         assert release_status_calls == [('release-1', 'failed')]
 
-    def test_movie_reset_to_active_and_research_triggered_exactly_once(self):
+    def test_movie_persisted_active_and_research_triggered_exactly_once(self):
+        """Locks the reset itself (BLOCKING 3): the persisted movie doc must
+        actually become 'active', and the enriched doc handed to the
+        re-search must reflect that. Revert-proof: gut `_reset_if_downloaded`
+        to a permanent no-op (or drop the `media['status'] = 'active'` line)
+        and `fake_db.stored['status']` stays 'downloaded' -> this fails."""
         movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
         releases = [{'_id': 'release-1', 'status': 'downloaded'}]
-        refreshed_movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1', 'releases': releases}
 
-        result, _, single_search_calls = self._run(
-            movie, releases, media_get_result=refreshed_movie,
-        )
+        result, _, single_search_calls, fake_db = self._run(movie, releases)
 
         assert result is True
+        assert fake_db.stored['status'] == 'active', "movie must be persisted active"
         assert len(single_search_calls) == 1
         fired_media, fired_manual = single_search_calls[0]
-        assert fired_media == refreshed_movie
+        assert fired_media['status'] == 'active', "re-search must see the reset movie"
         assert fired_manual is True
 
     def test_snatched_seeding_and_done_landed_releases_are_all_marked_failed(self):
@@ -217,9 +246,8 @@ class TestMarkFailedAndResearch:
             {'_id': 'release-seeding', 'status': 'seeding'},
             {'_id': 'release-done', 'status': 'done'},
         ]
-        refreshed_movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1'}
 
-        _, release_status_calls, _ = self._run(movie, releases, media_get_result=refreshed_movie)
+        _, release_status_calls, _, _ = self._run(movie, releases)
 
         assert ('release-snatched', 'failed') in release_status_calls
         assert ('release-seeding', 'failed') in release_status_calls
@@ -232,32 +260,97 @@ class TestMarkFailedAndResearch:
             {'_id': 'release-available', 'status': 'available'},
             {'_id': 'release-ignored', 'status': 'ignored'},
         ]
-        refreshed_movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1'}
 
-        _, release_status_calls, _ = self._run(movie, releases, media_get_result=refreshed_movie)
+        _, release_status_calls, _, _ = self._run(movie, releases)
 
         assert release_status_calls == []
 
-    def test_conflict_resetting_movie_status_returns_false_without_searching(self):
-        """CAS conflict on the movie-status write must not crash, must
-        report failure, and must not kick off a search against a movie
-        whose status we couldn't confirm."""
+    def test_zero_releases_still_resets_and_researches(self):
+        """Parity case the reviewer flagged: a 'downloaded' movie with no
+        release rows must still be reset to 'active' and re-searched (the
+        release-failing loop is simply a no-op). Revert-proof: if the reset
+        were gated behind 'has a landed release', this movie would never
+        flip to active."""
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
+
+        result, release_status_calls, single_search_calls, fake_db = self._run(movie, releases=[])
+
+        assert result is True
+        assert fake_db.stored['status'] == 'active'
+        assert release_status_calls == []
+        assert len(single_search_calls) == 1
+
+    def test_done_movie_is_a_noop_and_never_reopens(self):
+        """BLOCKING 2 lock: the action is spec-scoped to a 'downloaded'
+        (review-gated) movie. A stale-tab / double-submit / direct-API
+        mark_failed on an already-confirmed 'done' movie must be a hard
+        no-op -- its confirmed 'done' release must NOT be flipped to
+        'failed', its status must NOT be rewritten, and NO re-search may
+        fire (its profile_id is still set, so single()'s gate wouldn't block
+        it). Revert-proof: change the guard to accept any status (e.g.
+        `if media.get('status') == 'active'`) and this movie's release gets
+        failed + status flips to active + search fires -> every assertion
+        here breaks."""
+        movie = {'_id': 'movie-1', 'status': 'done', 'profile_id': 'profile-1'}
+        releases = [{'_id': 'release-1', 'status': 'done'}]
+
+        result, release_status_calls, single_search_calls, fake_db = self._run(movie, releases)
+
+        assert result is False
+        assert release_status_calls == [], "a confirmed release must not be failed"
+        assert single_search_calls == [], "a confirmed movie must not be re-searched"
+        assert fake_db.stored['status'] == 'done', "status must be untouched"
+
+    def test_active_movie_is_a_noop(self):
+        """Guard also covers an already-'active' movie (nothing to reopen):
+        no release change, no search, no write. Revert-proof alongside the
+        'done' case -- with the old `== 'active' -> no-op, else flip` mutator
+        this specific movie happened to be a no-op too, so on its own it
+        wouldn't catch a broken guard; it's the 'done' test that does. Kept
+        for completeness of the guard's status matrix."""
+        movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1'}
+        releases = [{'_id': 'release-1', 'status': 'snatched'}]
+
+        result, release_status_calls, single_search_calls, fake_db = self._run(movie, releases)
+
+        assert result is False
+        assert release_status_calls == []
+        assert single_search_calls == []
+        assert fake_db.stored['status'] == 'active'
+
+    def test_reset_failure_prevents_any_release_from_being_failed(self):
+        """BLOCKING 1 lock (ordering / no half-done state): when the movie
+        CAS reset can't land (persistent ConflictError), NOTHING downstream
+        may run -- no release may be marked 'failed' and no re-search may
+        fire. Otherwise the movie is stuck 'downloaded' with its only landed
+        release already 'failed' and no auto-recovery. Revert-proof: move the
+        release-failing loop back *before* the reset and `release_status_calls`
+        becomes non-empty here -> this fails."""
         movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
         releases = [{'_id': 'release-1', 'status': 'downloaded'}]
 
-        result, _, single_search_calls = self._run(
+        result, release_status_calls, single_search_calls, fake_db = self._run(
             movie, releases, update_with_retry_result='conflict',
         )
 
         assert result is False
+        assert release_status_calls == [], "no release may be failed if the reset didn't land"
         assert single_search_calls == []
+        assert fake_db.stored['status'] == 'downloaded', "movie must stay in the review gate"
 
-    def test_media_not_found_returns_false_without_searching(self):
+    def test_media_not_found_after_reset_returns_false_without_searching(self):
+        """If the enriched re-fetch comes back empty (movie deleted between
+        the reset and the re-fetch), report failure and don't fire a search
+        against a missing movie. The reset already landed and the release was
+        already failed by this point -- that's an acceptable degraded state
+        (movie is 'active', the next cron picks it up), NOT the half-done
+        state BLOCKING 1 guards against (there the movie was left
+        'downloaded')."""
         movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
         releases = [{'_id': 'release-1', 'status': 'downloaded'}]
 
-        result, _, single_search_calls = self._run(
-            movie, releases, media_get_result=None,
+        result, _, single_search_calls, _ = self._run(
+            movie, releases, media_get_returns_none=True,
         )
 
         assert result is False

--- a/tests/unit/test_review_actions_backend.py
+++ b/tests/unit/test_review_actions_backend.py
@@ -1,0 +1,330 @@
+"""Tests for workflow Phase 3b (specs/DOWNLOADED-REVIEW-WORKFLOW.md): the
+backend API views a Phase-3 UI will call for the "Downloaded / review" gate's
+per-movie and per-release user actions.
+
+Three routes are covered:
+
+- `media.done` (`MediaPlugin.markDone`, couchpotato/core/media/_base/media/main.py)
+  extended so that, in addition to setting the movie to 'done', it also
+  completes the movie's landed release (the copy the user is confirming).
+- `movie.searcher.mark_failed` (new; `MovieSearcher.markFailedView` /
+  `.markFailedAndResearch`, couchpotato/core/media/movie/searcher.py) --
+  marks the movie's landed release 'failed', resets the movie to 'active',
+  and immediately triggers a manual re-search.
+- `release.failed` (new; `Release.failedView`, couchpotato/core/plugins/release/main.py)
+  -- a per-release "mark failed" action, mirroring the existing
+  `release.ignore` view's shape.
+
+Harness style mirrors test_downloaded_review_workflow_phase2.py: real plugin
+methods exercised via `Plugin.__new__(Plugin)` (skips `__init__`'s event/api
+registration side effects), with hand-rolled FakeDB objects and a
+`fake_fire_event` dispatcher that only answers the exact events the method
+under test is expected to call -- any unexpected event raises immediately so
+a wiring mistake surfaces as a hard test failure rather than a silent no-op.
+"""
+from pathlib import Path
+from unittest.mock import patch
+
+from couchpotato.core.db.sqlite_adapter import ConflictError
+from couchpotato.core.media._base.media.main import MediaPlugin
+from couchpotato.core.media.movie.searcher import MovieSearcher
+from couchpotato.core.plugins.release.main import Release
+
+
+SEARCHER_SOURCE = Path(__file__).resolve().parents[2] / 'couchpotato' / 'core' / 'media' / 'movie' / 'searcher.py'
+RELEASE_SOURCE = Path(__file__).resolve().parents[2] / 'couchpotato' / 'core' / 'plugins' / 'release' / 'main.py'
+
+
+# --- MediaPlugin.markDone(): also completes the movie's landed release -----
+
+class TestMarkDoneCompletesLandedRelease:
+
+    def _run_mark_done(self, media_doc, releases, update_with_retry_result='write'):
+        plugin = MediaPlugin.__new__(MediaPlugin)
+
+        release_status_calls = []
+
+        class FakeDB:
+            def update_with_retry(self, mutator, doc_id, retries=3):
+                assert doc_id == media_doc['_id']
+                doc = dict(media_doc)
+                if mutator(doc) is False:
+                    return None
+                if update_with_retry_result == 'conflict':
+                    raise ConflictError(doc_id)
+                return doc
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'release.for_media':
+                assert args[0] == media_doc['_id']
+                return [dict(r) for r in releases]
+            if event == 'release.update_status':
+                release_status_calls.append((args[0], kwargs.get('status')))
+                return True
+            raise AssertionError('Unexpected fireEvent call: %r' % (event,))
+
+        with (
+            patch('couchpotato.core.media._base.media.main.get_db', return_value=FakeDB()),
+            patch('couchpotato.core.media._base.media.main.fireEvent', side_effect=fake_fire_event),
+        ):
+            result = plugin.markDone(media_doc['_id'])
+
+        return result, release_status_calls
+
+    def test_downloaded_release_is_completed_alongside_the_movie(self):
+        movie = {'_id': 'movie-1', 'status': 'downloaded'}
+        releases = [{'_id': 'release-1', 'status': 'downloaded'}]
+
+        result, release_status_calls = self._run_mark_done(movie, releases)
+
+        assert result == {'success': True}
+        assert release_status_calls == [('release-1', 'done')]
+
+    def test_snatched_and_seeding_releases_are_also_completed(self):
+        """Any 'landed but not yet finalized' status counts, not just
+        'downloaded' -- matches the spec's status list verbatim."""
+        movie = {'_id': 'movie-1', 'status': 'downloaded'}
+        releases = [
+            {'_id': 'release-snatched', 'status': 'snatched'},
+            {'_id': 'release-seeding', 'status': 'seeding'},
+        ]
+
+        _, release_status_calls = self._run_mark_done(movie, releases)
+
+        assert ('release-snatched', 'done') in release_status_calls
+        assert ('release-seeding', 'done') in release_status_calls
+        assert len(release_status_calls) == 2
+
+    def test_available_release_is_left_untouched(self):
+        """An 'available' candidate release (never snatched) is not the
+        landed copy -- it must not be silently marked done."""
+        movie = {'_id': 'movie-1', 'status': 'downloaded'}
+        releases = [{'_id': 'release-available', 'status': 'available'}]
+
+        _, release_status_calls = self._run_mark_done(movie, releases)
+
+        assert release_status_calls == []
+
+    def test_already_done_ignored_and_failed_releases_are_left_alone(self):
+        movie = {'_id': 'movie-1', 'status': 'downloaded'}
+        releases = [
+            {'_id': 'release-done', 'status': 'done'},
+            {'_id': 'release-ignored', 'status': 'ignored'},
+            {'_id': 'release-failed', 'status': 'failed'},
+        ]
+
+        _, release_status_calls = self._run_mark_done(movie, releases)
+
+        assert release_status_calls == []
+
+    def test_no_release_case_still_marks_movie_done(self):
+        movie = {'_id': 'movie-1', 'status': 'downloaded'}
+
+        result, release_status_calls = self._run_mark_done(movie, releases=[])
+
+        assert result == {'success': True}
+        assert release_status_calls == []
+
+    def test_conflict_on_movie_update_returns_failure_without_touching_releases(self):
+        """The pre-existing ConflictError -> {'success': False} contract
+        must be preserved, and since the movie write never landed, the
+        release-completion step must not run at all."""
+        movie = {'_id': 'movie-1', 'status': 'downloaded'}
+        releases = [{'_id': 'release-1', 'status': 'downloaded'}]
+
+        result, release_status_calls = self._run_mark_done(movie, releases, update_with_retry_result='conflict')
+
+        assert result == {'success': False, 'error': 'Database busy, please retry'}
+        assert release_status_calls == []
+
+
+# --- MovieSearcher: "Mark Failed & re-search" -------------------------------
+
+class TestMarkFailedAndResearch:
+
+    def _run(self, media_doc, releases, media_get_result=None, update_with_retry_result='write'):
+        searcher = MovieSearcher.__new__(MovieSearcher)
+
+        release_status_calls = []
+        single_search_calls = []
+
+        class FakeDB:
+            def update_with_retry(self, mutator, doc_id, retries=3):
+                assert doc_id == media_doc['_id']
+                doc = dict(media_doc)
+                if mutator(doc) is False:
+                    return None
+                if update_with_retry_result == 'conflict':
+                    raise ConflictError(doc_id)
+                return doc
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'release.for_media':
+                assert args[0] == media_doc['_id']
+                return [dict(r) for r in releases]
+            if event == 'release.update_status':
+                release_status_calls.append((args[0], kwargs.get('status')))
+                return True
+            if event == 'media.get':
+                return media_get_result
+            if event == 'movie.searcher.single':
+                single_search_calls.append((args[0], kwargs.get('manual')))
+                return None
+            raise AssertionError('Unexpected fireEvent call: %r' % (event,))
+
+        with (
+            patch('couchpotato.core.media.movie.searcher.get_db', return_value=FakeDB()),
+            patch('couchpotato.core.media.movie.searcher.fireEvent', side_effect=fake_fire_event),
+        ):
+            result = searcher.markFailedAndResearch(media_doc['_id'])
+
+        return result, release_status_calls, single_search_calls
+
+    def test_landed_release_marked_failed_not_ignored(self):
+        """BLOCKING distinction from the pre-existing try_next/tryNextRelease
+        view, which marks the old release 'ignored'. The spec calls for the
+        bad copy to be marked 'failed' here instead."""
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
+        releases = [{'_id': 'release-1', 'status': 'downloaded'}]
+        refreshed_movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1', 'releases': releases}
+
+        result, release_status_calls, single_search_calls = self._run(
+            movie, releases, media_get_result=refreshed_movie,
+        )
+
+        assert result is True
+        assert release_status_calls == [('release-1', 'failed')]
+
+    def test_movie_reset_to_active_and_research_triggered_exactly_once(self):
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
+        releases = [{'_id': 'release-1', 'status': 'downloaded'}]
+        refreshed_movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1', 'releases': releases}
+
+        result, _, single_search_calls = self._run(
+            movie, releases, media_get_result=refreshed_movie,
+        )
+
+        assert result is True
+        assert len(single_search_calls) == 1
+        fired_media, fired_manual = single_search_calls[0]
+        assert fired_media == refreshed_movie
+        assert fired_manual is True
+
+    def test_snatched_seeding_and_done_landed_releases_are_all_marked_failed(self):
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
+        releases = [
+            {'_id': 'release-snatched', 'status': 'snatched'},
+            {'_id': 'release-seeding', 'status': 'seeding'},
+            {'_id': 'release-done', 'status': 'done'},
+        ]
+        refreshed_movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1'}
+
+        _, release_status_calls, _ = self._run(movie, releases, media_get_result=refreshed_movie)
+
+        assert ('release-snatched', 'failed') in release_status_calls
+        assert ('release-seeding', 'failed') in release_status_calls
+        assert ('release-done', 'failed') in release_status_calls
+        assert len(release_status_calls) == 3
+
+    def test_available_and_ignored_releases_are_not_touched(self):
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
+        releases = [
+            {'_id': 'release-available', 'status': 'available'},
+            {'_id': 'release-ignored', 'status': 'ignored'},
+        ]
+        refreshed_movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1'}
+
+        _, release_status_calls, _ = self._run(movie, releases, media_get_result=refreshed_movie)
+
+        assert release_status_calls == []
+
+    def test_conflict_resetting_movie_status_returns_false_without_searching(self):
+        """CAS conflict on the movie-status write must not crash, must
+        report failure, and must not kick off a search against a movie
+        whose status we couldn't confirm."""
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
+        releases = [{'_id': 'release-1', 'status': 'downloaded'}]
+
+        result, _, single_search_calls = self._run(
+            movie, releases, update_with_retry_result='conflict',
+        )
+
+        assert result is False
+        assert single_search_calls == []
+
+    def test_media_not_found_returns_false_without_searching(self):
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1'}
+        releases = [{'_id': 'release-1', 'status': 'downloaded'}]
+
+        result, _, single_search_calls = self._run(
+            movie, releases, media_get_result=None,
+        )
+
+        assert result is False
+        assert single_search_calls == []
+
+    def test_view_wraps_result_in_success_dict(self):
+        searcher = MovieSearcher.__new__(MovieSearcher)
+
+        with patch.object(searcher, 'markFailedAndResearch', return_value=True) as mocked:
+            result = searcher.markFailedView(media_id='movie-1')
+
+        mocked.assert_called_once_with('movie-1')
+        assert result == {'success': True}
+
+    def test_view_reports_failure(self):
+        searcher = MovieSearcher.__new__(MovieSearcher)
+
+        with patch.object(searcher, 'markFailedAndResearch', return_value=False):
+            result = searcher.markFailedView(media_id='movie-1')
+
+        assert result == {'success': False}
+
+
+# --- Release.failedView(): per-release "Mark failed" ------------------------
+
+class TestReleaseFailedView:
+
+    def test_calls_update_status_with_failed(self):
+        plugin = Release.__new__(Release)
+
+        with patch.object(plugin, 'updateStatus', return_value=True) as mocked:
+            result = plugin.failedView(id='release-1')
+
+        mocked.assert_called_once_with('release-1', 'failed')
+        assert result == {'success': True}
+
+    def test_reports_failure_when_update_status_fails(self):
+        """Covers the CAS/conflict path: Release.updateStatus already
+        swallows ConflictError internally and returns False rather than
+        raising, so failedView must surface that as {'success': False}
+        instead of crashing or reporting a false success."""
+        plugin = Release.__new__(Release)
+
+        with patch.object(plugin, 'updateStatus', return_value=False):
+            result = plugin.failedView(id='release-1')
+
+        assert result == {'success': False}
+
+    def test_missing_id_reports_failure_without_calling_update_status(self):
+        plugin = Release.__new__(Release)
+
+        with patch.object(plugin, 'updateStatus') as mocked:
+            result = plugin.failedView()
+
+        mocked.assert_not_called()
+        assert result == {'success': False}
+
+
+# --- Reachability: routes must be registered via addApiView so /api/<route>
+# doesn't 404 for the frontend PR that wires up the buttons. -----------------
+
+class TestApiViewsRegistered:
+
+    def test_movie_searcher_mark_failed_route_registered(self):
+        source = SEARCHER_SOURCE.read_text()
+        assert "addApiView('movie.searcher.mark_failed'" in source
+
+    def test_release_failed_route_registered(self):
+        source = RELEASE_SOURCE.read_text()
+        assert "addApiView('release.failed'" in source


### PR DESCRIPTION
Part of #14 (Downloaded/review workflow), **Phase 3b — backend API views** the review UI will call. UI buttons + E2E are the next PR (3c).

## Routes

1. **`media.done`** (extended) — after CAS-setting movie → `done`, also completes the owning release(s) (status `downloaded`/`snatched`/`seeding` → `done`). Leaves `available`/`done`/`failed`/`ignored` and the no-release case alone. Preserves the `ConflictError` → `{'success': False}` contract.
2. **`movie.searcher.mark_failed`** (new) — the review-gate "Mark Failed & re-search": **movie → `active` (guarded CAS) first**, then the landed release(s) → `failed` (not `ignored` — the failed copy is excluded from re-grab), then an enriched re-fetch and one `movie.searcher.single(manual=True)` (the `downloaded` gate is bypassed when `manual`). **Guarded to `status=='downloaded'` only** — a no-op on any other status.
3. **`release.failed`** (new API view) — `release.update_status(id,'failed')` (the underlying method is event-only, unreachable from `/api/`); propagates the `False`-on-conflict return.

## Local-review gate (three rounds — the gate front-loaded real bugs)

The first review round on `mark_failed` caught **two blocking correctness bugs** + **one blocking test gap**, all fixed before this push:
- **Ordering:** it marked the release `failed` *before* the movie CAS reset — a reset failure left a half-done stuck state. Fixed: reset first, releases only on success.
- **No status precondition:** it flipped *any* status to `active`, so a stale-tab/double-submit call would reopen a Terminal `done` movie and fail its confirmed release. Fixed: guard on `status=='downloaded'`.
- **Tautological test:** the `FakeDB` discarded the mutated doc, so gutting the reset left all tests green. Fixed the harness to apply+persist the mutator; the reset is now revert-proven.

A second, independent review round confirmed the fixes correct/complete and the locks real (guard, ordering, and reset each fail a targeted test on revert). 1147 unit tests pass, ruff clean, `make verify` green.

## Constraints

CAS-safe throughout (no raw get→mutate→update races); CodernityDB untouched; no Docker-only assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)