### PR TITLE
chore: ignore local agent scaffolding and keep it out of the Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,8 @@ docker-compose.yml
 .env.*
 .config/
 .openclaw/
+.design-sync/
+ds-bundle/
 HEARTBEAT.md
 IDENTITY.md
 SOUL.md

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,13 @@ reports/mutation
 # mutmut cache (3.x uses a mutants dir / sqlite cache)
 .mutmut-cache
 mutants/
+
+# Local agent / design-tooling scaffolding — not part of this project
+/.openclaw/
+/.design-sync/
+/ds-bundle/
+/HEARTBEAT.md
+/IDENTITY.md
+/SOUL.md
+/TOOLS.md
+/USER.md


### PR DESCRIPTION
## What

Two small hygiene commits:

1. **`.gitignore`** — ignore the Openclaw / design-sync scaffolding that lands in the repo root (`SOUL.md`, `IDENTITY.md`, `USER.md`, `TOOLS.md`, `HEARTBEAT.md`, `.openclaw/`, `.design-sync/`, `ds-bundle/`). These are per-developer local tooling, not part of CouchPotatoServer, and showed as untracked noise in every `git status` — one stray `git add -A` would have committed them. Patterns are root-anchored (`/SOUL.md`, not `SOUL.md`) so a same-named file deeper in the tree is unaffected.

2. **`.dockerignore`** — add `.design-sync/` and `ds-bundle/`. The file already excluded the openclaw scaffolding but not these two. Since the Dockerfile does `COPY --chown=couchpotato:couchpotato . ${APP_DIR}/`, a local `docker build -t couchpotato:test .` (the command AGENTS.md tells contributors to run) copied **28 files, ~412K** — mostly design-system screenshots — into the production image. The existing `*.md` rule did not cover the markdown among them: `.dockerignore` patterns do not cross directory separators, so `*.md` matches only root-level files.

**CI was never affected** — it builds from a clean checkout where these untracked directories don't exist. This only bit local builds.

## Verification

- Measured the leak empirically: built a throwaway `COPY . /ctx` image against the real context with master's `.dockerignore` (28 files present under those dirs) and with this change applied (none present).
- Confirmed nothing in the repo references `ds-bundle` or `design-sync` — not app source, templates, `Makefile`, `scripts/`, `.github/workflows/`, or docs — so excluding them breaks nothing.
- Confirmed none of the ignored paths were ever committed to git history, so `.gitignore` is a sufficient fix rather than papering over a leak.
- `make verify` (lint + 1209 py unit + 194 UI unit) green. Full Playwright suite 131/133; the two failures are the known `waitForLoadState('networkidle')` flakes in `interactions.e2e.spec.ts`, identical before and after this change, and both pass on re-run in isolation.

## Notes

- No tests added: dotfile-only exclusion config with no runtime behavior.
- Merging this will trigger a beta build (`.gitignore`/`.dockerignore` are not in `docker.yml`'s `paths-ignore`), so `:beta` will move ahead of the just-released `:latest` (v3.13.0). No prod impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01776dG2XJe9h9DWz9dSJ2KK