### PR TITLE
fix(docker): pin c-ares>=1.34.8-r0 to clear CVE-2026-33630 (HIGH)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,12 +48,16 @@ ENV PYTHONUNBUFFERED=1 \
 # - 7zip provides `7zz`, rarfile's preferred external tool for extracting
 #   RAR archives (VENDORED-07: replaces the vendored unrar2 binaries) so RAR
 #   extraction works out of the box in the container without extra setup.
+# - c-ares is pulled in transitively; pin it to the patched version to clear
+#   CVE-2026-33630 (HIGH, use-after-free/double-free) which fails the Trivy gate.
+#   Drop this explicit pin once the base image ships c-ares >= 1.34.8-r0.
 RUN apk add --no-cache \
         ca-certificates \
         su-exec \
         mediainfo \
         libstdc++ \
-        7zip
+        7zip \
+        "c-ares>=1.34.8-r0"
 
 # Create app user
 ARG PUID=1000


### PR DESCRIPTION
The `docker` Trivy gate is failing repo-wide on **c-ares CVE-2026-33630** (HIGH, use-after-free/double-free), pulled in transitively at 1.34.6-r0, fixed in 1.34.8-r0. Pin it in the runtime stage.

**Verified locally:** rebuilt the image and re-ran the exact CI Trivy scan (`--severity HIGH,CRITICAL --ignore-unfixed --exit-code 1`) → exit 0, c-ares gone, zero fixable HIGH/CRITICAL remaining.

Unblocks PR #176. Drop the explicit pin once the base image ships c-ares ≥ 1.34.8-r0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaP7WGgYS1oV5t2jao3UYS