### PR TITLE
feat(workflow): Phase 3c review-action UI (Mark Done / Mark Failed & re-search / per-release Mark failed)

### DIFF
--- a/couchpotato/ui/templates/partials/movie_detail.html
+++ b/couchpotato/ui/templates/partials/movie_detail.html
@@ -123,19 +123,41 @@
       {% endif %}
 
       <!-- Actions -->
-      <div class="flex flex-wrap gap-2 mt-6" x-data="{ refreshing: false, markingDone: false, deleting: false }">
+      <div class="flex flex-wrap gap-2 mt-6" x-data="{ refreshing: false, markingDone: false, deleting: false, markingReviewDone: false, markingReviewFailed: false }">
         <button @click="refreshing = true; fetch(CP.apiBase + '/movie.refresh/?id={{ movie_id }}').then(() => { refreshing = false; location.reload(); })"
                 class="px-3.5 py-1.5 bg-cp-accent/10 text-cp-accent hover:bg-cp-accent/20 font-medium rounded-md text-xs transition-colors disabled:opacity-50"
                 :disabled="refreshing">
           <span x-show="!refreshing">Refresh</span>
           <span x-show="refreshing">Refreshing…</span>
         </button>
-        {% if status != 'done' %}
+        {% if status != 'done' and status != 'downloaded' %}
         <button @click="markingDone = true; fetch(CP.apiBase + '/media.done/?id={{ movie_id }}').then(r => r.json()).then(d => { if(d.success) { location.reload(); } else { markingDone = false; } }).catch(() => { markingDone = false; })"
                 class="px-3.5 py-1.5 bg-cp-success/10 text-cp-success hover:bg-cp-success/20 font-medium rounded-md text-xs transition-colors disabled:opacity-50"
                 :disabled="markingDone">
           <span x-show="!markingDone">Mark as Done</span>
           <span x-show="markingDone">Marking…</span>
