### PR TITLE
feat(workflow): Phase 4a — notify on entering Downloaded/review gate (movie.downloaded)

### DIFF
--- a/couchpotato/core/media/_base/media/main.py
+++ b/couchpotato/core/media/_base/media/main.py
@@ -825,6 +825,19 @@ class MediaPlugin(MediaBase):
                     if tag_recent:
                         self.tag(media_id, 'recent', update_edited = True)
 
+                    # Workflow phase 4a: notify exactly once on a genuine
+                    # transition into the 'downloaded' manual-review gate
+                    # (mirrors the 'movie.snatched' notification path in
+                    # couchpotato/core/plugins/release/main.py rather than the
+                    # dead renamer.after chain). Guarded by both the
+                    # previous_status != m['status'] check above (so a
+                    # no-op restatus never fires) and this explicit
+                    # 'downloaded' check (so entering 'done' never fires it).
+                    if m['status'] == 'downloaded' and previous_status != 'downloaded':
+                        fireEvent('%s.downloaded' % m.get('type', 'movie'),
+                                  message = '%s downloaded — awaiting review' % getTitle(m),
+                                  data = m)
+
                 return m['status']
             except Exception:
                 log.error('Failed restatus: %s', traceback.format_exc())

--- a/couchpotato/core/notifications/base.py
+++ b/couchpotato/core/notifications/base.py
@@ -16,7 +16,7 @@ class Notification(Provider):
 
     listen_to = [
         'media.available',
-        'renamer.after', 'movie.snatched',
+        'renamer.after', 'movie.snatched', 'movie.downloaded',
         'updater.available', 'updater.updated',
         'core.message.important',
     ]

--- a/couchpotato/core/notifications/core/main.py
+++ b/couchpotato/core/notifications/core/main.py
@@ -31,7 +31,7 @@ class CoreNotifier(Notification):
 
     listen_to = [
         'media.available',
-        'renamer.after', 'movie.snatched',
+        'renamer.after', 'movie.snatched', 'movie.downloaded',
         'updater.available', 'updater.updated',
         'core.message', 'core.message.important',
     ]

--- a/couchpotato/core/notifications/homey.py
+++ b/couchpotato/core/notifications/homey.py
@@ -13,7 +13,7 @@ class Homey(Notification):
 
     listen_to = [
         'media.available',
-        'renamer.after', 'movie.snatched',
+        'renamer.after', 'movie.snatched', 'movie.downloaded',
     ]
 
     def notify(self, message = '', data = None, listener = None):

--- a/couchpotato/core/notifications/xbmc.py
+++ b/couchpotato/core/notifications/xbmc.py
@@ -19,7 +19,7 @@ autoload = 'XBMC'
 
 class XBMC(Notification):
 
-    listen_to = ['renamer.after', 'movie.snatched']
+    listen_to = ['renamer.after', 'movie.snatched', 'movie.downloaded']
     use_json_notifications = {}
     http_time_between_calls = 0
 

--- a/specs/DOWNLOADED-REVIEW-WORKFLOW.md
+++ b/specs/DOWNLOADED-REVIEW-WORKFLOW.md
@@ -176,21 +176,89 @@ wiring, unit/mutation tests, and any conformance/E2E touch-up) is left for a
 Phase 3 follow-up rather than folded into this phase. Until then the toggle
 is settable only via the `profile.save` API directly.
 
-### Notification
+### Notification — Phase 4a: DONE
 
-On entering `downloaded`, fire `notify.frontend` (and the configured
-notification providers) with a "‹title› downloaded — awaiting review" message.
-This rides on the renamer-completion hook.
+On entering `downloaded`, fire a `movie.downloaded` event (mirroring the
+proven `movie.snatched` notification path,
+`couchpotato/core/plugins/release/main.py:387`
+`fireEvent('%s.snatched' % data['type'], message = snatch_message, data =
+media)` — **not** the dead `renamer.after` chain, see Phase 4b below) with a
+"‹title› downloaded — awaiting review" message.
 
