### PR TITLE
ci(dependabot): ignore guessit/rebulk major bumps (blocked by trakit)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,19 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
+    ignore:
+      # guessit 4.x requires rebulk>=6, but the subtitle stack caps rebulk<4:
+      # subliminal (hard dep) -> knowit -> trakit==0.2.5 (latest) requires
+      # rebulk<4. trakit and knowit are unmaintained (~1yr, no rebulk-6 work),
+      # and the whole ecosystem — including Bazarr — is pinned at guessit 3.8.0 /
+      # rebulk 3.2.0 for the same reason. We don't even use knowit/trakit (the
+      # metadata refiner is never invoked). Ignoring the major bumps so they stop
+      # reopening. Revisit when trakit/knowit support rebulk 6, or when subliminal
+      # makes knowit an optional extra. See closed PR #183 for the full analysis.
+      - dependency-name: "guessit"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "rebulk"
+        update-types: ["version-update:semver-major"]
 
   # Node.js dependencies
   - package-ecosystem: "npm"


### PR DESCRIPTION
Stops #183-style guessit 3→4 PRs from reopening. guessit 4.x needs rebulk≥6, but the subtitle stack caps rebulk<4 (subliminal → knowit → trakit==0.2.5, latest & unmaintained). The whole ecosystem incl. Bazarr is pinned at guessit 3.8.0 / rebulk 3.2.0, and we don't even use knowit/trakit (metadata refiner never invoked).

- Scoped to `version-update:semver-major` only — patch/minor bumps (incl. security) still flow.
- Ignores both guessit AND rebulk: a rebulk major can't be adopted without breaking guessit 3.8.0 or the trakit<4 cap, so guessit-only would leave Dependabot churning un-mergeable rebulk PRs.
- Revisit trigger documented inline (when trakit/knowit support rebulk 6, or subliminal makes knowit optional). Full analysis: closed PR #183.

Local review gate run (2 independent agents, both PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaP7WGgYS1oV5t2jao3UYS