+        </button>
+        {% endif %}
+        {% if status == 'downloaded' %}
+        <!-- Downloaded/review workflow (specs/DOWNLOADED-REVIEW-WORKFLOW.md phase 3c):
+             non-destructive confirmation that the landed copy is good. Calls the
+             existing media.done route (movie -> done, owning release -> done). -->
+        <button @click="markingReviewDone = true; fetch(CP.apiBase + '/media.done/?id={{ movie_id }}').then(r => r.json()).then(d => { if(d.success) { toast('Marked done', 'success'); setTimeout(() => location.reload(), 900); } else { markingReviewDone = false; toast('Failed to mark as done', 'error'); } }).catch(() => { markingReviewDone = false; toast('Failed to mark as done', 'error'); })"
+                class="px-3.5 py-1.5 bg-cp-success/10 text-cp-success hover:bg-cp-success/20 font-medium rounded-md text-xs transition-colors disabled:opacity-50 inline-flex items-center gap-1.5"
+                :disabled="markingReviewDone">
+          <svg aria-hidden="true" class="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
+          <span x-show="!markingReviewDone">Mark Done</span>
+          <span x-show="markingReviewDone">Marking…</span>
+        </button>
+        <!-- Destructive: discards the landed copy and re-searches immediately, so
+             confirm() first (mirrors the Delete button's confirm below). Calls
+             movie.searcher.mark_failed (param media_id, per searcher.py:428). -->
+        <button @click="if(confirm('Mark this download as failed and search for another copy? This discards the current copy.')) { markingReviewFailed = true; fetch(CP.apiBase + '/movie.searcher.mark_failed/?media_id={{ movie_id }}').then(r => r.json()).then(d => { if(d.success) { toast('Marked failed — searching for another copy', 'success'); setTimeout(() => location.reload(), 900); } else { markingReviewFailed = false; toast('Failed to mark as failed', 'error'); } }).catch(() => { markingReviewFailed = false; toast('Failed to mark as failed', 'error'); }); }"
+                class="px-3.5 py-1.5 bg-cp-danger/10 text-cp-danger hover:bg-cp-danger/15 font-medium rounded-md text-xs transition-colors disabled:opacity-50 inline-flex items-center gap-1.5"
+                :disabled="markingReviewFailed">
+          <svg aria-hidden="true" class="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
+          <span x-show="!markingReviewFailed">Mark Failed &amp; Re-search</span>
+          <span x-show="markingReviewFailed">Re-searching…</span>
         </button>
         {% endif %}
         {% if imdb_id %}
@@ -271,7 +293,8 @@
               {% endif %}
             </td>
             <td class="px-4 py-2.5 text-cp-muted font-light">{{ r_age|int }}d</td>
-            <td class="px-4 py-2.5 space-x-1">
+            <td class="px-4 py-2.5">
+              <div class="flex flex-wrap items-center gap-1">
               {% if r.get('status', '') == 'available' %}
               <button @click="downloadRelease('{{ r_id }}')"
                       class="px-2 py-1 rounded text-[9px] font-medium bg-cp-success/10 text-cp-success hover:bg-cp-success/20 transition-colors disabled:opacity-50"
@@ -296,7 +319,23 @@
                 <span x-show="!ignoring['{{ r_id }}']">↩ Un-skip</span>
                 <span x-show="ignoring['{{ r_id }}']">...</span>
               </button>
+              {% elif r.get('status', '') == 'downloaded' %}
+              <!-- Downloaded/review workflow (specs/DOWNLOADED-REVIEW-WORKFLOW.md phase 3c):
+                   per-release rejection of the landed copy, distinct from the
+                   movie-level Mark Failed action above. Calls release.failed
+                   (param id, per release/main.py:283) directly -- unlike
+                   ignore(), this is a one-way transition (no toggle-back), so it
+                   is gated behind confirm() like the movie-level action. -->
+              <button @click="if(confirm('Mark this release as failed? This excludes it from future searches and cannot be undone.')) { markingReleaseFailed['{{ r_id }}'] = true; fetch(CP.apiBase + '/release.failed/?id={{ r_id }}').then(r => r.json()).then(d => { if(d.success) { toast('Release marked failed', 'success'); setTimeout(() => location.reload(), 900); } else { markingReleaseFailed['{{ r_id }}'] = false; toast('Failed to mark release as failed', 'error'); } }).catch(() => { markingReleaseFailed['{{ r_id }}'] = false; toast('Failed to mark release as failed', 'error'); }); }"
+                      class="px-2 py-1 rounded text-[9px] font-medium bg-cp-danger/10 text-cp-danger hover:bg-cp-danger/20 transition-colors disabled:opacity-50 inline-flex items-center gap-1"
+                      :disabled="markingReleaseFailed['{{ r_id }}']"
+                      title="Mark this release as failed (exclude it from future searches)">
+                <svg aria-hidden="true" class="w-3 h-3 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
+                <span x-show="!markingReleaseFailed['{{ r_id }}']">Mark failed</span>
+                <span x-show="markingReleaseFailed['{{ r_id }}']">...</span>
+              </button>
               {% endif %}
+              </div>
             </td>
           </tr>
           {% endfor %}
@@ -363,7 +402,8 @@ function releaseDownloader() {
     downloading: {},
     downloadErrors: {},
     ignoring: {},
-    
+    markingReleaseFailed: {},
+
     init() {},
     
     async downloadRelease(releaseId) {

--- a/specs/DOWNLOADED-REVIEW-WORKFLOW.md
+++ b/specs/DOWNLOADED-REVIEW-WORKFLOW.md
@@ -80,12 +80,50 @@ scanner completion path):
 accordingly, and must treat `downloaded` as a terminal-for-search state (don't
 demote it back to `active`).
 
-### User actions (backend) — Phase 3b: DONE
+### User actions (backend) — Phase 3b: DONE. UI — Phase 3c: DONE
 
 The three API views below (all `addApiView`, so reachable at `/api/<route>`)
 are implemented and unit-tested
-(`tests/unit/test_review_actions_backend.py`); wiring the UI buttons + htmx
-endpoints + E2E coverage is the remaining Phase-3 piece (a separate PR).
+(`tests/unit/test_review_actions_backend.py`). Phase 3c wires the UI buttons
+that call them (`couchpotato/ui/templates/partials/movie_detail.html`):
+
+- **Mark Done** (movie, shown only when `status == 'downloaded'`) — single
+  click, `fetch('/media.done/?id=<movie_id>')`, toasts "Marked done" and
+  reloads on success. Non-destructive, no confirmation.
+- **Mark Failed & Re-search** (movie, shown only when `status ==
+  'downloaded'`) — `confirm()`-gated (destructive: discards the landed
+  copy), then `fetch('/movie.searcher.mark_failed/?media_id=<movie_id>')`,
+  toasts "Marked failed — searching for another copy" and reloads on
+  success.
+- **Mark failed** (per release, shown only for a release row with `status ==
+  'downloaded'`) — `confirm()`-gated, then `fetch('/release.failed/?id=<release_id>')`,
+  toasts and reloads on success. Sits alongside the pre-existing Skip/Ignore
+  button (`release.ignore`, reused unchanged — it already handles the "hide a
+  bad release from future searches" case).
+
+All three follow the file's existing Alpine.js `fetch().then(r => r.json())`
+pattern (mirroring the pre-existing "Mark as Done"/"Delete" buttons), use
+inline Heroicons-outline SVGs (24×24, `stroke-width="1.5"`, per
+`docs/design-system/CONFORMANCE.md`) rather than emoji, and reuse the shared
+`toast()` helper defined on `appShell()` in `base.html` (reachable from the
+nested `x-data` scopes via Alpine's parent-scope chaining). Each success
+branch delays the `location.reload()` by 900ms (`setTimeout`) so the success
+toast can paint before the full-page reload begins — the loading flag stays
+set through the delay so the button can't be re-submitted before the reload
+lands. The gating logic (which button shows for which status) is locked by a
+Jinja render unit test, `tests/unit/test_review_actions_ui_template.py`, which
+renders the actual partial with fabricated `movie` dicts and asserts:
+`downloaded` → all three review buttons render and the generic "Mark as Done"
+does not; `done`/`active` → the review buttons are absent (and `active` keeps
+the generic "Mark as Done" — no regression); and the per-release "Mark failed"
+keys off the *release* status, not the movie's. E2E coverage is in
+`tests/e2e/movie-detail.spec.ts` — see the coverage-gap note there: there is
+no fixture / test-only API to seed a `downloaded`-status movie (CI/local e2e
+always start from a fresh, empty data dir), so the E2E suite asserts the
+buttons are **absent** for a non-downloaded movie and exercises the
+confirm-dialog behavior only when a `downloaded` movie happens to be present,
+rather than faking one — the render test above is what deterministically
+locks the "buttons ARE shown when downloaded" side that E2E can't reach.
 
 Per-movie (when in `downloaded`):
 - **Mark Done** → `media.done` (existing route,
@@ -268,14 +306,23 @@ feature's completion-path change rather than a separate reconstruction.
      falsy makes the post-loop `late` clause fire — the top-level branch
      sidesteps that entirely. A genuinely non-`downloaded` movie's
      wanted/snatched/late behavior is unchanged.
-3. **UI actions:** Mark Done / Mark Failed&re-search (movie); Skip/Ignore &
-   Mark-failed (release); immediate re-search on Fail. Tests + E2E.
+3. ✅ **DONE (3b + 3c).** **UI actions:** Mark Done / Mark Failed&re-search
+   (movie); Skip/Ignore & Mark-failed (release); immediate re-search on Fail.
+   Tests + E2E.
    **Phase 3b (backend API views) is DONE** — see "User actions (backend)"
    above for the three routes (`media.done` extended, new
    `movie.searcher.mark_failed`, new `release.failed`) and
-   `tests/unit/test_review_actions_backend.py`. **Still remaining for this
-   phase:** the UI buttons + htmx wiring that call these routes, and E2E
-   coverage — a separate PR.
+   `tests/unit/test_review_actions_backend.py`.
+   **Phase 3c (frontend UI actions) is DONE** — the buttons wiring those
+   routes into `movie_detail.html` (success toasts paint before a 900ms-
+   delayed reload), a Jinja render unit test
+   (`tests/unit/test_review_actions_ui_template.py`) that deterministically
+   locks the per-status button gating, plus `tests/e2e/movie-detail.spec.ts`
+   coverage (buttons absent for a non-downloaded movie; confirm-dialog
+   behavior exercised when a `downloaded` movie is present). See "User
+   actions (backend)" above for the button-by-button breakdown and the
+   E2E coverage-gap note (no fixture produces a `downloaded` movie in this
+   suite today — the render test covers the "shown when downloaded" side).
 
    **Re-add guard — IMPLEMENTED (Phase 3a):** `MovieBase.add()`
    (`couchpotato/core/media/movie/_base/main.py`) defaults `force_readd=True`,

--- a/tests/e2e/movie-detail.spec.ts
+++ b/tests/e2e/movie-detail.spec.ts
@@ -86,10 +86,10 @@ test.describe('Movie Detail', () => {
     // We can't easily find a movie without a year, so we just verify
     // that the year format is correct (either a number or TBA)
     await page.goto('/');
-    
+
     const movieGrid = page.locator('#movie-grid');
     await expect(movieGrid).toBeVisible({ timeout: 10000 });
-    
+
     const firstCard = movieGrid.locator('.poster-card').first();
     if (await firstCard.count() > 0) {
       // Check year format in card - should not be empty or "()"
@@ -97,6 +97,103 @@ test.describe('Movie Detail', () => {
       expect(yearText).toBeTruthy();
       expect(yearText).not.toBe('');
       expect(yearText?.trim()).not.toBe('()');
+    }
+  });
+
+  /**
+   * Downloaded/review workflow (specs/DOWNLOADED-REVIEW-WORKFLOW.md, Phase 3c).
+   *
+   * COVERAGE GAP: there is no fixture / test-only API to seed a movie in the
+   * 'downloaded' (review-gate) status -- reaching it requires a profile with
+   * manual_confirmation ON plus a real completed download (Phase 2 completion
+   * routing). CI and local e2e always start from a fresh, empty data dir
+   * (see playwright.config.ts's throwaway .e2e-data / .config), so the Wanted
+   * list here can only ever contain 'active' movies (or be empty). We
+   * therefore assert the review-gate buttons are ABSENT for whatever movie is
+   * actually present, and skip (rather than fake) the "buttons ARE shown"
+   * case -- faking a 'downloaded' movie via direct DB access from an e2e test
+   * would misrepresent real coverage.
+   */
+  test('review-gate buttons (Mark Done / Mark Failed & Re-search) are absent for a non-downloaded movie', async ({ page }) => {
+    await page.goto('/');
+
+    const movieGrid = page.locator('#movie-grid');
+    await expect(movieGrid).toBeVisible({ timeout: 10000 });
+
+    const firstCard = movieGrid.locator('.poster-card').first();
+    if (await firstCard.count() > 0) {
+      await firstCard.click();
+      await expect(page).toHaveURL(/.*movie\/.+/);
+      await expect(page.locator('h1')).toBeVisible({ timeout: 5000 });
+
+      // "Mark Done" (review-gate) has a distinct accessible name from the
+      // pre-existing generic "Mark as Done" button (shown for any
+      // non-done/non-downloaded movie) -- exact match keeps them from
+      // being confused with each other.
+      await expect(page.getByRole('button', { name: 'Mark Done', exact: true })).toHaveCount(0);
+      await expect(page.getByRole('button', { name: /mark failed\s*&\s*re-search/i })).toHaveCount(0);
+
+      // Per-release "Mark failed" (only rendered for a release in
+      // 'downloaded' status) should likewise be absent.
+      await expect(page.getByRole('button', { name: 'Mark failed', exact: true })).toHaveCount(0);
+    }
+  });
+
+  test('Mark Failed & Re-search requires confirmation when shown (review-gate movie)', async ({ page }) => {
+    await page.goto('/');
+
+    const movieGrid = page.locator('#movie-grid');
+    await expect(movieGrid).toBeVisible({ timeout: 10000 });
+
+    const firstCard = movieGrid.locator('.poster-card').first();
+    if (await firstCard.count() > 0) {
+      await firstCard.click();
+      await expect(page).toHaveURL(/.*movie\/.+/);
+
+      const markFailedButton = page.getByRole('button', { name: /mark failed\s*&\s*re-search/i });
+      if (await markFailedButton.count() > 0) {
+        let dialogMessage: string | null = null;
+        page.once('dialog', async (dialog) => {
+          dialogMessage = dialog.message();
+          expect(dialog.type()).toBe('confirm');
+          await dialog.dismiss();
+        });
+        await markFailedButton.click();
+        await expect.poll(() => dialogMessage).not.toBeNull();
+        // Dismissed -- should not have navigated away or reloaded into an
+        // active/searching state we didn't confirm.
+        await expect(page).toHaveURL(/.*movie\/.+/);
+      }
+      // See the coverage-gap note on the preceding test: this suite has no
+      // way to reliably produce a 'downloaded' movie, so the "dialog shown"
+      // branch above only exercises when such a movie happens to exist.
+    }
+  });
+
+  test('per-release Mark failed requires confirmation when shown', async ({ page }) => {
+    await page.goto('/');
+
+    const movieGrid = page.locator('#movie-grid');
+    await expect(movieGrid).toBeVisible({ timeout: 10000 });
+
+    const firstCard = movieGrid.locator('.poster-card').first();
+    if (await firstCard.count() > 0) {
+      await firstCard.click();
+      await expect(page).toHaveURL(/.*movie\/.+/);
+
+      const releaseMarkFailedButton = page.getByRole('button', { name: 'Mark failed', exact: true });
+      if (await releaseMarkFailedButton.count() > 0) {
+        let dialogMessage: string | null = null;
+        page.once('dialog', async (dialog) => {
+          dialogMessage = dialog.message();
+          expect(dialog.type()).toBe('confirm');
+          await dialog.dismiss();
+        });
+        await releaseMarkFailedButton.first().click();
+        await expect.poll(() => dialogMessage).not.toBeNull();
+      }
+      // Coverage gap: see above -- no fixture produces a 'downloaded' release
+      // in this suite, so this only exercises when one happens to exist.
     }
   });
 });

--- a/tests/unit/test_review_actions_ui_template.py
+++ b/tests/unit/test_review_actions_ui_template.py
@@ -1,0 +1,125 @@
+"""Render tests for the Downloaded/review-workflow action buttons (Phase 3c).
+
+These lock the *gating* of the review-action UI in
+``couchpotato/ui/templates/partials/movie_detail.html`` — which buttons appear
+for which movie/release status — that the E2E suite cannot exercise. The E2E
+tests (``tests/e2e/movie-detail.spec.ts``) can only reach ``active`` movies
+because CI/local runs start from a fresh, empty ``.e2e-data`` with no way to
+seed a ``downloaded``-status movie (see the coverage-gap note there and in
+``specs/DOWNLOADED-REVIEW-WORKFLOW.md``). So instead we render the *actual*
+Jinja partial (not a copy) with fabricated ``movie`` dicts and assert the
+gating directly.
+
+Buttons under test (per spec Phase 3c):
+- Movie-level **Mark Done** and **Mark Failed & Re-search** — shown only when
+  the movie ``status == 'downloaded'``.
+- Per-release **Mark failed** — shown only for a release row whose
+  ``status == 'downloaded'``.
+- The pre-existing generic **Mark as Done** — shown for any movie that is not
+  ``done`` and not ``downloaded`` (i.e. it must NOT double up with the
+  review-gate Mark Done, and must NOT regress for ``active`` movies).
+"""
+
+from couchpotato.ui import _jinja
+
+
+# Distinctive rendered substrings. Each is the visible ``<span>`` label so it
+# can't collide with an attribute value or another button's text. Note the
+# review "Mark Done" (capital D, no "as") is deliberately distinct from the
+# generic "Mark as Done", and the movie-level "Mark Failed" (capital F) is
+# distinct from the per-release "Mark failed" (lowercase f).
+REVIEW_MARK_DONE = '>Mark Done<'
+REVIEW_MARK_FAILED = 'Mark Failed &amp; Re-search'
+RELEASE_MARK_FAILED = '>Mark failed<'
+GENERIC_MARK_AS_DONE = '>Mark as Done<'
+
+
+def _render(movie):
+    ctx = {
+        'api_key': 'test-key',
+        'api_base': '/api/test-key',
+        'web_base': '/',
+        'new_base': '/',
+        'movie': movie,
+    }
+    return _jinja.get_template('partials/movie_detail.html').render(**ctx)
+
+
+def _movie(status, releases=None):
+    return {
+        '_id': 'movie-1',
+        'status': status,
+        'info': {'titles': ['Fixture Movie'], 'year': 2021},
+        # A profile with no qualities means matching_releases == releases, so
+        # every fabricated release row is rendered.
+        'profile': {'label': 'HD', 'qualities': []},
+        'releases': releases or [],
+    }
+
+
+def _release(status, rid='rel-1'):
+    return {
+        '_id': rid,
+        'status': status,
+        'quality': '720p',
+        'info': {'name': 'Fixture.Release.720p'},
+        'identifier': 'tt1.unknown.720p',
+        'files': {},
+    }
+
+
+def test_downloaded_movie_shows_all_three_review_buttons():
+    """status='downloaded' + a 'downloaded' release row -> all review actions,
+    and NOT the generic 'Mark as Done'."""
+    html = _render(_movie('downloaded', releases=[_release('downloaded')]))
+
+    assert REVIEW_MARK_DONE in html, 'Mark Done (review) must render for a downloaded movie'
+    assert REVIEW_MARK_FAILED in html, 'Mark Failed & Re-search must render for a downloaded movie'
+    assert RELEASE_MARK_FAILED in html, 'per-release Mark failed must render for a downloaded release'
+    assert GENERIC_MARK_AS_DONE not in html, (
+        'the generic "Mark as Done" must be suppressed for a downloaded movie '
+        '(the review-gate Mark Done replaces it) to avoid a duplicate button'
+    )
+
+
+def test_done_movie_hides_all_review_buttons():
+    """status='done' -> none of the three review buttons, and no generic
+    'Mark as Done' (a done movie is terminal)."""
+    html = _render(_movie('done', releases=[_release('done')]))
+
+    assert REVIEW_MARK_DONE not in html
+    assert REVIEW_MARK_FAILED not in html
+    assert RELEASE_MARK_FAILED not in html
+    assert GENERIC_MARK_AS_DONE not in html
+
+
+def test_active_movie_hides_review_buttons_but_keeps_generic_mark_as_done():
+    """status='active' -> no review buttons; the pre-existing generic
+    'Mark as Done' must still render (no regression). An 'available' release
+    row must not surface the per-release Mark failed action."""
+    html = _render(_movie('active', releases=[_release('available')]))
+
+    assert REVIEW_MARK_DONE not in html
+    assert REVIEW_MARK_FAILED not in html
+    assert RELEASE_MARK_FAILED not in html
+    assert GENERIC_MARK_AS_DONE in html, (
+        'the generic "Mark as Done" button must remain for an active movie'
+    )
+
+
+def test_per_release_mark_failed_is_gated_on_release_status_not_movie_status():
+    """The per-release Mark failed button keys off the *release* status: a
+    non-'downloaded' release under a downloaded movie must not show it, and a
+    'downloaded' release only surfaces it for that specific row."""
+    # Downloaded movie, but its (only) release is 'done' -> no per-release
+    # Mark failed button, though the movie-level buttons still show.
+    html = _render(_movie('downloaded', releases=[_release('done')]))
+    assert RELEASE_MARK_FAILED not in html
+    assert REVIEW_MARK_DONE in html
+
+    # Two releases, only one 'downloaded' -> exactly one per-release button.
+    html = _render(_movie('downloaded', releases=[
+        _release('available', rid='rel-a'),
+        _release('downloaded', rid='rel-b'),
+    ]))
+    assert html.count(RELEASE_MARK_FAILED) == 1


### PR DESCRIPTION
Part of #14 (Downloaded/review workflow), **Phase 3c — the frontend** that wires the Phase-3b backend routes (#173) into the movie detail UI. This completes Phase 3.

## UI (all in `couchpotato/ui/templates/partials/movie_detail.html`, gated on the review state)

- **Mark Done** — shown only when the movie status is `downloaded`. Single click (non-destructive) → `media.done?id=` (movie → `done` + owning release → `done`). check-circle icon, success style.
- **Mark Failed & Re-search** — same gate. **`confirm()`-gated** (destructive) → `movie.searcher.mark_failed?media_id=` (release → `failed`, movie → `active`, immediate manual re-search). x-circle icon, danger style.
- **Per-release Mark failed** — in the release row, gated on a `downloaded` release → `release.failed?id=`. Skip/Ignore already existed (`release.ignore`) and is reused.
- The pre-existing generic "Mark as Done" is gated off for `downloaded` movies so the review pair doesn't duplicate it; `active`/other statuses are unchanged.

Heroicons-outline icons (no emoji), visible text labels (accessible names), inherited `:focus-visible` ring, success/danger variants matching the file's conventions, and the release action cell now `flex flex-wrap` so it stays responsive. Success actions toast then reload after a 900ms delay (so the confirmation is actually visible; buttons stay disabled through the delay — no double-submit).

## Tests

- **Jinja render test** (`tests/unit/test_review_actions_ui_template.py`, 4 tests) renders the real partial via the app's Jinja env and locks the gating deterministically: `downloaded` shows the three review buttons (generic Mark-as-Done absent), `done` hides all, `active` hides the review pair but keeps the generic button (regression lock), and per-release Mark-failed keys off the *release* status. This closes the coverage the E2E can't reach (fresh `.e2e-data` has no `downloaded`-status movie — honestly noted).
- **E2E** (`tests/e2e/movie-detail.spec.ts`): absence-assertions on a non-downloaded movie + confirm-dialog cases. 8/8 pass.
- 1151 unit tests pass, ruff + conformance (33 templates) clean, `make verify` green.

## Local-review gate

Two full review rounds (correctness/wiring + frontend/a11y/DS). Round 1 verified every button's param name against its backend view (a mismatch would silently no-op) and confirmed the generic-Mark-Done gate change doesn't regress non-downloaded movies; it caught the success-toast being raced by an immediate reload (dead confirmation) — fixed (900ms delay) — and I added the render test to close the gating coverage gap. Round 2 confirmed the render test discriminates (revert-proven) and the timing fix is correct. Only then pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)