-### Ties into renamer #13 (enrichment)
+Fire site: `MediaPlugin.restatus()`
+(`couchpotato/core/media/_base/media/main.py`), inside the existing
+"only update when status has changed" guard (`if previous_status !=
+m['status'] and (not allowed_restatus or m['status'] in allowed_restatus):`),
+immediately after the successful `db.update(m)`. Conditioned on `m['status']
+== 'downloaded' and previous_status != 'downloaded'`, so it fires exactly
+once, only on a genuine transition into the review gate, and only when the
+status change was actually persisted (a caller-supplied `allowed_restatus`
+that excludes `'downloaded'` skips both the write and the notification).
+`restatus()` is called repeatedly and from multiple call sites
+(`searcher.py`, `release/main.py`), so this two-part guard (persisted status
+change AND explicit `'downloaded'` check) is what prevents a re-fire on every
+subsequent no-op restatus of an already-`downloaded` movie:
+
+```python
+fireEvent('%s.downloaded' % m.get('type', 'movie'),
+          message = '%s downloaded — awaiting review' % getTitle(m),
+          data = m)
+```
+
+Registered on both notification `listen_to` lists so configured providers
+*and* the core (DB-persisted) notifier pick it up, exactly like
+`movie.snatched`:
+
+- `couchpotato/core/notifications/base.py` `Notification.listen_to` (fans out
+  to every configured provider).
+- `couchpotato/core/notifications/core/main.py` `CoreNotifier.listen_to`
+  (persists a `notification` DB row, queryable via `notification.list`, and
+  pushes `notify.frontend` to the legacy long-poll listener).
+
+**Known gap (in scope, not a bug):** the new htmx/Alpine UI does not consume
+the `notify.frontend` long-poll stream, so this reaches configured providers
++ the persisted DB notification + the legacy long-poll surface, but not a
+new-UI live toast — that's separate work, not folded into this phase.
+
+Tests: `tests/unit/test_downloaded_review_notify.py` — manual-confirmation
+completion fires `movie.downloaded` exactly once with a message containing
+the title and `data` equal to the persisted media doc; a second `restatus()`
+call on an already-`downloaded` movie does not re-fire (idempotency); an auto
+profile routing to `done` does not fire; a no-transition call (status
+unchanged) does not fire; both `listen_to` lists carry `'movie.downloaded'`.
+
+### Ties into renamer #13 (enrichment) — Phase 4b: DEFERRED
 
 The dead `renamer.before`/`renamer.after` chain (subtitles, trailers,
-notifications, metadata — see `specs/RENAMER-EVENT-CHAIN.md`) should fire at the
-**completion/`downloaded`** point, NOT at an auto-`done`. Since production shows
-**no stuck backlog** (0 releases moved-but-unfinalized), the feared
-"storm on upgrade" is moot — enrichment fires only for genuinely-new
-completions going forward. Wiring the enrichment events is folded into this
-feature's completion-path change rather than a separate reconstruction.
+notifications, metadata — see `specs/RENAMER-EVENT-CHAIN.md`) should, in
+principle, fire at the **completion/`downloaded`** point, NOT at an
+auto-`done`. Since production shows **no stuck backlog** (0 releases
+moved-but-unfinalized), the feared "storm on upgrade" is moot — enrichment
+would only fire for genuinely-new completions going forward.
+
+**Deferred, not wired up in Phase 4a.** This is a large reconstruction
+coupled to the separate `specs/RENAMER-EVENT-CHAIN.md` project, and must
+**not** be naively wired into the review-gate completion point:
+
+- `manage.py`'s `after_rename → release.add()` path finalizes a release
+  straight to `done` as a side effect of the rename-completion flow — wiring
+  `renamer.after` into the `downloaded` transition without first
+  reconciling that path would let a "completion" enrichment call flip the
+  release (and, via `restatus()`, the movie) past the review gate it's
+  supposed to be waiting behind, defeating the whole point of Phase
+  1–3's gating work.
+- The file-touching listeners (subtitles/trailers/metadata/library-rescan
+  providers on `renamer.after`) expect payload keys like `destination_dir`,
+  `filename`, and `renamed_files` that the current, unported rename flow
+  (see the `renamer-event-chain-unported` gotcha — the event chain was never
+  reconnected during the FastAPI migration) no longer produces. Firing the
+  event today would call real subtitle/trailer/metadata providers with an
+  incomplete or stale payload shape rather than a controlled no-op.
+
+Pending a prod-backlog decision on `specs/RENAMER-EVENT-CHAIN.md` and a
+config gate (default **off**) so enrichment can be turned on deliberately
+once the rename flow and its payload are reconciled, rather than firing
+unconditionally the moment a movie enters `downloaded`.
 
 ## Rollout / safety
 
@@ -368,10 +436,24 @@ feature's completion-path change rather than a separate reconstruction.
    `downloaded` movie (the top-level branch catches `manage` first) but is kept
    as harmless defense-in-depth. Locked by
    `TestManageDeleteExemptsDownloadedMovies.test_downloaded_movie_with_zero_releases_survives_manage_delete`.
-4. **Notification + renamer enrichment hook:** fire notify + `renamer.after`
-   enrichment on entering `downloaded`; wire the dead listeners
-   (per `specs/RENAMER-EVENT-CHAIN.md`). Tests: listeners fire once, only on
-   genuine completion.
+4. **Notification + renamer enrichment hook:**
+   - ✅ **DONE (Phase 4a).** Fire the `movie.downloaded` notification event
+     exactly once on entering `downloaded`, via the proven `movie.snatched`
+     path (see "Notification" above). Tests:
+     `tests/unit/test_downloaded_review_notify.py` — fires once on a genuine
+     transition, does not re-fire on a subsequent no-op restatus, does not
+     fire when routed to `done` or when status is unchanged, and both
+     `listen_to` lists register the event.
+   - ⏸️ **DEFERRED (Phase 4b).** Wiring the dead `renamer.after` enrichment
+     chain (subtitles/trailers/metadata/library rescans) into the
+     `downloaded` transition (see "Ties into renamer #13 (enrichment)"
+     above for why: it's coupled to the separate reconstruction in
+     `specs/RENAMER-EVENT-CHAIN.md`, `manage.py`'s `after_rename →
+     release.add()` path would finalize releases to `done` and defeat the
+     gate, and the listeners' expected payload keys
+     (`destination_dir`/`filename`/`renamed_files`) aren't produced by the
+     unported rename flow). Pending a prod-backlog decision + a config gate
+     (default off).
 5. **Docs + beta + prod-copy validation**, then release.
 
 ## Acceptance criteria

--- a/tests/unit/test_downloaded_review_notify.py
+++ b/tests/unit/test_downloaded_review_notify.py
@@ -24,6 +24,9 @@ from unittest.mock import patch
 from couchpotato.core.media._base.media.main import MediaPlugin
 from couchpotato.core.notifications.base import Notification
 from couchpotato.core.notifications.core.main import CoreNotifier
+from couchpotato.core.notifications.homey import Homey
+from couchpotato.core.notifications.trakt import Trakt
+from couchpotato.core.notifications.xbmc import XBMC
 
 
 def _run_restatus(media_doc, profile_doc, releases):
@@ -88,7 +91,11 @@ class TestNotifyOnEnteringDownloadedGate:
 
         event, args, kwargs = downloaded_events[0]
         assert 'Predestination' in kwargs['message']
-        assert kwargs['data'] == updated[0]
+        # The payload must carry the RIGHT movie, in its review state --
+        # assert on the fields directly rather than object identity with the
+        # recorded snapshot (which would be true almost by construction).
+        assert kwargs['data']['_id'] == 'movie-1'
+        assert kwargs['data']['status'] == 'downloaded'
 
     def test_idempotent_second_restatus_on_already_downloaded_movie_does_not_refire(self):
         """Calling restatus again on a movie that's already 'downloaded'
@@ -143,3 +150,21 @@ class TestMovieDownloadedRegisteredWithNotificationListeners:
 
     def test_registered_in_core_notifier_listen_to(self):
         assert 'movie.downloaded' in CoreNotifier.listen_to
+
+    def test_registered_in_providers_that_override_listen_to(self):
+        """Two providers OVERRIDE the base listen_to (rather than inheriting
+        it), so adding 'movie.downloaded' to base.py alone silently misses
+        them -- they'd get 'movie.snatched' but not the review-gate entry.
+        Both must carry it explicitly."""
+        assert 'movie.snatched' in XBMC.listen_to  # sanity: it does override
+        assert 'movie.downloaded' in XBMC.listen_to
+        assert 'movie.snatched' in Homey.listen_to
+        assert 'movie.downloaded' in Homey.listen_to
+
+    def test_not_added_to_trakt_which_should_not_fire_on_review_gate(self):
+        """Trakt overrides listen_to with ['renamer.after'] only (no
+        'movie.snatched') -- it's a library-add scrobbler and must NOT fire
+        on a review-gate entry, since the movie isn't confirmed yet. Guard
+        against a future well-meaning 'add it everywhere' edit."""
+        assert 'movie.snatched' not in Trakt.listen_to
+        assert 'movie.downloaded' not in Trakt.listen_to

--- a/tests/unit/test_downloaded_review_notify.py
+++ b/tests/unit/test_downloaded_review_notify.py
@@ -1,0 +1,145 @@
+"""Tests for workflow Phase 4a (specs/DOWNLOADED-REVIEW-WORKFLOW.md): a
+notification fired exactly once when a movie TRANSITIONS into the
+'downloaded' manual-review gate.
+
+Mirrors the `movie.snatched` notification path
+(`couchpotato/core/plugins/release/main.py:387`
+`fireEvent('%s.snatched' % data['type'], message = snatch_message, data =
+media)`) rather than the dead `renamer.after` chain
+(specs/RENAMER-EVENT-CHAIN.md).
+
+Fire site: `MediaPlugin.restatus()`
+(couchpotato/core/media/_base/media/main.py), inside the guarded
+`db.update(m)` block, conditioned on `m['status'] == 'downloaded' and
+previous_status != 'downloaded'` -- so it fires exactly once, only on a
+genuine transition into 'downloaded', and only when the status change was
+actually persisted.
+
+Harness mirrors tests/unit/test_downloaded_review_workflow_phase2.py: real
+`restatus()` driven through a FakeDB + a fake fireEvent that records every
+event fired (rather than raising on the ones this phase cares about).
+"""
+from unittest.mock import patch
+
+from couchpotato.core.media._base.media.main import MediaPlugin
+from couchpotato.core.notifications.base import Notification
+from couchpotato.core.notifications.core.main import CoreNotifier
+
+
+def _run_restatus(media_doc, profile_doc, releases):
+    plugin = MediaPlugin.__new__(MediaPlugin)
+    updated = []
+    fired = []
+
+    class FakeDB:
+        def get(self, index, key, **kwargs):
+            if index == 'id' and key == media_doc['_id']:
+                return dict(media_doc)
+            if profile_doc and index == 'id' and key == profile_doc['_id']:
+                return dict(profile_doc)
+            raise AssertionError('Unexpected db.get call: %r %r' % (index, key))
+
+        def update(self, doc):
+            updated.append(dict(doc))
+            return doc
+
+    def fake_fire_event(event, *args, **kwargs):
+        if event == 'release.for_media':
+            return releases
+        if event == 'quality.isfinish':
+            return True
+        # Record anything else (including 'movie.downloaded') instead of
+        # raising, so we can assert on exactly what fired.
+        fired.append((event, args, kwargs))
+        return None
+
+    with (
+        patch('couchpotato.core.media._base.media.main.get_db', return_value=FakeDB()),
+        patch('couchpotato.core.media._base.media.main.fireEvent', side_effect=fake_fire_event),
+    ):
+        result = plugin.restatus(media_doc['_id'], tag_recent=False)
+
+    return result, updated, fired
+
+
+def _downloaded_events(fired):
+    return [f for f in fired if f[0] == 'movie.downloaded']
+
+
+class TestNotifyOnEnteringDownloadedGate:
+
+    def test_manual_confirmation_completion_fires_movie_downloaded_once(self):
+        """A manual_confirmation profile completing a download: restatus
+        transitions active -> downloaded AND fires 'movie.downloaded' exactly
+        once, with a message containing the title and data == the (updated)
+        media doc."""
+        movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1', 'title': 'Predestination'}
+        profile = {'_id': 'profile-1', 'qualities': ['1080p'], 'manual_confirmation': True}
+        releases = [{'status': 'done', 'quality': '1080p', 'last_edit': 0, 'is_3d': False}]
+
+        result, updated, fired = _run_restatus(movie, profile, releases)
+
+        assert result == 'downloaded'
+        assert len(updated) == 1
+        assert updated[0]['status'] == 'downloaded'
+
+        downloaded_events = _downloaded_events(fired)
+        assert len(downloaded_events) == 1
+
+        event, args, kwargs = downloaded_events[0]
+        assert 'Predestination' in kwargs['message']
+        assert kwargs['data'] == updated[0]
+
+    def test_idempotent_second_restatus_on_already_downloaded_movie_does_not_refire(self):
+        """Calling restatus again on a movie that's already 'downloaded'
+        (previous_status == 'downloaded') must NOT re-fire 'movie.downloaded'
+        -- the Phase-1 preservation path keeps it 'downloaded' with no
+        genuine transition, and no db.update happens either."""
+        movie = {'_id': 'movie-1', 'status': 'downloaded', 'profile_id': 'profile-1', 'title': 'Predestination'}
+        profile = {'_id': 'profile-1', 'qualities': ['1080p'], 'manual_confirmation': True}
+        releases = [{'status': 'done', 'quality': '1080p', 'last_edit': 0, 'is_3d': False}]
+
+        result, updated, fired = _run_restatus(movie, profile, releases)
+
+        assert result == 'downloaded'
+        assert updated == []
+        assert _downloaded_events(fired) == []
+
+    def test_auto_profile_routes_to_done_and_does_not_fire(self):
+        """A profile without manual_confirmation completes to 'done', not
+        'downloaded' -- must never fire 'movie.downloaded'."""
+        movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1', 'title': 'Predestination'}
+        profile = {'_id': 'profile-1', 'qualities': ['1080p'], 'manual_confirmation': False}
+        releases = [{'status': 'done', 'quality': '1080p', 'last_edit': 0, 'is_3d': False}]
+
+        result, updated, fired = _run_restatus(movie, profile, releases)
+
+        assert result == 'done'
+        assert len(updated) == 1
+        assert updated[0]['status'] == 'done'
+        assert _downloaded_events(fired) == []
+
+    def test_no_transition_does_not_fire(self):
+        """An active movie with no finishing release stays 'active'
+        (no status change, no db.update) -- must not fire 'movie.downloaded'."""
+        movie = {'_id': 'movie-1', 'status': 'active', 'profile_id': 'profile-1', 'title': 'Predestination'}
+        profile = {'_id': 'profile-1', 'qualities': ['1080p'], 'manual_confirmation': True}
+        releases = []  # no done releases -> stays 'active'
+
+        result, updated, fired = _run_restatus(movie, profile, releases)
+
+        assert result == 'active'
+        assert updated == []
+        assert _downloaded_events(fired) == []
+
+
+class TestMovieDownloadedRegisteredWithNotificationListeners:
+    """Registration lock: 'movie.downloaded' must be in both notification
+    listen_to lists so configured providers AND the core (DB-persisted)
+    notifier pick it up -- mirroring how 'movie.snatched' is registered."""
+
+    def test_registered_in_base_notification_listen_to(self):
+        assert 'movie.downloaded' in Notification.listen_to
+
+    def test_registered_in_core_notifier_listen_to(self):
+        assert 'movie.downloaded' in CoreNotifier.listen_to

--- a/tests/unit/test_downloaded_review_workflow_phase2.py
+++ b/tests/unit/test_downloaded_review_workflow_phase2.py
@@ -48,6 +48,11 @@ class TestRestatusManualConfirmationRouting:
                 return releases
             if event == 'quality.isfinish':
                 return True
+            # Phase 4a: restatus() fires 'movie.downloaded' on a genuine
+            # transition into the review gate. This suite only cares about
+            # the done/downloaded routing decision, so just record it.
+            if event == 'movie.downloaded':
+                return None
             raise AssertionError('Unexpected fireEvent call: %r' % (event,))
 
         with (
@@ -619,6 +624,10 @@ class TestManualConfirmationRoutingGatesSearcher:
                 return releases
             if event == 'quality.isfinish':
                 return True
+            # Phase 4a: restatus() fires 'movie.downloaded' on this genuine
+            # active -> downloaded transition; not this test's concern.
+            if event == 'movie.downloaded':
+                return None
             raise AssertionError('Unexpected fireEvent call: %r' % (event,))
 
         with (


### PR DESCRIPTION
Part of #14 (Downloaded/review workflow), **Phase 4a — notify on entering the review gate**.

## What

When a movie transitions into the `downloaded` review gate (a `manual_confirmation` profile completing a download, via `restatus`), fire a user notification: `<title> downloaded — awaiting review`.

- Fires `fireEvent('movie.downloaded', message=..., data=media)` at the transition point in `MediaPlugin.restatus` — **after** the status is persisted and **only** on a genuine `active → downloaded` transition (inside the `previous_status != m['status']` persist guard, conditioned on the new status being `downloaded`). Fires exactly once; repeated `restatus` calls on an already-`downloaded` movie don't re-fire (Phase-1 preservation makes the outer guard false).
- Registers `movie.downloaded` on `Notification.listen_to` and `CoreNotifier.listen_to`, mirroring the proven `movie.snatched` path — so it reaches the configured providers (email/pushover/etc.) and persists a DB notification (queryable via `notification.list`).

Known scope note: the new htmx/Alpine UI doesn't consume the `notify.frontend` long-poll stream, so this reaches providers + the persisted notification + the legacy long-poll surface. A live new-UI toast would be separate work.

## Phase 4b (renamer enrichment) — DEFERRED (documented in the spec)

Wiring the dead `renamer.after` chain (subtitles/trailers/metadata/library rescans) onto the review-gate completion is a large reconstruction and is deliberately **not** done here: `manage.py`'s `after_rename → release.add` path would finalize a release to `done`, **defeating the review gate**; and the file-touching listeners need payload keys (`destination_dir`/`filename`/`renamed_files`) that the unported rename flow no longer produces. Deferred to the separate `specs/RENAMER-EVENT-CHAIN.md` project, pending a prod-backlog decision and a config gate (default off).

## Tests

`tests/unit/test_downloaded_review_notify.py` (6): manual-confirmation completion fires `movie.downloaded` exactly once (message contains title, `data` = persisted doc); idempotency on a second `restatus`; auto-profile → `done` doesn't fire; no-transition doesn't fire; both `listen_to` registrations. 1157 unit tests pass, ruff clean.

## Local-review gate

Two review rounds (correctness/concurrency + tests). The concurrency review specifically cleared the write-lock reentrancy/deadlock concern: `db.update` releases `_write_lock` before returning (RLock regardless), the notification's `db.insert` is a fresh uncontended acquire, no provider re-enters `restatus`/`media_lock`, and `fireEvent` swallows listener exceptions — structurally identical to the proven `movie.snatched` site. Both reviews confirmed the fire + registrations are revert-proven and the collateral Phase-2 test-harness edit didn't weaken those tests. Only then pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
