### PR TITLE
fix: 'Best' profile downloads 720p, and pre-release downloads (BUG-016, BUG-017)

### DIFF
--- a/couchpotato/core/media/movie/_base/main.py
+++ b/couchpotato/core/media/movie/_base/main.py
@@ -49,17 +49,33 @@ def releaseDatesFromInfo(info):
 
     try:
         year, month, day = (int(x) for x in date_part.split('-'))
-        # timegm, not mktime: the gate compares against int(time.time()),
-        # which is UTC, so a local-time parse would shift the unlock by up
-        # to a day depending on the server's timezone.
-        theater = calendar.timegm((year, month, day, 0, 0, 0, 0, 0, 0))
     except (ValueError, TypeError, AttributeError):
         return {}
 
-    # Reject impossible dates that still parse as integers (e.g. 2026-13-45):
-    # timegm normalises them silently rather than raising.
-    if not (1 <= month <= 12 and 1 <= day <= 31):
+    # Reject impossible dates. timegm() NORMALISES them silently rather than
+    # raising -- 2026-02-30 becomes 2026-03-02 -- and a quietly shifted
+    # unlock date is worse than a rejected one because nothing surfaces it.
+    # monthrange, not `day <= 31`, so Feb 30 and Apr 31 are caught too.
+    if not 1 <= month <= 12:
         return {}
+    if not 1 <= day <= calendar.monthrange(year, month)[1]:
+        return {}
+
+    # Anything before the epoch is treated as unknown rather than derived.
+    # TMDB uses 1900-01-01 to mean "no release date" -- themoviedb.py already
+    # nulls `year` for it ("1900 is the same as None") but still writes the
+    # placeholder to `released`. Taking it literally would reopen BUG-017:
+    # a negative epoch is couldBeReleased()'s pre-1972 "definitely out"
+    # sentinel, so an unknown date would authorise an immediate download.
+    # Genuinely old films lose nothing -- an old `year` routes them to the
+    # "old movie, no dates" heuristic, which already assumes released.
+    if year < 1970:
+        return {}
+
+    # timegm, not mktime: the gate compares against int(time.time()), which
+    # is UTC, so a local-time parse would shift the unlock by up to a day
+    # depending on the server's timezone.
+    theater = calendar.timegm((year, month, day, 0, 0, 0, 0, 0, 0))
 
     return {'theater': theater, 'dvd': 0}
 

--- a/couchpotato/core/media/movie/_base/main.py
+++ b/couchpotato/core/media/movie/_base/main.py
@@ -56,6 +56,13 @@ def releaseDatesFromInfo(info):
     # raising -- 2026-02-30 becomes 2026-03-02 -- and a quietly shifted
     # unlock date is worse than a rejected one because nothing surfaces it.
     # monthrange, not `day <= 31`, so Feb 30 and Apr 31 are caught too.
+    #
+    # The year bound comes first: monthrange() and timegm() both raise
+    # ValueError above 9999 ("year must be in 1..9999"), and this function
+    # promises never to raise -- a provider returning a nonsense year must
+    # degrade to "unknown", not throw once per movie into the search loop.
+    if not 1 <= year <= 9999:
+        return {}
     if not 1 <= month <= 12:
         return {}
     if not 1 <= day <= calendar.monthrange(year, month)[1]:

--- a/couchpotato/core/media/movie/_base/main.py
+++ b/couchpotato/core/media/movie/_base/main.py
@@ -1,3 +1,4 @@
+import calendar
 import sqlite3
 import traceback
 import time
@@ -14,6 +15,53 @@ from couchpotato.core.media_lock import media_lock
 
 
 log = CPLog(__name__)
+
+
+def releaseDatesFromInfo(info):
+    """Derive the ETA mapping from the release date the info provider already
+    stored on the movie document.
+
+    BUG-017: `movie.info.release_date` has no handler anywhere, so the
+    mapping the ETA gate reads was always empty and the gate never held
+    anything back. The date itself was always present -- the TMDB provider
+    writes TMDB's `release_date` to `info['released']`.
+
+    Returns ``{'theater': <utc epoch>, 'dvd': 0}``, or ``{}`` when nothing
+    usable is there. `dvd` is deliberately left unknown rather than guessed:
+    a fabricated dvd date would unlock the "4 weeks before dvd" early-download
+    path in couldBeReleased().
+    """
+    if not isinstance(info, dict):
+        return {}
+
+    released = info.get('released')
+    if not isinstance(released, str):
+        return {}
+
+    # `str(movie.get('release_date'))` in the TMDB provider turns a missing
+    # date into the literal 'None', which is truthy -- reject it explicitly.
+    released = released.strip()
+    if not released or released.lower() == 'none':
+        return {}
+
+    # Some providers append a time component; the date part is what we want.
+    date_part = released.split(' ')[0].split('T')[0]
+
+    try:
+        year, month, day = (int(x) for x in date_part.split('-'))
+        # timegm, not mktime: the gate compares against int(time.time()),
+        # which is UTC, so a local-time parse would shift the unlock by up
+        # to a day depending on the server's timezone.
+        theater = calendar.timegm((year, month, day, 0, 0, 0, 0, 0, 0))
+    except (ValueError, TypeError, AttributeError):
+        return {}
+
+    # Reject impossible dates that still parse as integers (e.g. 2026-13-45):
+    # timegm normalises them silently rather than raising.
+    if not (1 <= month <= 12 and 1 <= day <= 31):
+        return {}
+
+    return {'theater': theater, 'dvd': 0}
 
 
 class MovieBase(MovieTypeBase):
@@ -422,10 +470,25 @@ class MovieBase(MovieTypeBase):
             else:
                 dates = media.get('info').get('release_date')
 
+            # A stale `[]` may be cached here: older versions stored whatever
+            # the unhandled event returned, on every search.
+            if not isinstance(dates, dict):
+                dates = None
+
             if dates and (dates.get('expires', 0) < time.time() or dates.get('expires', 0) > time.time() + (604800 * 4)) or not dates:
-                dates = fireEvent('movie.info.release_date', identifier = getIdentifier(media), merge = True)
-                media['info'].update({'release_date': dates})
-                db.update(media)
+                fetched = fireEvent('movie.info.release_date', identifier = getIdentifier(media), merge = True)
+
+                if isinstance(fetched, dict) and fetched:
+                    dates = fetched
+                    media['info'].update({'release_date': dates})
+                    db.update(media)
+                else:
+                    # No provider implements movie.info.release_date, so this
+                    # is the normal path (BUG-017). Derive from the date the
+                    # info provider already stored. Not written back: it is
+                    # free to recompute, and persisting it would mean a db
+                    # write per movie per search cycle for no benefit.
+                    dates = releaseDatesFromInfo(media.get('info') or {})
 
             return dates
         except Exception:

--- a/couchpotato/core/media/movie/searcher.py
+++ b/couchpotato/core/media/movie/searcher.py
@@ -378,6 +378,12 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
         now_year = date.today().year
         now_month = date.today().month
 
+        # updateReleaseDate() returns {} both from its exception handler and
+        # when the info provider simply has no release_date yet, and callers
+        # may pass None. Normalise once so the .get() calls below are safe
+        # without a `not dates` short-circuit -- see BUG-017.
+        dates = dates or {}
+
         if (year is None or year < now_year - 1 or (year <= now_year - 1 and now_month > 4)) and (not dates or (dates.get('theater', 0) == 0 and dates.get('dvd', 0) == 0)):
             return True
         else:
@@ -387,8 +393,16 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
             if year is not None and year > (now_year + add_year):
                 return False
 
-            # For movies before 1972
-            if not dates or dates.get('theater', 0) < 0 or dates.get('dvd', 0) < 0:
+            # For movies before 1972 (a negative epoch is the sentinel).
+            #
+            # BUG-017: this used to also match `not dates`, so an UNKNOWN
+            # release date was read as "already released" and authorised a
+            # download. Unknown dates now fall through every branch below to
+            # the closing `return False` -- unknown means not yet released.
+            # The similar `not dates` test at the top of this method is a
+            # different, deliberate case ("old movie AND no dates"): a film
+            # two years in the past cannot be unreleased.
+            if dates.get('theater', 0) < 0 or dates.get('dvd', 0) < 0:
                 return True
 
             if is_pre_release:
@@ -554,7 +568,7 @@ config = [{
                     'migrate_from': 'searcher',
                     'type': 'bool',
                     'label': 'Always search',
-                    'description': 'Search for movies even before there is a ETA. Enabling this will probably get you a lot of fakes.',
+                    'description': 'Search for <em>and download</em> movies even before there is an ETA. This bypasses the release-date gate entirely, not just the search, so you will probably get a lot of fakes and early grabs.',
                 },
                 {
                     'name': 'run_on_launch',

--- a/couchpotato/core/media/movie/searcher.py
+++ b/couchpotato/core/media/movie/searcher.py
@@ -181,6 +181,7 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
         too_early_to_search = []
         outside_eta_results = 0
         always_search = self.conf('always_search')
+        wait_days = self.conf('wait_for_release')
         ignore_eta = manual
         total_result_count = 0
 
@@ -209,7 +210,7 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
                 'minimum_score': profile.get('minimum_score', 1),
             }
 
-            could_not_be_released = not self.couldBeReleased(q_identifier in pre_releases, release_dates, movie['info']['year'])
+            could_not_be_released = not self.couldBeReleased(q_identifier in pre_releases, release_dates, movie['info']['year'], wait_days = wait_days)
             if not always_search and could_not_be_released:
                 too_early_to_search.append(q_identifier)
 
@@ -372,17 +373,29 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
         log.info("Wrong: %s, undetermined naming. Looking for '%s (%s)'", nzb['name'], media_title, media['info']['year'])
         return False
 
-    def couldBeReleased(self, is_pre_release, dates, year = None):
+    def couldBeReleased(self, is_pre_release, dates, year = None, wait_days = None):
+        """Whether a movie is far enough past its release date to download.
+
+        `wait_days` is the configurable hold-off after the release date
+        (the `wait_for_release` setting, default 0 = as soon as it is out).
+        It is a parameter rather than a `self.conf()` read so this stays a
+        pure function -- callers pass the configured value.
+        """
 
         now = int(time.time())
         now_year = date.today().year
         now_month = date.today().month
 
-        # updateReleaseDate() returns {} both from its exception handler and
-        # when the info provider simply has no release_date yet, and callers
-        # may pass None. Normalise once so the .get() calls below are safe
-        # without a `not dates` short-circuit -- see BUG-017.
-        dates = dates or {}
+        # `dates` may arrive as a list: an unhandled fireEvent returns [], and
+        # older databases have [] cached in info['release_date']. Normalise
+        # once so the .get() calls below are safe without a `not dates`
+        # short-circuit -- see BUG-017.
+        if not isinstance(dates, dict):
+            dates = {}
+
+        # A blank or junk setting means "no wait", never a crash or a hold
+        # that never expires.
+        wait_seconds = max(tryInt(wait_days, 0), 0) * 86400
 
         if (year is None or year < now_year - 1 or (year <= now_year - 1 and now_month > 4)) and (not dates or (dates.get('theater', 0) == 0 and dates.get('dvd', 0) == 0)):
             return True
@@ -410,8 +423,11 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
                 if dates.get('theater', 0) > 0 and dates.get('theater', 0) - 604800 < now:
                     return True
             else:
-                # 12 weeks after theater release
-                if dates.get('theater', 0) > 0 and dates.get('theater', 0) + 7257600 < now:
+                # Past the release date, plus the configured hold-off. This
+                # was a hardcoded 12 weeks (7257600s), written when waiting
+                # for physical media was the point; it is now the
+                # `wait_for_release` setting, default 0 -- see BUG-017.
+                if dates.get('theater', 0) > 0 and dates.get('theater', 0) + wait_seconds < now:
                     return True
 
                 if dates.get('dvd', 0) > 0:
@@ -569,6 +585,13 @@ config = [{
                     'type': 'bool',
                     'label': 'Always search',
                     'description': 'Search for <em>and download</em> movies even before there is an ETA. This bypasses the release-date gate entirely, not just the search, so you will probably get a lot of fakes and early grabs.',
+                },
+                {
+                    'name': 'wait_for_release',
+                    'default': 0,
+                    'type': 'int',
+                    'label': 'Wait after release',
+                    'description': 'Days to wait after a movie\'s release date before downloading it. <strong>0</strong>: as soon as it is out. Raise this if you keep getting fakes or poor early rips; <strong>84</strong> (12 weeks) matches the old built-in behaviour of waiting for a physical release.',
                 },
                 {
                     'name': 'run_on_launch',

--- a/couchpotato/core/migration/fix_profile_quality_order.py
+++ b/couchpotato/core/migration/fix_profile_quality_order.py
@@ -76,6 +76,24 @@ def _match(doc):
     if not stored_3d:
         stored_3d = [False] * len(qualities)
 
+    # Refuse to touch a row whose positional lists disagree in length. Only
+    # 'qualities' and '3d' take part in matching, so such a row would still
+    # match a legacy default -- and _permute() would reorder 'qualities'
+    # while leaving the mismatched list stale, silently re-pairing every
+    # remaining flag with a different quality. Leaving a malformed row
+    # exactly as found is strictly better than making it differently wrong.
+    # An ABSENT (or empty) list is a different case: older schemas simply
+    # lacked it, and there is nothing to detach.
+    for key in POSITIONAL_KEYS:
+        values = doc.get(key)
+        if values and len(values) != len(qualities):
+            log.warning(
+                'Profile %r has %d %s entries for %d qualities; skipping '
+                'quality-order fix for it.',
+                label, len(values), key, len(qualities),
+            )
+            return None
+
     for legacy in LEGACY_DEFAULTS:
         if (label == legacy['label']
                 and list(qualities) == legacy['qualities']

--- a/couchpotato/core/migration/fix_profile_quality_order.py
+++ b/couchpotato/core/migration/fix_profile_quality_order.py
@@ -1,0 +1,147 @@
+"""Repair the quality order of default profiles seeded before BUG-016.
+
+The built-in profiles used to be seeded worst-first: 'Best' was
+``['720p', '1080p', 'brrip', 'dvdrip']``. Index 0 of a profile is the *most
+preferred* quality and ``MovieSearcher.single()`` stops at the first
+successful download, so 'Best' fetched 720p and never reached 1080p, and
+'UHD 4K' (``['720p', '1080p', '2160p']``) could never deliver 4K.
+
+``ProfilePlugin.fill()`` only runs on a fresh install, so correcting the
+seeds does nothing for existing databases. This migration repairs them.
+
+**Only a profile whose label AND stored quality order match a known-bad seed
+exactly is rewritten.** Anything the user renamed, reordered, or edited is
+left strictly alone -- someone who deliberately prefers 720p (disk space, a
+slow line) must not have that silently undone. That also makes the migration
+idempotent: once repaired, a profile no longer matches a known-bad seed.
+
+See specs/BUG-016-default-profile-quality-order.md.
+"""
+from couchpotato.core.logger import CPLog
+
+log = CPLog(__name__)
+
+
+# Each entry describes one mis-seeded default.
+#
+# 'permutation' holds indices into the OLD lists, in their new order:
+# new[i] = old[permutation[i]]. Explicit indices rather than a sort key
+# because 'Prefer 3D HD' repeats identifiers, so only position distinguishes
+# its rungs.
+#
+# '3d' is part of the match, not just the payload -- for the 3D profiles the
+# identifiers alone are ambiguous.
+LEGACY_DEFAULTS = [{
+    'label': 'Best',
+    'qualities': ['720p', '1080p', 'brrip', 'dvdrip'],
+    '3d': [False, False, False, False],
+    'permutation': [1, 0, 2, 3],
+}, {
+    'label': 'HD',
+    'qualities': ['720p', '1080p'],
+    '3d': [False, False],
+    'permutation': [1, 0],
+}, {
+    'label': 'SD',
+    'qualities': ['dvdrip', 'dvdr'],
+    '3d': [False, False],
+    'permutation': [1, 0],
+}, {
+    'label': 'UHD 4K',
+    'qualities': ['720p', '1080p', '2160p'],
+    '3d': [False, False, False],
+    'permutation': [2, 1, 0],
+}, {
+    # Only the non-3D tail was inverted; the 3D head was already correct.
+    'label': 'Prefer 3D HD',
+    'qualities': ['1080p', '720p', '720p', '1080p'],
+    '3d': [True, True, False, False],
+    'permutation': [0, 1, 3, 2],
+}]
+
+# Kept in step with the lists build_profile_doc() produces.
+POSITIONAL_KEYS = ('qualities', 'finish', 'wait_for', 'stop_after', '3d')
+
+
+def _match(doc):
+    """Return the LEGACY_DEFAULTS entry this profile is an untouched copy
+    of, or None."""
+    label = doc.get('label')
+    qualities = doc.get('qualities')
+    if not label or not qualities:
+        return None
+
+    # Very old rows may have no '3d' list at all; that means "no 3D rungs".
+    stored_3d = [bool(x) for x in (doc.get('3d') or [])]
+    if not stored_3d:
+        stored_3d = [False] * len(qualities)
+
+    for legacy in LEGACY_DEFAULTS:
+        if (label == legacy['label']
+                and list(qualities) == legacy['qualities']
+                and stored_3d == legacy['3d']):
+            return legacy
+
+    return None
+
+
+def _permute(doc, legacy):
+    """Apply the permutation to every positional list present on the doc.
+
+    All five lists are permuted identically -- permuting 'qualities' alone
+    would detach each rung's finish/wait_for/stop_after/3d flags from the
+    quality they describe.
+    """
+    permutation = legacy['permutation']
+
+    for key in POSITIONAL_KEYS:
+        values = doc.get(key)
+        # A row missing a positional list (or with a truncated one) is left
+        # as-is for that key rather than being padded with guesses.
+        if not values or len(values) != len(permutation):
+            continue
+        doc[key] = [values[i] for i in permutation]
+
+
+def fix_profile_quality_order(db):
+    """Reorder mis-seeded default profiles best-first.
+
+    Returns a tuple of (fixed_count, checked_count).
+    """
+    fixed = 0
+    checked = 0
+
+    try:
+        profiles = [x['doc'] for x in db.all('profile', with_doc=True)]
+    except Exception as e:
+        log.warning('Could not list profiles for quality-order fix: %s (%s)',
+                    e, type(e).__name__)
+        return 0, 0
+
+    for doc in profiles:
+        try:
+            if doc.get('_t') != 'profile':
+                continue
+
+            checked += 1
+
+            legacy = _match(doc)
+            if not legacy:
+                continue
+
+            before = list(doc.get('qualities') or [])
+            _permute(doc, legacy)
+
+            db.update(doc)
+            fixed += 1
+            log.info('Reordered default profile %r best-first: %s -> %s',
+                     doc.get('label'), before, doc.get('qualities'))
+
+        except Exception as e:
+            # One bad row (a write conflict, a malformed document) must not
+            # strand the rest of the batch -- keep going.
+            log.debug('Skipped profile during quality-order fix: %s (%s)',
+                      e, type(e).__name__)
+            continue
+
+    return fixed, checked

--- a/couchpotato/core/plugins/dashboard.py
+++ b/couchpotato/core/plugins/dashboard.py
@@ -8,6 +8,7 @@ from couchpotato.core.event import fireEvent
 from couchpotato.core.helpers.variable import splitString, tryInt
 from couchpotato.core.logger import CPLog
 from couchpotato.core.plugins.base import Plugin
+from couchpotato.environment import Env
 
 
 log = CPLog(__name__)
@@ -22,8 +23,21 @@ class Dashboard(Plugin):
 
     def getSoonView(self, limit_offset = None, random = False, late = False, **kwargs):
 
+        # Imported here rather than at module scope: the plugin loader
+        # swallows ImportError at DEBUG, so a load-order problem would
+        # silently disable the whole dashboard. Hoisted out of the per-movie
+        # loop below -- getSoonView can iterate a large active list.
+        from couchpotato.core.media.movie._base.main import releaseDatesFromInfo
+
         db = get_db()
         now = time.time()
+
+        # The same hold-off the searcher applies (MovieSearcher.single reads
+        # this too). Without it this view answers "coming soon" for a movie
+        # the searcher is still holding back, so the dashboard and the
+        # downloader disagree about the same movie. Read from the searcher's
+        # own section -- self.conf() would resolve to 'dashboard'.
+        wait_days = Env.setting('wait_for_release', section = 'moviesearcher', default = 0)
 
         # Get profiles first, determine pre or post theater
         profiles = fireEvent('profile.all', single = True)
@@ -77,20 +91,16 @@ class Dashboard(Plugin):
                 # it from the date the info provider did store, exactly as
                 # MovieBase.updateReleaseDate() does. Without this the ETA
                 # gate answers "not released" for every movie and the view
-                # lists nothing. Imported here rather than at module scope:
-                # the plugin loader swallows ImportError at DEBUG, so a
-                # load-order problem would silently disable the dashboard.
-                from couchpotato.core.media.movie._base.main import releaseDatesFromInfo
-
+                # lists nothing.
                 eta = media['info'].get('release_date') or {}
                 if not isinstance(eta, dict) or not eta:
                     eta = releaseDatesFromInfo(media['info'])
                 coming_soon = False
 
                 # Theater quality
-                if pp.get('theater') and fireEvent('movie.searcher.could_be_released', True, eta, media['info']['year'], single = True):
+                if pp.get('theater') and fireEvent('movie.searcher.could_be_released', True, eta, media['info']['year'], wait_days = wait_days, single = True):
                     coming_soon = 'theater'
-                elif pp.get('dvd') and fireEvent('movie.searcher.could_be_released', False, eta, media['info']['year'], single = True):
+                elif pp.get('dvd') and fireEvent('movie.searcher.could_be_released', False, eta, media['info']['year'], wait_days = wait_days, single = True):
                     coming_soon = 'dvd'
 
                 if coming_soon:

--- a/couchpotato/core/plugins/dashboard.py
+++ b/couchpotato/core/plugins/dashboard.py
@@ -72,7 +72,19 @@ class Dashboard(Plugin):
                 pp = profile_pre.get(media.get('profile_id'))
                 if not pp: continue
 
-                eta = media['info'].get('release_date', {}) or {}
+                # Nothing populates info['release_date'] -- `movie.info
+                # .release_date` has no handler -- so fall back to deriving
+                # it from the date the info provider did store, exactly as
+                # MovieBase.updateReleaseDate() does. Without this the ETA
+                # gate answers "not released" for every movie and the view
+                # lists nothing. Imported here rather than at module scope:
+                # the plugin loader swallows ImportError at DEBUG, so a
+                # load-order problem would silently disable the dashboard.
+                from couchpotato.core.media.movie._base.main import releaseDatesFromInfo
+
+                eta = media['info'].get('release_date') or {}
+                if not isinstance(eta, dict) or not eta:
+                    eta = releaseDatesFromInfo(media['info'])
                 coming_soon = False
 
                 # Theater quality
@@ -84,7 +96,10 @@ class Dashboard(Plugin):
                 if coming_soon:
 
                     # Don't list older movies
-                    eta_date = eta.get(coming_soon)
+                    # A derived mapping only knows 'theater' ('dvd' is left
+                    # unknown rather than guessed), so fall back to it --
+                    # otherwise the 'late' cutoff can never match.
+                    eta_date = eta.get(coming_soon) or eta.get('theater')
                     eta_3month_passed = (eta_date < (now - 7862400)) if eta_date else False  # Release was more than 3 months ago
 
                     if (not late and not eta_3month_passed) or \

--- a/couchpotato/core/plugins/profile/main.py
+++ b/couchpotato/core/plugins/profile/main.py
@@ -12,6 +12,76 @@ from .index import ProfileIndex
 log = CPLog(__name__)
 
 
+# Seeded on a fresh install by ProfilePlugin.fill().
+#
+# ORDER MATTERS: index 0 is the MOST preferred quality (see QualityPlugin
+# .isHigher -- "a lower number means higher quality"), and MovieSearcher
+# .single() walks this list in order and stops at the first successful
+# download. So the first entry is effectively what a profile fetches.
+#
+# BUG-016: these used to be seeded worst-first -- 'Best' led with 720p and so
+# never reached 1080p, and 'UHD 4K' led with 720p and so could never deliver
+# 4K. Keep every list ordered best-first per the canonical ranking in
+# QualityPlugin.qualities. Existing databases are repaired separately by
+# couchpotato/core/migration/fix_profile_quality_order.py.
+#
+# The '3d' entries are consumed back-to-front by build_profile_doc(), so a
+# profile's 3D rungs must come first in its qualities list.
+DEFAULT_PROFILES = [{
+    'label': 'Best',
+    # Deliberately no 2160p: adding it here would silently switch existing
+    # users onto 20-60GB downloads. Users who want 4K have 'UHD 4K'.
+    'qualities': ['1080p', '720p', 'brrip', 'dvdrip']
+}, {
+    'label': 'HD',
+    'qualities': ['1080p', '720p']
+}, {
+    'label': 'SD',
+    'qualities': ['dvdr', 'dvdrip']
+}, {
+    'label': 'Prefer 3D HD',
+    'qualities': ['1080p', '720p', '1080p', '720p'],
+    '3d': [True, True]
+}, {
+    'label': '3D HD',
+    'qualities': ['1080p', '720p'],
+    '3d': [True, True]
+}, {
+    'label': 'UHD 4K',
+    'qualities': ['2160p', '1080p', '720p']
+}]
+
+
+def build_profile_doc(profile, order):
+    """Expand a DEFAULT_PROFILES entry into the document stored in the db.
+
+    `finish`/`wait_for`/`stop_after`/`3d` are positional siblings of
+    `qualities` -- entry N of each describes rung N -- so they are always
+    built to the same length. Defaults are "take the best thing available
+    now, then stop" (finish, no waiting).
+    """
+    doc = {
+        '_t': 'profile',
+        'label': toUnicode(profile.get('label')),
+        'order': order,
+        'qualities': profile.get('qualities'),
+        'minimum_score': 1,
+        'finish': [],
+        'wait_for': [],
+        'stop_after': [],
+        '3d': []
+    }
+
+    threed = list(profile.get('3d', []))
+    for _ in profile.get('qualities'):
+        doc['finish'].append(True)
+        doc['wait_for'].append(0)
+        doc['stop_after'].append(0)
+        doc['3d'].append(threed.pop() if threed else False)
+
+    return doc
+
+
 class ProfilePlugin(Plugin):
 
     _database = {
@@ -219,54 +289,10 @@ class ProfilePlugin(Plugin):
         try:
             db = get_db()
 
-            profiles = [{
-                'label': 'Best',
-                'qualities': ['720p', '1080p', 'brrip', 'dvdrip']
-            }, {
-                'label': 'HD',
-                'qualities': ['720p', '1080p']
-            }, {
-                'label': 'SD',
-                'qualities': ['dvdrip', 'dvdr']
-            }, {
-                'label': 'Prefer 3D HD',
-                'qualities': ['1080p', '720p', '720p', '1080p'],
-                '3d': [True, True]
-            }, {
-                'label': '3D HD',
-                'qualities': ['1080p', '720p'],
-                '3d': [True, True]
-            }, {
-                'label': 'UHD 4K',
-                'qualities': ['720p', '1080p', '2160p']
-            }]
-
-            # Create default quality profile
-            order = 0
-            for profile in profiles:
+            # Create default quality profiles
+            for order, profile in enumerate(DEFAULT_PROFILES):
                 log.info('Creating default profile: %s', profile.get('label'))
-
-                pro = {
-                    '_t': 'profile',
-                    'label': toUnicode(profile.get('label')),
-                    'order': order,
-                    'qualities': profile.get('qualities'),
-                    'minimum_score': 1,
-                    'finish': [],
-                    'wait_for': [],
-                    'stop_after': [],
-                    '3d': []
-                }
-
-                threed = profile.get('3d', [])
-                for q in profile.get('qualities'):
-                    pro['finish'].append(True)
-                    pro['wait_for'].append(0)
-                    pro['stop_after'].append(0)
-                    pro['3d'].append(threed.pop() if threed else False)
-
-                db.insert(pro)
-                order += 1
+                db.insert(build_profile_doc(profile, order))
 
             return True
         except Exception:

--- a/couchpotato/runner.py
+++ b/couchpotato/runner.py
@@ -300,6 +300,17 @@ def runCouchPotato(options, base_path, args, data_dir=None, log_dir=None, Env=No
     except Exception as e:
         log.warning('Release quality fix skipped: %s', e)
 
+    # Reorder default profiles seeded worst-first (BUG-016: 'Best' led with
+    # 720p, so it never reached 1080p). Only untouched default profiles are
+    # rewritten; customised ones are left alone.
+    try:
+        from couchpotato.core.migration.fix_profile_quality_order import fix_profile_quality_order
+        n_fixed, n_checked = fix_profile_quality_order(db)
+        if n_fixed:
+            log.info('Reordered %d of %d quality profiles best-first.', n_fixed, n_checked)
+    except Exception as e:
+        log.warning('Profile quality order fix skipped: %s', e)
+
     fireEventAsync('app.load')
 
     # Run with uvicorn

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -36,6 +36,19 @@
   notifications/metadata don't auto-fire); being addressed by the
   Downloaded/review workflow — see `specs/DOWNLOADED-REVIEW-WORKFLOW.md` +
   `specs/RENAMER-EVENT-CHAIN.md`.
+- **`movie.info.release_date` has no provider handler.** The event is fired
+  (`media/movie/_base/main.py`) but nothing registers a handler, so the
+  `{theater, dvd}` mapping the ETA gate reads was always empty and the gate
+  was a no-op — every movie downloaded regardless of release date (BUG-017).
+  Worked around by deriving a theatrical date from the `released` string the
+  TMDB provider already stores. The real fix is a provider handler using
+  TMDB's per-country `release_dates` endpoint, which would give a genuine
+  **digital/physical** date as well; until then `dvd` is always unknown, so
+  the dvd-based unlock paths in `couldBeReleased()` are dead code and the
+  dashboard's "late" view falls back to the theatrical date.
+- **The legacy `/old` UI's `movie.js` reads `info.release_date`** for display
+  and has therefore always shown nothing. Harmless — that stack is
+  unreachable (`/old/*` redirects) — but it goes away with UI-CLEANUP.
 - **Review + implement Dependabot dependency PRs** — keep the dependency
   update PRs Dependabot opens triaged and merged (bump, verify CI, `--admin`
   merge if they predate a CI change — see Lessons Learned #7); don't let them

--- a/specs/BUG-016-default-profile-quality-order.md
+++ b/specs/BUG-016-default-profile-quality-order.md
@@ -1,0 +1,128 @@
+# BUG-016: Default quality profiles are ordered worst-first
+
+## Problem
+
+A user set several movies to the built-in **Best** profile and every one of
+them downloaded at 720p, even though 1080p releases were available.
+
+This is working exactly as configured — the configuration is wrong.
+
+`couchpotato/core/plugins/quality/main.py:544` states the ordering contract:
+
+```python
+# Note to self: a lower number means higher quality
+```
+
+Index 0 of a profile's `qualities` list is the **most preferred** quality.
+`MovieSearcher.single()` iterates the list in order and breaks out of the loop
+as soon as one download succeeds (`searcher.py:282`, `if self.shuttingDown()
+or ret: break`), so index 0 wins whenever anything is found for it.
+
+But `Profile.fill()` (`profile/main.py:222`) seeds:
+
+```python
+{'label': 'Best',    'qualities': ['720p', '1080p', 'brrip', 'dvdrip']}
+{'label': 'HD',      'qualities': ['720p', '1080p']}
+{'label': 'SD',      'qualities': ['dvdrip', 'dvdr']}
+{'label': 'UHD 4K',  'qualities': ['720p', '1080p', '2160p']}
+{'label': 'Prefer 3D HD', 'qualities': ['1080p', '720p', '720p', '1080p'], '3d': [True, True]}
+```
+
+`fill()` also sets `finish: True` for every entry, so the first quality
+obtained also *ends* the movie — there is no later upgrade pass.
+
+Consequences:
+- **Best** means "prefer 720p, stop". 1080p is unreachable while any 720p exists.
+- **UHD 4K** never fetches 2160p while any 720p exists — the profile cannot do
+  the one thing its name promises.
+- **SD** prefers DVD-Rip over DVD-R, inverting the canonical ranking.
+- **Prefer 3D HD**'s non-3D tail (`720p`, `1080p`) is inverted; its 3D head is
+  correct.
+
+The canonical ranking is the order of `QualityPlugin.qualities`
+(`quality/main.py:27-38`), best first:
+
+    2160p > bd50 > 1080p > 720p > brrip > dvdr > dvdrip > scr > r5 > tc > ts > cam
+
+This is inherited from upstream CouchPotato, not introduced by this fork — but
+the labels have always been wrong about what the profiles do.
+
+## Fix Required
+
+1. Reorder the seeded defaults in `Profile.fill()` to match the canonical
+   ranking, **without changing which qualities are in each set**:
+
+   | Profile | Before | After |
+   |---|---|---|
+   | Best | `720p, 1080p, brrip, dvdrip` | `1080p, 720p, brrip, dvdrip` |
+   | HD | `720p, 1080p` | `1080p, 720p` |
+   | SD | `dvdrip, dvdr` | `dvdr, dvdrip` |
+   | UHD 4K | `720p, 1080p, 2160p` | `2160p, 1080p, 720p` |
+   | Prefer 3D HD | `1080p, 720p, 720p, 1080p` | `1080p, 720p, 1080p, 720p` |
+   | 3D HD | `1080p, 720p` | unchanged (already correct) |
+
+   Deliberately **not** adding 2160p to `Best`: that would silently switch
+   existing users onto 20–60GB downloads. Users who want 4K have `UHD 4K`,
+   which this change makes actually work.
+
+   The `'3d'` flags for `Prefer 3D HD` are produced by `threed.pop()` and
+   remain `[True, True, False, False]` — the reorder must not disturb the
+   pairing of 3D flags to qualities.
+
+2. `fill()` only runs on a fresh install, so existing databases keep the bad
+   order. Add a one-time migration that repairs them.
+
+## Migration
+
+New `couchpotato/core/migration/fix_profile_quality_order.py`, wired into
+`couchpotato/runner.py` alongside `clean_orphans` and `fix_release_quality`
+(same try/except-and-log shape).
+
+**Safety rule: only rewrite a profile whose `label` AND `qualities` list match
+a known-bad seeded default exactly.** Anything the user has renamed,
+reordered, or edited is left strictly alone. This is the whole safety story —
+a migration that "helpfully" reorders custom profiles would destroy
+deliberate user choices (e.g. someone who genuinely prefers 720p for disk
+reasons).
+
+`finish` / `wait_for` / `stop_after` / `3d` are positional siblings of
+`qualities`. When a profile matches a bad default, all five lists must be
+permuted with the **same** permutation, or the flags detach from their
+qualities. For the seeded defaults every `finish` is `True` and every
+`wait_for`/`stop_after` is `0`, so this is invisible for untouched rows — but
+the migration must permute rather than assume uniform values, because a user
+may have changed a flag without changing the quality order.
+
+## Acceptance Criteria
+
+- [ ] AC1: `Profile.fill()` seeds every default profile in canonical
+      best-first order; asserted against the ordering derived from
+      `QualityPlugin.qualities` rather than a hardcoded copy, so the test
+      keeps working if a quality is added.
+- [ ] AC2: `fill()` still produces `finish`/`wait_for`/`stop_after`/`3d` lists
+      of the same length as `qualities` for every profile.
+- [ ] AC3: `Prefer 3D HD` keeps 3D 1080p first, 3D 720p second, and its
+      non-3D tail is 1080p then 720p.
+- [ ] AC4: The migration reorders a stored profile that exactly matches a
+      known-bad default, permuting `finish`/`wait_for`/`stop_after`/`3d`
+      identically.
+- [ ] AC5: The migration does **not** touch a profile whose `qualities` have
+      been customised, whose label was renamed, or which is already in the
+      correct order (idempotent — a second run is a no-op).
+- [ ] AC6: The migration returns `(fixed, checked)` and survives a DB error
+      without raising into startup.
+
+## Affected Files
+
+- `couchpotato/core/plugins/profile/main.py` — `fill()` defaults
+- `couchpotato/core/migration/fix_profile_quality_order.py` — new
+- `couchpotato/runner.py` — invoke migration
+- `tests/unit/test_profile_defaults.py` — new (AC1–AC3)
+- `tests/unit/test_fix_profile_quality_order.py` — new (AC4–AC6)
+
+## Note for affected users
+
+Existing movies already grabbed at 720p and marked done are **not**
+retroactively upgraded by this change; the migration fixes the profile so
+*future* searches prefer 1080p. To upgrade an existing movie, re-add it (or
+clear its release) after the migration has run.

--- a/specs/BUG-017-eta-unknown-release-dates.md
+++ b/specs/BUG-017-eta-unknown-release-dates.md
@@ -1,0 +1,128 @@
+# BUG-017: Unknown release dates are treated as "already released"
+
+## Problem
+
+A user bulk-added a batch of new movies and some began downloading before
+their release date.
+
+This is **not** the BUG-014 pre-release hole — that fix (#190) is present in
+the running v3.10.0 and guards the `is_pre_release` branch. This is a
+different path through the same method.
+
+`MovieSearcher.couldBeReleased()` (`couchpotato/core/media/movie/searcher.py:391`):
+
+```python
+# For movies before 1972
+if not dates or dates.get('theater', 0) < 0 or dates.get('dvd', 0) < 0:
+    return True
+```
+
+The comment states the intent: a **negative** epoch timestamp is the
+pre-1970/pre-1972 sentinel, so such movies are assumed long released. But
+`not dates` was folded into the same condition, which means an **empty or
+missing** `dates` dict also returns "could be released".
+
+Empty is exactly what the caller supplies when the lookup fails.
+`MovieBase.updateReleaseDate()` (`couchpotato/core/media/movie/_base/main.py:434`)
+returns `{}` from its exception handler, and also yields `{}` whenever the
+info provider simply has no `release_date` for the title yet.
+
+So: **"we don't know when this comes out" is read as "it's out"**, and the
+searcher proceeds to download.
+
+Note the asymmetry that makes this a latent trap rather than an obvious one —
+a dict with explicit zeros behaves correctly:
+
+| `dates` | current result | correct |
+|---|---|---|
+| `{'theater': 0, 'dvd': 0}` | False (too early) ✓ | False |
+| `{}` | **True (downloads)** ✗ | False |
+| `None` | **True (downloads)** ✗ | False |
+
+`{'theater': 0, 'dvd': 0}` is covered by an existing test
+(`test_non_pre_release_with_unknown_dates_returns_false`); `{}` and `None`
+are not, which is why BUG-014's work didn't surface this.
+
+### Why bulk-adding triggers it
+
+`search_on_add` defaults to on (`searcher.py` config block), so a search fires
+immediately per movie as it is added. Adding many movies at once is precisely
+when info-provider calls are most likely to be slow, rate-limited, or
+incomplete — producing the empty `dates` dict for some fraction of the batch.
+That matches the reported "added a bunch, some downloaded early".
+
+## Secondary finding: `always_search` under-describes itself
+
+`always_search` is documented as:
+
+> Search for movies even before there is a ETA. Enabling this will probably
+> get you a lot of fakes.
+
+But at `searcher.py:268` it is also one of the three conditions that authorise
+the **download**:
+
+```python
+if (force_download or not could_not_be_released or always_search) and \
+        fireEvent('release.try_download_result', ...):
+```
+
+So the setting does not merely widen searching, it disables the ETA download
+gate entirely. Anyone who enabled it expecting "search early, show me
+results, let me pick" gets automatic pre-ETA grabs.
+
+**Scope decision: do not change the behaviour.** Users have configured around
+the current semantics, and silently narrowing an opt-in setting is its own
+regression. Fix the description so it states the download consequence.
+
+## Fix Required
+
+1. Normalise `dates` once at the top of `couldBeReleased()`
+   (`dates = dates or {}`), so the remaining `.get()` calls are safe now that
+   the `not dates` short-circuit is being removed from the pre-1972 branch.
+
+2. Remove `not dates` from the pre-1972 condition, leaving only the negative
+   sentinel:
+
+   ```python
+   if dates.get('theater', 0) < 0 or dates.get('dvd', 0) < 0:
+       return True
+   ```
+
+   An empty dict then falls through every branch to the method's closing
+   `return False` — "unknown ⇒ not yet released". No new branch is needed.
+
+3. **Leave the top-of-method heuristic at line 381 alone.** It also tests
+   `not dates`, but there the combination is "old movie *and* no dates", which
+   is a deliberate and correct assumption (an unreleased film cannot have a
+   year two or more in the past). AC5 of BUG-014 pins that behaviour.
+
+4. Reword the `always_search` description to state that it also bypasses the
+   ETA gate for downloads, not just searching.
+
+## Acceptance Criteria
+
+- [ ] AC1 (bug repro): `couldBeReleased(False, {}, year=<current year>)`
+      returns False. Fails against the unfixed code.
+- [ ] AC2: same for `dates=None` — must return False, not raise.
+- [ ] AC3: same for `is_pre_release=True` with `{}` / `None`.
+- [ ] AC4 (regression): the negative-epoch sentinel still returns True —
+      `{'theater': -1}` and `{'dvd': -1}`.
+- [ ] AC5 (regression): an old movie with no dates still returns True via the
+      line-381 heuristic, for `{}`, `None` and `{'theater': 0, 'dvd': 0}`.
+- [ ] AC6 (regression): every existing case in
+      `tests/unit/test_movie_searcher_eta.py` still passes unchanged.
+- [ ] AC7: `always_search`'s description states that it also enables
+      downloading before the ETA.
+
+## Affected Files
+
+- `couchpotato/core/media/movie/searcher.py` — `couldBeReleased()`, and the
+  `always_search` config description
+- `tests/unit/test_movie_searcher_eta.py` — new cases (AC1–AC5)
+
+## Out of scope
+
+- Changing `always_search` behaviour (see scope decision above).
+- Making `search_on_add` wait for release-date resolution. Worth considering
+  separately, but the fix above already prevents the bad download; ordering
+  work here risks delaying legitimate adds.

--- a/specs/BUG-017-eta-unknown-release-dates.md
+++ b/specs/BUG-017-eta-unknown-release-dates.md
@@ -43,13 +43,51 @@ a dict with explicit zeros behaves correctly:
 (`test_non_pre_release_with_unknown_dates_returns_false`); `{}` and `None`
 are not, which is why BUG-014's work didn't surface this.
 
-### Why bulk-adding triggers it
+### The actual scale: the ETA gate has never worked at all
 
-`search_on_add` defaults to on (`searcher.py` config block), so a search fires
-immediately per movie as it is added. Adding many movies at once is precisely
-when info-provider calls are most likely to be slow, rate-limited, or
-incomplete — producing the empty `dates` dict for some fraction of the batch.
-That matches the reported "added a bunch, some downloaded early".
+An initial reading of this bug assumed empty `dates` was an occasional
+failure under load. It is not. **`movie.info.release_date` has no registered
+handler anywhere in the codebase.**
+
+```
+$ grep -rn "addEvent(" couchpotato --include "*.py" | grep -i release_date
+couchpotato/core/media/movie/_base/main.py:55:  addEvent('movie.update_release_dates', self.updateReleaseDate)
+```
+
+Only the *outer* event is registered. The inner one is fired but never
+handled, and `fireEvent` returns `[]` when a name has no handlers
+(`couchpotato/core/event.py:95`). Verified directly:
+
+```
+>>> fireEvent('movie.info.release_date', identifier='tt1', merge=True)
+[]
+```
+
+So `updateReleaseDate()` returns empty for **every movie on every search**,
+`not dates` is always true, and `couldBeReleased()` therefore always returns
+True. The ETA gate is a no-op: CouchPotato downloads whatever it finds,
+whenever it finds it. That — not an occasional provider hiccup — is why a
+batch of newly-added films downloaded before their release dates.
+
+It also means the naive fix is dangerous. Removing `not dates` while nothing
+populates `dates` flips the gate from always-open to always-**closed** for
+any movie whose year is the current year (older years exit early via the
+line-381 heuristic). Those films would never auto-download until the calendar
+rolled them into the "old movie" branch — roughly 16 months. That trades an
+early-download bug for a no-download bug.
+
+### The data already exists
+
+The TMDB provider stores the release date on the movie document
+(`providers/info/themoviedb.py:256`):
+
+```python
+'released': str(movie.get('release_date')),   # 'YYYY-MM-DD', or 'None'
+```
+
+Nothing ever converts it into the `{theater, dvd}` epoch mapping the gate
+reads. Deriving it there requires no extra API call and works for any info
+provider that populates `released`.
 
 ## Secondary finding: `always_search` under-describes itself
 
@@ -76,11 +114,44 @@ regression. Fix the description so it states the download consequence.
 
 ## Fix Required
 
-1. Normalise `dates` once at the top of `couldBeReleased()`
-   (`dates = dates or {}`), so the remaining `.get()` calls are safe now that
-   the `not dates` short-circuit is being removed from the pre-1972 branch.
+Closing the gate is only safe once something opens it, so the population fix
+and the guard fix must land together.
 
-2. Remove `not dates` from the pre-1972 condition, leaving only the negative
+1. **Populate the dates.** In `MovieBase.updateReleaseDate()`, when
+   `movie.info.release_date` yields nothing usable (i.e. always, today),
+   derive the mapping from the `released` string the info provider already
+   stored. A module-level `releaseDatesFromInfo(info)` keeps this testable
+   without a database:
+   - parse `'YYYY-MM-DD'` to a UTC-midnight epoch → `{'theater': <epoch>, 'dvd': 0}`
+   - return `{}` for anything unparseable, including the literal `'None'`
+     that `str(movie.get('release_date'))` produces when TMDB has no date
+   - do **not** write derived dates back to the document. Deriving is free,
+     and the current code's unconditional `db.update(media)` on every search
+     is a write per movie per cycle for no benefit.
+
+2. **Make the wait configurable.** The existing rule unlocks a download 12
+   weeks after the theatrical date (`theater + 7257600 < now`), which was
+   written when physical media was the target. Replace the hardcoded constant
+   with a new `wait_for_release` setting, **default 0 days** — a film unlocks
+   once its release date has passed. Users who want the old conservative
+   behaviour can set 84.
+
+   `couldBeReleased()` takes `wait_days` as a parameter (defaulting to 0)
+   rather than reading `self.conf` internally, so it stays a pure function
+   and the existing tests can keep instantiating it via `object.__new__`.
+   `MovieSearcher.single()` reads the setting and passes it.
+
+   The dvd-date rules are left untouched: they are a separate unlock path and
+   nothing populates `dvd` today, so changing them would be unverifiable
+   churn.
+
+3. Normalise `dates` once at the top of `couldBeReleased()`
+   (`dates = dates or {}`). Note the caller can supply a **list** — an
+   unhandled `fireEvent` returns `[]`, and existing databases have `[]`
+   stored in `info['release_date']` from previous runs — so `.get()` is not
+   safe without this.
+
+4. Remove `not dates` from the pre-1972 condition, leaving only the negative
    sentinel:
 
    ```python
@@ -88,15 +159,16 @@ regression. Fix the description so it states the download consequence.
        return True
    ```
 
-   An empty dict then falls through every branch to the method's closing
-   `return False` — "unknown ⇒ not yet released". No new branch is needed.
+   An empty mapping then falls through to the closing `return False` —
+   "unknown ⇒ not yet released". Safe only because of step 1.
 
-3. **Leave the top-of-method heuristic at line 381 alone.** It also tests
+5. **Leave the top-of-method heuristic at line 381 alone.** It also tests
    `not dates`, but there the combination is "old movie *and* no dates", which
    is a deliberate and correct assumption (an unreleased film cannot have a
-   year two or more in the past). AC5 of BUG-014 pins that behaviour.
+   year two or more in the past). AC5 of BUG-014 pins that behaviour. It also
+   remains the safety net for a movie whose `released` field is missing.
 
-4. Reword the `always_search` description to state that it also bypasses the
+6. Reword the `always_search` description to state that it also bypasses the
    ETA gate for downloads, not just searching.
 
 ## Acceptance Criteria
@@ -113,12 +185,49 @@ regression. Fix the description so it states the download consequence.
       `tests/unit/test_movie_searcher_eta.py` still passes unchanged.
 - [ ] AC7: `always_search`'s description states that it also enables
       downloading before the ETA.
+- [ ] AC8: `releaseDatesFromInfo({'released': '2026-08-14'})` returns a
+      `theater` epoch matching 2026-08-14 UTC midnight.
+- [ ] AC9: it returns `{}` for a missing key, `''`, the literal `'None'`,
+      a malformed string, and a non-string type — never raising.
+- [ ] AC10: `updateReleaseDate()` falls back to the derived dates when
+      `movie.info.release_date` returns `[]` (its real behaviour today), and
+      does not write the derived value back to the document.
+- [ ] AC11: a real provider result still wins over the derived fallback.
+- [ ] AC12: `couldBeReleased` honours `wait_days` — a movie released
+      yesterday is releasable at `wait_days=0` but not at `wait_days=7`; one
+      released 100 days ago is releasable at both.
+- [ ] AC13: a `wait_for_release` setting exists, defaults to `0`, and
+      `MovieSearcher.single()` passes it through.
+- [ ] AC14: the end-to-end case that started this — an unreleased film
+      (theatre date in the future) with a fully populated info document is
+      NOT releasable at the default setting.
 
 ## Affected Files
 
 - `couchpotato/core/media/movie/searcher.py` — `couldBeReleased()`, and the
   `always_search` config description
 - `tests/unit/test_movie_searcher_eta.py` — new cases (AC1–AC5)
+
+## Residual risk
+
+Closing the gate means a movie with no derivable date and a current-year
+`year` will not auto-download until the calendar rolls it into the line-381
+"old movie" heuristic. Two things keep that narrow:
+
+- The TMDB provider derives `year` **from** `release_date`
+  (`themoviedb.py:229`), so a movie with no release date generally has no
+  year either — and `year is None` routes to the line-381 heuristic, which
+  fails **open**. The dangerous combination (year known, release date
+  unknown) requires the year to have come from somewhere other than TMDB's
+  release date.
+- A manual search is unaffected: `manual=True` sets `ignore_eta`, and
+  `release.manual_download` bypasses `couldBeReleased()` entirely. The
+  searcher also surfaces out-of-ETA results in the dashboard for manual
+  selection.
+
+If this proves to bite, the fix is a real `movie.info.release_date` provider
+handler (TMDB exposes a per-country `release_dates` endpoint with both
+theatrical and digital dates), not re-opening the gate.
 
 ## Out of scope
 

--- a/tests/unit/test_dashboard_soon.py
+++ b/tests/unit/test_dashboard_soon.py
@@ -44,8 +44,13 @@ def _media(released, media_id='m1'):
     }
 
 
-def _run(media, gate, late=False, profile=None):
-    """Drive getSoonView with the surrounding plumbing mocked."""
+def _run(media, gate, late=False, profile=None, wait_days=0):
+    """Drive getSoonView with the surrounding plumbing mocked.
+
+    `gate` is the real couldBeReleased, called with whatever positional and
+    keyword arguments the view passes -- so a missing `wait_days` shows up as
+    a wrong answer rather than being silently absorbed by a stub.
+    """
     dashboard = object.__new__(Dashboard)
     profile = profile or {'_id': 'p1', 'qualities': ['1080p', '720p']}
 
@@ -57,7 +62,13 @@ def _run(media, gate, late=False, profile=None):
         if name == 'media.with_status':
             return [{'_id': media['_id']}]
         if name == 'movie.searcher.could_be_released':
-            return gate(*args)
+            # fireEvent consumes its own dispatch options before invoking a
+            # handler; forward only what the handler would really receive.
+            passthrough = {
+                k: v for k, v in kwargs.items()
+                if k not in ('single', 'merge', 'in_order', 'on_complete', 'is_after_event')
+            }
+            return gate(*args, **passthrough)
         if name == 'release.for_media':
             return []
         return None
@@ -67,7 +78,8 @@ def _run(media, gate, late=False, profile=None):
     db.get.return_value = media
 
     with patch('couchpotato.core.plugins.dashboard.get_db', return_value=db), \
-            patch('couchpotato.core.plugins.dashboard.fireEvent', side_effect=fake_fire_event):
+            patch('couchpotato.core.plugins.dashboard.fireEvent', side_effect=fake_fire_event), \
+            patch('couchpotato.core.plugins.dashboard.Env.setting', return_value=wait_days):
         return dashboard.getSoonView(late=late)
 
 
@@ -129,6 +141,38 @@ class TestComingSoonUsesDerivedDates:
         result = _run(_media(released='None'), gate)
 
         assert result['empty'] is True
+
+
+class TestHonoursTheConfiguredWait:
+    """The view answers "is this coming soon" by calling the same gate the
+    searcher uses. If it does not pass the configured `wait_for_release`, it
+    reports a movie as available while the searcher is still holding it back
+    -- the dashboard and the downloader disagree about the same movie.
+    """
+
+    def test_a_movie_inside_the_wait_window_is_not_listed(self, gate):
+        recent = time.strftime('%Y-%m-%d', time.gmtime(time.time() - 3 * DAY))
+
+        result = _run(_media(released=recent), gate, wait_days=21)
+
+        assert result['empty'] is True, (
+            'released 3 days ago with a 21-day wait: the searcher will not '
+            'download it, so the dashboard must not advertise it'
+        )
+
+    def test_a_movie_past_the_wait_window_is_listed(self, gate):
+        older = time.strftime('%Y-%m-%d', time.gmtime(time.time() - 30 * DAY))
+
+        result = _run(_media(released=older), gate, wait_days=21)
+
+        assert result['empty'] is False
+
+    def test_default_zero_wait_is_unchanged(self, gate):
+        recent = time.strftime('%Y-%m-%d', time.gmtime(time.time() - 3 * DAY))
+
+        result = _run(_media(released=recent), gate, wait_days=0)
+
+        assert result['empty'] is False
 
 
 class TestLateView:

--- a/tests/unit/test_dashboard_soon.py
+++ b/tests/unit/test_dashboard_soon.py
@@ -1,0 +1,152 @@
+"""Tests for the dashboard 'Coming soon' / 'Late' views (BUG-017 follow-up).
+
+`Dashboard.getSoonView()` decides whether a movie is coming soon by firing
+`movie.searcher.could_be_released` with `media['info']['release_date']` read
+straight off the document. Nothing ever populates that field -- the same
+BUG-017 root cause -- so it always passed an empty mapping.
+
+That was survivable only because `couldBeReleased()` used to return True for
+an empty mapping, which made the view list *every* active movie. Closing that
+hole for the searcher flips this caller from "lists everything" to "lists
+nothing", so the dashboard has to derive dates the same way the searcher now
+does.
+
+These tests drive the real `couldBeReleased` rather than stubbing it, so they
+exercise the actual gate.
+"""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from couchpotato.core.media.movie.searcher import MovieSearcher
+from couchpotato.core.plugins.dashboard import Dashboard
+
+DAY = 86400
+
+
+@pytest.fixture
+def gate():
+    """The real ETA gate, as the event would dispatch to it."""
+    searcher = object.__new__(MovieSearcher)
+    return searcher.couldBeReleased
+
+
+def _media(released, media_id='m1'):
+    return {
+        '_id': media_id,
+        '_t': 'movie',
+        'title': 'Test Movie',
+        'profile_id': 'p1',
+        'status': 'active',
+        'info': {'year': time.gmtime().tm_year, 'released': released},
+    }
+
+
+def _run(media, gate, late=False, profile=None):
+    """Drive getSoonView with the surrounding plumbing mocked."""
+    dashboard = object.__new__(Dashboard)
+    profile = profile or {'_id': 'p1', 'qualities': ['1080p', '720p']}
+
+    def fake_fire_event(name, *args, **kwargs):
+        if name == 'profile.all':
+            return [profile]
+        if name == 'quality.pre_releases':
+            return ['cam', 'ts', 'tc', 'r5', 'scr']
+        if name == 'media.with_status':
+            return [{'_id': media['_id']}]
+        if name == 'movie.searcher.could_be_released':
+            return gate(*args)
+        if name == 'release.for_media':
+            return []
+        return None
+
+    db = MagicMock()
+    db.all.return_value = [{'_id': media['_id']}]
+    db.get.return_value = media
+
+    with patch('couchpotato.core.plugins.dashboard.get_db', return_value=db), \
+            patch('couchpotato.core.plugins.dashboard.fireEvent', side_effect=fake_fire_event):
+        return dashboard.getSoonView(late=late)
+
+
+class TestComingSoonUsesDerivedDates:
+
+    def test_lists_a_recently_released_movie(self, gate):
+        """Bug repro: with the ETA gate closed for unknown dates, a dashboard
+        that reads the never-populated `release_date` field lists nothing at
+        all. It must derive from `info['released']` like the searcher does.
+
+        'Soon' means within the view's 3-month window -- a film released
+        years ago belongs to the 'late' view, not this one.
+        """
+        recent = time.strftime('%Y-%m-%d', time.gmtime(time.time() - 10 * DAY))
+
+        result = _run(_media(released=recent), gate)
+
+        assert result['empty'] is False
+        assert [m['_id'] for m in result['movies']] == ['m1']
+
+    def test_excludes_an_unreleased_movie(self, gate):
+        """The flip side, and a genuine improvement: before this work the
+        view listed every active movie regardless of date, because the gate
+        always said yes. A film that is not out yet is not 'coming soon' in
+        the downloadable sense the view is reporting."""
+        future = time.strftime('%Y-%m-%d', time.gmtime(time.time() + 90 * DAY))
+
+        result = _run(_media(released=future), gate)
+
+        assert result['empty'] is True
+
+    def test_a_cached_provider_date_still_wins(self, gate):
+        """If a provider ever populates release_date, that value is
+        authoritative -- the derivation is only a fallback."""
+        media = _media(released='2020-05-01')
+        media['info']['release_date'] = {
+            'theater': int(time.time()) + 90 * DAY, 'dvd': 0,
+        }
+
+        result = _run(media, gate)
+
+        assert result['empty'] is True, (
+            'the cached future date must override the derived past one'
+        )
+
+    def test_ignores_a_stale_empty_list_cached_by_previous_versions(self, gate):
+        """Existing databases hold `release_date: []` written by the old
+        updateReleaseDate() on every search."""
+        recent = time.strftime('%Y-%m-%d', time.gmtime(time.time() - 10 * DAY))
+        media = _media(released=recent)
+        media['info']['release_date'] = []
+
+        result = _run(media, gate)
+
+        assert result['empty'] is False
+
+    def test_movie_with_no_derivable_date_is_not_listed(self, gate):
+        """Unknown stays unknown -- no guessing."""
+        result = _run(_media(released='None'), gate)
+
+        assert result['empty'] is True
+
+
+class TestLateView:
+
+    def test_lists_a_movie_released_more_than_three_months_ago(self, gate):
+        """The 'late' cutoff reads `eta[coming_soon]`, but a derived mapping
+        only knows `theater` -- `dvd` is deliberately left 0 rather than
+        guessed. Without a fallback to `theater`, the late view can never
+        match anything for derived dates."""
+        old = time.strftime('%Y-%m-%d', time.gmtime(time.time() - 120 * DAY))
+
+        result = _run(_media(released=old), gate, late=True)
+
+        assert result['empty'] is False
+
+    def test_does_not_list_a_recent_release_as_late(self, gate):
+        recent = time.strftime('%Y-%m-%d', time.gmtime(time.time() - 10 * DAY))
+
+        result = _run(_media(released=recent), gate, late=True)
+
+        assert result['empty'] is True

--- a/tests/unit/test_fix_profile_quality_order.py
+++ b/tests/unit/test_fix_profile_quality_order.py
@@ -1,0 +1,279 @@
+"""Tests for the default-profile quality-order migration (BUG-016).
+
+`Profile.fill()` only runs on a fresh install, so correcting the seeded
+profiles does nothing for existing databases — a user whose 'Best' profile
+was created with `['720p', '1080p', ...]` keeps grabbing 720p forever. This
+migration repairs those rows on startup.
+
+The safety rule is the whole point: only a profile whose label AND stored
+quality order match a known-bad seed exactly is rewritten. A profile the user
+renamed, reordered, or otherwise edited is left strictly alone — somebody who
+deliberately prefers 720p for disk reasons must not have that silently undone.
+
+See specs/BUG-016-default-profile-quality-order.md.
+"""
+
+from unittest.mock import MagicMock
+
+from couchpotato.core.migration.fix_profile_quality_order import (
+    fix_profile_quality_order,
+)
+
+
+def _legacy_best():
+    """A 'Best' profile exactly as the old fill() would have seeded it."""
+    return {
+        '_t': 'profile',
+        '_id': 'profile-best',
+        '_rev': '001',
+        'label': 'Best',
+        'order': 0,
+        'qualities': ['720p', '1080p', 'brrip', 'dvdrip'],
+        'finish': [True, True, True, True],
+        'wait_for': [0, 0, 0, 0],
+        'stop_after': [0, 0, 0, 0],
+        '3d': [False, False, False, False],
+        'minimum_score': 1,
+    }
+
+
+def _db_with(*docs):
+    db = MagicMock()
+    db.all.return_value = [{'doc': doc} for doc in docs]
+    return db
+
+
+class TestRepairsLegacyDefaults:
+
+    def test_reorders_legacy_best_profile(self):
+        """AC4 (bug repro): the stored 'Best' profile is rewritten
+        best-first. Fails against a no-op migration."""
+        doc = _legacy_best()
+        db = _db_with(doc)
+
+        fixed, checked = fix_profile_quality_order(db)
+
+        assert (fixed, checked) == (1, 1)
+        db.update.assert_called_once()
+        updated = db.update.call_args[0][0]
+        assert updated['qualities'] == ['1080p', '720p', 'brrip', 'dvdrip']
+
+    def test_permutes_positional_lists_with_the_qualities(self):
+        """AC4: finish/wait_for/stop_after/3d are positional siblings. If
+        they are not permuted by the SAME permutation, a flag silently
+        detaches from its quality.
+
+        The seeds are uniform (all finish=True, all waits 0), which would
+        hide a bug here — so this fixture uses distinct per-rung values
+        while keeping the *qualities* an exact legacy match.
+        """
+        doc = _legacy_best()
+        doc['finish'] = [True, False, True, False]
+        doc['wait_for'] = [1, 2, 3, 4]
+        doc['stop_after'] = [10, 20, 30, 40]
+        db = _db_with(doc)
+
+        fixed, _ = fix_profile_quality_order(db)
+
+        assert fixed == 1
+        updated = db.update.call_args[0][0]
+        # 'Best' moves index 1 (1080p) to the front: permutation [1, 0, 2, 3]
+        assert updated['qualities'] == ['1080p', '720p', 'brrip', 'dvdrip']
+        assert updated['finish'] == [False, True, True, False]
+        assert updated['wait_for'] == [2, 1, 3, 4]
+        assert updated['stop_after'] == [20, 10, 30, 40]
+
+    def test_reorders_legacy_uhd_4k_profile(self):
+        """AC4: 'UHD 4K' led with 720p and so could never deliver 4K."""
+        doc = _legacy_best()
+        doc['label'] = 'UHD 4K'
+        doc['qualities'] = ['720p', '1080p', '2160p']
+        doc['finish'] = [True, True, True]
+        doc['wait_for'] = [0, 0, 0]
+        doc['stop_after'] = [0, 0, 0]
+        doc['3d'] = [False, False, False]
+        db = _db_with(doc)
+
+        fixed, _ = fix_profile_quality_order(db)
+
+        assert fixed == 1
+        assert db.update.call_args[0][0]['qualities'] == ['2160p', '1080p', '720p']
+
+    def test_reorders_prefer_3d_hd_keeping_3d_flags_attached(self):
+        """AC4: 'Prefer 3D HD' has duplicate identifiers, so the 3D flags are
+        the only thing distinguishing rungs. Its 3D head is already correct;
+        only the non-3D tail is inverted."""
+        doc = _legacy_best()
+        doc['label'] = 'Prefer 3D HD'
+        doc['qualities'] = ['1080p', '720p', '720p', '1080p']
+        doc['3d'] = [True, True, False, False]
+        db = _db_with(doc)
+
+        fixed, _ = fix_profile_quality_order(db)
+
+        assert fixed == 1
+        updated = db.update.call_args[0][0]
+        pairs = list(zip(updated['qualities'], [bool(x) for x in updated['3d']]))
+        assert pairs == [
+            ('1080p', True),
+            ('720p', True),
+            ('1080p', False),
+            ('720p', False),
+        ]
+
+    def test_repairs_multiple_profiles_in_one_pass(self):
+        best = _legacy_best()
+        hd = _legacy_best()
+        hd['_id'] = 'profile-hd'
+        hd['label'] = 'HD'
+        hd['qualities'] = ['720p', '1080p']
+        hd['finish'] = [True, True]
+        hd['wait_for'] = [0, 0]
+        hd['stop_after'] = [0, 0]
+        hd['3d'] = [False, False]
+        db = _db_with(best, hd)
+
+        fixed, checked = fix_profile_quality_order(db)
+
+        assert (fixed, checked) == (2, 2)
+        assert db.update.call_count == 2
+
+
+class TestLeavesUserProfilesAlone:
+    """AC5 — the safety rule."""
+
+    def test_ignores_customised_quality_list(self):
+        """A 'Best' the user edited (here: 2160p added) no longer matches the
+        known-bad seed, so it must not be rewritten — we cannot know what
+        order they intended."""
+        doc = _legacy_best()
+        doc['qualities'] = ['720p', '1080p', '2160p', 'brrip', 'dvdrip']
+        doc['finish'] = [True] * 5
+        doc['wait_for'] = [0] * 5
+        doc['stop_after'] = [0] * 5
+        doc['3d'] = [False] * 5
+        db = _db_with(doc)
+
+        fixed, checked = fix_profile_quality_order(db)
+
+        assert (fixed, checked) == (0, 1)
+        db.update.assert_not_called()
+
+    def test_ignores_renamed_profile(self):
+        """Matching is on label as well as qualities: a renamed profile is
+        the user's, not ours."""
+        doc = _legacy_best()
+        doc['label'] = 'My Best'
+        db = _db_with(doc)
+
+        fixed, checked = fix_profile_quality_order(db)
+
+        assert (fixed, checked) == (0, 1)
+        db.update.assert_not_called()
+
+    def test_ignores_profile_the_user_already_reordered(self):
+        """Someone who deliberately put 720p last must keep that."""
+        doc = _legacy_best()
+        doc['qualities'] = ['brrip', 'dvdrip', '1080p', '720p']
+        db = _db_with(doc)
+
+        fixed, checked = fix_profile_quality_order(db)
+
+        assert (fixed, checked) == (0, 1)
+        db.update.assert_not_called()
+
+    def test_is_idempotent(self):
+        """AC5: an already-corrected profile is not a known-bad seed, so a
+        second startup is a no-op. Without this the migration would fight a
+        user who re-reorders after the first run."""
+        doc = _legacy_best()
+        doc['qualities'] = ['1080p', '720p', 'brrip', 'dvdrip']
+        db = _db_with(doc)
+
+        fixed, checked = fix_profile_quality_order(db)
+
+        assert (fixed, checked) == (0, 1)
+        db.update.assert_not_called()
+
+    def test_ignores_3d_variant_that_does_not_match_flags(self):
+        """'Prefer 3D HD' with different 3D flags is a different profile;
+        the identifiers alone are ambiguous because they repeat."""
+        doc = _legacy_best()
+        doc['label'] = 'Prefer 3D HD'
+        doc['qualities'] = ['1080p', '720p', '720p', '1080p']
+        doc['3d'] = [True, False, True, False]
+        db = _db_with(doc)
+
+        fixed, checked = fix_profile_quality_order(db)
+
+        assert (fixed, checked) == (0, 1)
+        db.update.assert_not_called()
+
+    def test_ignores_3d_hd_which_was_already_correct(self):
+        """Regression guard: '3D HD' was never mis-seeded and must not be in
+        the known-bad table at all."""
+        doc = _legacy_best()
+        doc['label'] = '3D HD'
+        doc['qualities'] = ['1080p', '720p']
+        doc['finish'] = [True, True]
+        doc['wait_for'] = [0, 0]
+        doc['stop_after'] = [0, 0]
+        doc['3d'] = [True, True]
+        db = _db_with(doc)
+
+        fixed, checked = fix_profile_quality_order(db)
+
+        assert (fixed, checked) == (0, 1)
+        db.update.assert_not_called()
+
+
+class TestFailureHandling:
+    """AC6 — this runs during startup; it must never take the app down."""
+
+    def test_returns_zero_when_the_listing_fails(self):
+        db = MagicMock()
+        db.all.side_effect = Exception('database is locked')
+
+        assert fix_profile_quality_order(db) == (0, 0)
+
+    def test_one_bad_row_does_not_abort_the_batch(self):
+        """A write conflict on one profile must not strand the others."""
+        bad = _legacy_best()
+        good = _legacy_best()
+        good['_id'] = 'profile-hd'
+        good['label'] = 'HD'
+        good['qualities'] = ['720p', '1080p']
+        good['finish'] = [True, True]
+        good['wait_for'] = [0, 0]
+        good['stop_after'] = [0, 0]
+        good['3d'] = [False, False]
+        db = _db_with(bad, good)
+        db.update.side_effect = [Exception('conflict'), None]
+
+        fixed, checked = fix_profile_quality_order(db)
+
+        assert checked == 2
+        assert fixed == 1, 'the second profile should still have been repaired'
+
+    def test_tolerates_profile_missing_positional_lists(self):
+        """Very old rows may lack a '3d' list entirely; that must be
+        treated as all-non-3D for matching rather than raising."""
+        doc = _legacy_best()
+        del doc['3d']
+        db = _db_with(doc)
+
+        fixed, checked = fix_profile_quality_order(db)
+
+        assert checked == 1
+        assert fixed == 1
+        assert db.update.call_args[0][0]['qualities'] == [
+            '1080p', '720p', 'brrip', 'dvdrip',
+        ]
+
+    def test_ignores_non_profile_documents(self):
+        db = _db_with({'_t': 'movie', '_id': 'x', 'label': 'Best'})
+
+        fixed, checked = fix_profile_quality_order(db)
+
+        assert (fixed, checked) == (0, 0)
+        db.update.assert_not_called()

--- a/tests/unit/test_fix_profile_quality_order.py
+++ b/tests/unit/test_fix_profile_quality_order.py
@@ -270,6 +270,48 @@ class TestFailureHandling:
             '1080p', '720p', 'brrip', 'dvdrip',
         ]
 
+    def test_refuses_to_half_migrate_a_row_with_a_truncated_list(self):
+        """A malformed row must be left ALONE, not partially rewritten.
+
+        `_match()` validates label/qualities/3d, so a row whose `finish` (or
+        `wait_for`/`stop_after`) list is the wrong length still matches a
+        legacy default. If we reorder `qualities` but skip the mismatched
+        list, every remaining flag silently describes a different quality
+        than before — e.g. finish[0] was 720p's and now claims to be
+        1080p's. That is worse than leaving the row untouched, because the
+        damage is invisible.
+
+        The row is already broken (MovieSearcher.single() indexes
+        profile['finish'][index] with no length guard), but the migration
+        must not make it *differently* broken.
+        """
+        doc = _legacy_best()
+        doc['finish'] = [True, False, True]  # 3 entries for 4 qualities
+        db = _db_with(doc)
+
+        fixed, checked = fix_profile_quality_order(db)
+
+        assert (fixed, checked) == (0, 1)
+        db.update.assert_not_called()
+        assert doc['qualities'] == ['720p', '1080p', 'brrip', 'dvdrip'], (
+            'the malformed row must be left exactly as found'
+        )
+
+    def test_absent_positional_list_is_still_migratable(self):
+        """Distinguish 'absent' from 'present but wrong length'. An absent
+        list has nothing to detach, so reordering qualities stays safe —
+        this is the older-schema case covered above for '3d'."""
+        doc = _legacy_best()
+        del doc['stop_after']
+        db = _db_with(doc)
+
+        fixed, checked = fix_profile_quality_order(db)
+
+        assert (fixed, checked) == (1, 1)
+        assert db.update.call_args[0][0]['qualities'] == [
+            '1080p', '720p', 'brrip', 'dvdrip',
+        ]
+
     def test_ignores_non_profile_documents(self):
         db = _db_with({'_t': 'movie', '_id': 'x', 'label': 'Best'})
 

--- a/tests/unit/test_movie_release_dates.py
+++ b/tests/unit/test_movie_release_dates.py
@@ -119,6 +119,23 @@ class TestReleaseDatesFromInfo:
         one, because nothing surfaces it."""
         assert releaseDatesFromInfo({'released': released}) == {}
 
+    @pytest.mark.parametrize('released', [
+        '10000-01-01',      # one past datetime's ceiling
+        '99999999-06-15',
+    ])
+    def test_rejects_years_outside_the_representable_range(self, released):
+        """calendar.monthrange/timegm raise ValueError above year 9999
+        (`year must be in 1..9999`). This function promises never to raise --
+        a provider returning a nonsense year must degrade to "unknown", not
+        throw an exception up into the search loop once per movie."""
+        assert releaseDatesFromInfo({'released': released}) == {}
+
+    def test_accepts_the_last_representable_year(self):
+        """The boundary on the other side stays usable."""
+        dates = releaseDatesFromInfo({'released': '9999-12-31'})
+
+        assert dates['theater'] == _epoch(9999, 12, 31)
+
     def test_accepts_a_real_leap_day(self):
         """The mirror of the above: 2024 IS a leap year, so this is valid and
         must not be rejected by an over-eager guard."""

--- a/tests/unit/test_movie_release_dates.py
+++ b/tests/unit/test_movie_release_dates.py
@@ -1,0 +1,156 @@
+"""Tests for release-date population (BUG-017).
+
+`MovieBase.updateReleaseDate()` fires `movie.info.release_date` to obtain the
+`{theater, dvd}` epoch mapping the ETA gate reads. **Nothing in the codebase
+registers a handler for that event**, and `fireEvent` returns `[]` for an
+unhandled name, so the mapping was empty for every movie on every search —
+which made `couldBeReleased()` a no-op that authorised every download.
+
+The date itself was always there: the info provider stores TMDB's
+`release_date` as `info['released']` ('YYYY-MM-DD', or the literal string
+'None' when TMDB has no date, because it is written via `str()`). These tests
+cover deriving the mapping from it.
+
+See specs/BUG-017-eta-unknown-release-dates.md.
+"""
+
+import calendar
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from couchpotato.core.media.movie._base.main import releaseDatesFromInfo
+
+
+def _epoch(year, month, day):
+    return calendar.timegm((year, month, day, 0, 0, 0, 0, 0, 0))
+
+
+class TestReleaseDatesFromInfo:
+
+    def test_parses_an_iso_date_to_utc_midnight(self):
+        """AC8: the happy path — TMDB's 'YYYY-MM-DD'."""
+        dates = releaseDatesFromInfo({'released': '2026-08-14'})
+
+        assert dates['theater'] == _epoch(2026, 8, 14)
+
+    def test_leaves_dvd_unknown(self):
+        """The info provider gives one date. Claiming a dvd date we don't
+        have would unlock the '4 weeks before dvd' early-download path on a
+        fabricated value."""
+        dates = releaseDatesFromInfo({'released': '2026-08-14'})
+
+        assert dates['dvd'] == 0
+
+    def test_is_timezone_independent(self):
+        """The gate compares against `int(time.time())`, which is UTC. Using
+        a local-time parse would shift the unlock by up to a day and make
+        behaviour depend on the server's TZ."""
+        dates = releaseDatesFromInfo({'released': '1970-01-02'})
+
+        assert dates['theater'] == 86400
+
+    @pytest.mark.parametrize('info', [
+        {},
+        {'released': ''},
+        {'released': None},
+        {'released': 'None'},          # str(None) from the TMDB provider
+        {'released': 'none'},
+        {'released': 'not-a-date'},
+        {'released': '2026-13-45'},    # well-formed shape, impossible date
+        {'released': '2026'},
+        {'released': 12345},           # not a string at all
+        {'released': ['2026-08-14']},
+    ], ids=lambda i: repr(i.get('released', '<missing>')))
+    def test_unparseable_input_yields_empty_without_raising(self, info):
+        """AC9: anything we cannot read must degrade to "unknown", never
+        raise into a search cycle and never invent a date.
+
+        'None' matters most: `str(movie.get('release_date'))` in the TMDB
+        provider turns a missing date into that literal string, and it is
+        truthy, so a naive check would treat it as a real value.
+        """
+        assert releaseDatesFromInfo(info) == {}
+
+    def test_tolerates_a_non_dict(self):
+        assert releaseDatesFromInfo(None) == {}
+
+    def test_accepts_a_datetime_style_string(self):
+        """Some providers append a time component; take the date part."""
+        dates = releaseDatesFromInfo({'released': '2026-08-14 00:00:00'})
+
+        assert dates['theater'] == _epoch(2026, 8, 14)
+
+
+class TestUpdateReleaseDateFallback:
+    """AC10/AC11 — the wiring in MovieBase.updateReleaseDate()."""
+
+    def _media(self, released='2026-08-14', cached=None):
+        info = {'released': released, 'year': 2026}
+        if cached is not None:
+            info['release_date'] = cached
+        return {
+            '_t': 'movie',
+            '_id': 'movie-1',
+            '_rev': '001',
+            'identifiers': {'imdb': 'tt1234567'},
+            'info': info,
+        }
+
+    def _run(self, media, event_result):
+        """Drive updateReleaseDate with a mocked db and event bus."""
+        from couchpotato.core.media.movie._base.main import MovieBase
+
+        plugin = object.__new__(MovieBase)
+        db = MagicMock()
+        db.get.return_value = media
+
+        with patch('couchpotato.core.media.movie._base.main.get_db', return_value=db), \
+                patch('couchpotato.core.media.movie._base.main.fireEvent',
+                      return_value=event_result) as fire:
+            result = plugin.updateReleaseDate('movie-1')
+
+        return result, db, fire
+
+    def test_falls_back_to_derived_dates_when_event_is_unhandled(self):
+        """AC10 (bug repro): `[]` is what an unhandled fireEvent returns, and
+        it is what this event returns in production. The derived date must be
+        used instead of surfacing the empty list."""
+        result, _, _ = self._run(self._media(), event_result=[])
+
+        assert result['theater'] == _epoch(2026, 8, 14)
+
+    def test_does_not_write_derived_dates_back_to_the_document(self):
+        """AC10: deriving is free, so persisting it would just be a db write
+        per movie per search cycle -- which is what the old code did with the
+        useless empty result."""
+        _, db, _ = self._run(self._media(), event_result=[])
+
+        db.update.assert_not_called()
+
+    def test_a_real_provider_result_wins_over_the_fallback(self):
+        """AC11: if a provider ever implements the event, its answer is
+        authoritative -- it may know a dvd date, which we never derive."""
+        provided = {'theater': 111, 'dvd': 222, 'expires': 999}
+
+        result, db, _ = self._run(self._media(), event_result=provided)
+
+        assert result == provided
+        db.update.assert_called_once()
+
+    def test_returns_empty_when_nothing_is_derivable(self):
+        """No usable date anywhere -> unknown. couldBeReleased() then treats
+        the movie as not-yet-released unless it is old enough to hit the
+        'old movie' heuristic."""
+        result, _, _ = self._run(self._media(released='None'), event_result=[])
+
+        assert result == {}
+
+    def test_ignores_a_stale_empty_list_cached_by_previous_versions(self):
+        """Existing databases have `release_date: []` written by the old code
+        on every search. That must not be mistaken for a valid cached value."""
+        result, _, _ = self._run(
+            self._media(cached=[]), event_result=[],
+        )
+
+        assert result['theater'] == _epoch(2026, 8, 14)

--- a/tests/unit/test_movie_release_dates.py
+++ b/tests/unit/test_movie_release_dates.py
@@ -75,6 +75,57 @@ class TestReleaseDatesFromInfo:
     def test_tolerates_a_non_dict(self):
         assert releaseDatesFromInfo(None) == {}
 
+    def test_rejects_the_tmdb_1900_placeholder(self):
+        """TMDB uses 1900-01-01 to mean "no release date". The provider
+        already knows this -- themoviedb.py has `# 1900 is the same as None`
+        and nulls `year` for it -- but it still writes the placeholder to
+        `released`.
+
+        Taking it literally is not merely wrong, it reopens this very bug:
+        1900 is a NEGATIVE epoch, and couldBeReleased() treats a negative
+        date as the pre-1972 "definitely already out" sentinel and returns
+        True before any wait is applied. So an unknown release date would
+        once again authorise an immediate download.
+        """
+        assert releaseDatesFromInfo({'released': '1900-01-01'}) == {}
+
+    @pytest.mark.parametrize('released', [
+        '1900-01-01', '1899-12-31', '1965-06-01', '1969-12-31',
+    ])
+    def test_rejects_pre_epoch_dates(self, released):
+        """More generally: never derive a negative epoch, because it collides
+        with the pre-1972 sentinel. Genuinely old films are not harmed -- an
+        old `year` routes them to couldBeReleased()'s "old movie, no dates"
+        heuristic, which assumes released. Being unknown is the right answer
+        here; being negative is an assertion we don't want to make."""
+        assert releaseDatesFromInfo({'released': released}) == {}
+
+    def test_accepts_the_first_representable_date(self):
+        """The boundary: 1970-01-01 is epoch 0, which is not negative and so
+        does not trip the sentinel."""
+        assert releaseDatesFromInfo({'released': '1970-01-01'}) == {
+            'theater': 0, 'dvd': 0,
+        }
+
+    @pytest.mark.parametrize('released', [
+        '2026-02-30',   # February never has 30 days
+        '2026-04-31',   # April has 30
+        '2023-02-29',   # not a leap year
+    ], ids=['feb-30', 'apr-31', 'non-leap-feb-29'])
+    def test_rejects_impossible_days_for_the_month(self, released):
+        """`timegm` silently NORMALISES an impossible day rather than
+        raising -- 2026-02-30 becomes 2026-03-02 -- so a day <= 31 check is
+        not enough. A quietly shifted unlock date is worse than a rejected
+        one, because nothing surfaces it."""
+        assert releaseDatesFromInfo({'released': released}) == {}
+
+    def test_accepts_a_real_leap_day(self):
+        """The mirror of the above: 2024 IS a leap year, so this is valid and
+        must not be rejected by an over-eager guard."""
+        dates = releaseDatesFromInfo({'released': '2024-02-29'})
+
+        assert dates['theater'] == _epoch(2024, 2, 29)
+
     def test_accepts_a_datetime_style_string(self):
         """Some providers append a time component; take the date part."""
         dates = releaseDatesFromInfo({'released': '2026-08-14 00:00:00'})

--- a/tests/unit/test_movie_searcher_eta.py
+++ b/tests/unit/test_movie_searcher_eta.py
@@ -340,19 +340,66 @@ class TestWaitForReleaseSetting:
         assert option['type'] == 'int'
 
     def test_single_passes_the_setting_to_could_be_released(self):
-        """A setting nothing reads is worse than no setting. Pin the wiring
-        so a refactor cannot quietly drop it."""
-        import inspect
+        """A setting nothing reads is worse than no setting.
+
+        This drives single() for real and asserts on the call, rather than
+        grepping its source: a source check stays green if the value is read
+        into a variable and then silently dropped before the call, which is
+        exactly the regression worth guarding against.
+        """
+        from unittest.mock import MagicMock, patch
 
         from couchpotato.core.media.movie.searcher import MovieSearcher
 
-        source = inspect.getsource(MovieSearcher.single)
+        searcher = MovieSearcher.__new__(MovieSearcher)
+        movie = {
+            '_id': 'movie-1', 'title': 'Test', 'profile_id': 'profile-1',
+            'status': 'active', 'releases': [],
+            'info': {'year': 2026, 'titles': ['Test']},
+            'identifiers': {'imdb': 'tt1234567'},
+        }
+        profile = {
+            '_id': 'profile-1', 'qualities': ['1080p'], 'finish': [True],
+            'wait_for': [0], 'stop_after': [0], '3d': [False],
+            'minimum_score': 1,
+        }
 
-        assert "self.conf('wait_for_release')" in source, (
-            'single() must read the wait_for_release setting'
-        )
-        assert 'wait_days' in source, (
-            'single() must pass wait_days through to couldBeReleased'
+        def fake_fire_event(name, *args, **kwargs):
+            return {
+                'quality.pre_releases': [],
+                'movie.update_release_dates': {'theater': 1, 'dvd': 0},
+                'quality.single': {'identifier': '1080p', 'label': '1080p'},
+                'searcher.search': [],
+                'media.get': movie,
+                'release.create_from_search': [],
+                'release.try_download_result': False,
+                'media.restatus': 'active',
+            }.get(name)
+
+        db = MagicMock()
+        db.get.return_value = profile
+
+        # 'always_search' must stay falsy or the ETA branch is skipped.
+        conf = MagicMock(side_effect=lambda name, **kw: {
+            'always_search': False, 'wait_for_release': 21,
+        }.get(name))
+
+        # With always_search falsy, single() takes the "ignore eta once every
+        # 7 days" path, which reads Env.prop; float() needs a real number.
+        env = MagicMock()
+        env.prop.return_value = 0
+
+        with patch('couchpotato.core.media.movie.searcher.fireEvent', side_effect=fake_fire_event), \
+                patch('couchpotato.core.media.movie.searcher.get_db', return_value=db), \
+                patch('couchpotato.core.media.movie.searcher.Env', env), \
+                patch.object(searcher, 'conf', conf), \
+                patch.object(searcher, 'couldBeReleased', return_value=True) as could:
+            searcher.single(movie, search_protocols=['nzb'])
+
+        assert could.called, 'single() must consult couldBeReleased'
+        assert could.call_args.kwargs.get('wait_days') == 21, (
+            'single() must pass the configured wait through, got %r'
+            % (could.call_args,)
         )
 
 

--- a/tests/unit/test_movie_searcher_eta.py
+++ b/tests/unit/test_movie_searcher_eta.py
@@ -158,6 +158,115 @@ class TestCouldBeReleasedPreReleaseGuard:
         assert result is True
 
 
+class TestCouldBeReleasedUnknownDates:
+    """BUG-017: an EMPTY or absent `dates` mapping meant 'already released'.
+
+    The pre-1972 branch read `if not dates or dates.get('theater', 0) < 0
+    or dates.get('dvd', 0) < 0: return True`. The comment shows the intent —
+    a *negative* epoch is the pre-1970 sentinel — but `not dates` rode along,
+    so an unknown release date returned True and the searcher downloaded.
+
+    Empty is exactly what the caller passes when the lookup fails:
+    `MovieBase.updateReleaseDate()` returns `{}` from its exception handler
+    and whenever the info provider has no release_date yet. Bulk-adding
+    movies (each triggering a search via `search_on_add`) is when provider
+    calls are most likely to come back empty.
+
+    Note the asymmetry that hid this: `{'theater': 0, 'dvd': 0}` already
+    behaved correctly (see TestCouldBeReleasedPreReleaseGuard), so only the
+    falsy-mapping shapes were wrong. See specs/BUG-017-eta-unknown-release-dates.md.
+    """
+
+    @pytest.mark.parametrize('dates', [{}, None], ids=['empty-dict', 'none'])
+    def test_unknown_dates_are_not_releasable(self, searcher, dates):
+        """AC1/AC2 (bug repro): a current-year movie whose release dates
+        could not be resolved must NOT be considered released. Fails against
+        the unfixed code, which returns True for both shapes."""
+        result = searcher.couldBeReleased(
+            False, dates, year=time.gmtime().tm_year,
+        )
+        assert result is False, (
+            "Unknown release dates must not authorise a download"
+        )
+
+    @pytest.mark.parametrize('dates', [{}, None], ids=['empty-dict', 'none'])
+    def test_unknown_dates_are_not_releasable_for_pre_releases(self, searcher, dates):
+        """AC3: same for the pre-release branch — unknown is unknown
+        regardless of which branch asks."""
+        result = searcher.couldBeReleased(
+            True, dates, year=time.gmtime().tm_year,
+        )
+        assert result is False
+
+    @pytest.mark.parametrize('dates', [
+        {'theater': -1},
+        {'dvd': -1},
+        {'theater': -1, 'dvd': 0},
+    ], ids=['theater', 'dvd', 'theater-with-zero-dvd'])
+    def test_negative_epoch_sentinel_still_releasable(self, searcher, dates):
+        """AC4 (regression): the pre-1972 sentinel is the branch's real
+        purpose and must survive removal of the `not dates` clause. Note
+        these dicts are missing a key each — the fix must not reintroduce a
+        TypeError on partial mappings."""
+        result = searcher.couldBeReleased(
+            False, dates, year=time.gmtime().tm_year,
+        )
+        assert result is True
+
+    @pytest.mark.parametrize('dates', [
+        {}, None, {'theater': 0, 'dvd': 0},
+    ], ids=['empty-dict', 'none', 'explicit-zeros'])
+    def test_old_movie_with_unknown_dates_is_still_releasable(self, searcher, dates):
+        """AC5 (regression): the *other* `not dates` test — the top-of-method
+        'old movie and no dates' heuristic at line 381 — is deliberate and
+        must be left intact. A film two years old cannot be unreleased, so
+        assuming released is right there. Only the pre-1972 branch changes."""
+        old_year = time.gmtime().tm_year - 2
+        result = searcher.couldBeReleased(False, dates, year=old_year)
+        assert result is True
+
+    def test_unknown_year_with_unknown_dates_is_still_releasable(self, searcher):
+        """Regression: `year=None` also routes to the line-381 heuristic
+        (catalogue entries with no year at all)."""
+        assert searcher.couldBeReleased(False, {}, year=None) is True
+
+
+class TestAlwaysSearchDescription:
+    """AC7: `always_search` does not merely widen searching — at
+    `MovieSearcher.single()` it is also one of the three conditions that
+    authorise the download (`force_download or not could_not_be_released or
+    always_search`). The description said only 'Search for movies even
+    before there is a ETA', so a user could enable it expecting to review
+    results manually and instead get automatic pre-ETA grabs.
+
+    Behaviour is deliberately unchanged (people have configured around it);
+    only the description is corrected. See specs/BUG-017.
+    """
+
+    def _always_search_option(self):
+        from couchpotato.core.media.movie.searcher import config
+
+        for plugin in config:
+            for group in plugin.get('groups', []):
+                for option in group.get('options', []):
+                    if option.get('name') == 'always_search':
+                        return option
+        raise AssertionError('always_search option not found in config')
+
+    def test_description_mentions_downloading_not_just_searching(self):
+        description = self._always_search_option()['description'].lower()
+
+        assert 'download' in description, (
+            "always_search also bypasses the ETA gate for downloads; the "
+            "description must say so, got: %r" % description
+        )
+
+    def test_default_is_still_off(self):
+        """Regression guard: the honest description must not come with a
+        quiet default flip."""
+        assert self._always_search_option()['default'] is False
+
+
 class TestCouldBeReleasedMissingDateKeys:
     """Latent TypeError hardening: `dates.get('theater')` / `dates.get('dvd')`
     without an explicit default return None for a dict that has other keys

--- a/tests/unit/test_movie_searcher_eta.py
+++ b/tests/unit/test_movie_searcher_eta.py
@@ -231,6 +231,131 @@ class TestCouldBeReleasedUnknownDates:
         assert searcher.couldBeReleased(False, {}, year=None) is True
 
 
+class TestConfigurableWaitAfterRelease:
+    """BUG-017: the theatrical unlock was hardcoded at 12 weeks
+    (`theater + 7257600 < now`), written when physical media was the target.
+
+    Now that release dates are actually populated, that constant decides when
+    every movie in a library becomes downloadable, so it is a setting rather
+    than a magic number. Default 0 -- a film unlocks once its release date has
+    passed; set 84 for the old behaviour.
+    """
+
+    def _released_days_ago(self, days):
+        return {'theater': int(time.time()) - days * 86400, 'dvd': 0}
+
+    def test_default_unlocks_once_the_release_date_has_passed(self):
+        """AC12: yesterday's release is downloadable at the default."""
+        searcher = object.__new__(MovieSearcher)
+
+        result = searcher.couldBeReleased(
+            False, self._released_days_ago(1), year=time.gmtime().tm_year,
+        )
+        assert result is True
+
+    def test_future_release_is_not_downloadable_at_the_default(self):
+        """AC14: the reported bug, end to end. An unreleased film must not be
+        grabbed even though the default wait is zero."""
+        searcher = object.__new__(MovieSearcher)
+        future = {'theater': int(time.time()) + 30 * 86400, 'dvd': 0}
+
+        result = searcher.couldBeReleased(
+            False, future, year=time.gmtime().tm_year,
+        )
+        assert result is False
+
+    def test_wait_days_holds_back_a_recent_release(self):
+        """AC12: with a 7-day wait, yesterday's release is still too early."""
+        searcher = object.__new__(MovieSearcher)
+
+        result = searcher.couldBeReleased(
+            False, self._released_days_ago(1),
+            year=time.gmtime().tm_year, wait_days=7,
+        )
+        assert result is False
+
+    def test_wait_days_elapses(self):
+        """AC12: ...and is downloadable once the wait has elapsed."""
+        searcher = object.__new__(MovieSearcher)
+
+        result = searcher.couldBeReleased(
+            False, self._released_days_ago(10),
+            year=time.gmtime().tm_year, wait_days=7,
+        )
+        assert result is True
+
+    def test_legacy_twelve_week_behaviour_is_reproducible(self):
+        """The old hardcoded constant was 7257600s = 84 days. A user who
+        wants it back must be able to get exactly it."""
+        searcher = object.__new__(MovieSearcher)
+
+        assert searcher.couldBeReleased(
+            False, self._released_days_ago(83),
+            year=time.gmtime().tm_year, wait_days=84,
+        ) is False
+        assert searcher.couldBeReleased(
+            False, self._released_days_ago(85),
+            year=time.gmtime().tm_year, wait_days=84,
+        ) is True
+
+    def test_wait_days_does_not_affect_the_pre_release_window(self):
+        """The pre-release branch (cam/ts/scr, 1 week before theatres) is a
+        separate rule about pre-release *qualities* and must not be shifted
+        by a setting about waiting after release."""
+        searcher = object.__new__(MovieSearcher)
+        soon = {'theater': int(time.time()) + 3 * 86400, 'dvd': 0}
+
+        assert searcher.couldBeReleased(
+            True, soon, year=time.gmtime().tm_year, wait_days=30,
+        ) is True
+
+    @pytest.mark.parametrize('wait_days', [None, 0, '', 'abc'])
+    def test_unusable_wait_values_fall_back_to_no_wait(self, searcher, wait_days):
+        """The setting arrives from config as a string and may be blank.
+        A junk value must mean 'no wait', never a crash or an infinite hold."""
+        result = searcher.couldBeReleased(
+            False, self._released_days_ago(1),
+            year=time.gmtime().tm_year, wait_days=wait_days,
+        )
+        assert result is True
+
+
+class TestWaitForReleaseSetting:
+    """AC13 — the setting exists, is sane, and is actually wired up."""
+
+    def _option(self, name):
+        from couchpotato.core.media.movie.searcher import config
+
+        for plugin in config:
+            for group in plugin.get('groups', []):
+                for option in group.get('options', []):
+                    if option.get('name') == name:
+                        return option
+        raise AssertionError('%s option not found in config' % name)
+
+    def test_setting_exists_and_defaults_to_no_wait(self):
+        option = self._option('wait_for_release')
+
+        assert option['default'] == 0
+        assert option['type'] == 'int'
+
+    def test_single_passes_the_setting_to_could_be_released(self):
+        """A setting nothing reads is worse than no setting. Pin the wiring
+        so a refactor cannot quietly drop it."""
+        import inspect
+
+        from couchpotato.core.media.movie.searcher import MovieSearcher
+
+        source = inspect.getsource(MovieSearcher.single)
+
+        assert "self.conf('wait_for_release')" in source, (
+            'single() must read the wait_for_release setting'
+        )
+        assert 'wait_days' in source, (
+            'single() must pass wait_days through to couldBeReleased'
+        )
+
+
 class TestAlwaysSearchDescription:
     """AC7: `always_search` does not merely widen searching — at
     `MovieSearcher.single()` it is also one of the three conditions that

--- a/tests/unit/test_profile_defaults.py
+++ b/tests/unit/test_profile_defaults.py
@@ -1,0 +1,188 @@
+"""Tests for the seeded default quality profiles (BUG-016).
+
+The built-in profiles were ordered worst-first: `Best` was
+`['720p', '1080p', 'brrip', 'dvdrip']`, and index 0 of a profile is the
+*most preferred* quality (`quality/main.py`: "a lower number means higher
+quality"). Since `MovieSearcher.single()` breaks out of the quality loop on
+the first successful download, `Best` grabbed 720p and never reached 1080p.
+`UHD 4K` was `['720p', '1080p', '2160p']`, so it could never fetch 2160p.
+
+These tests assert the ordering against the canonical ranking derived from
+`QualityPlugin.qualities` rather than a hardcoded copy of the expected lists,
+so they keep meaning something if a quality is added or the seeds change.
+
+See specs/BUG-016-default-profile-quality-order.md.
+"""
+
+import pytest
+
+from couchpotato.core.plugins.profile.main import DEFAULT_PROFILES, build_profile_doc
+from couchpotato.core.plugins.quality.main import QualityPlugin
+
+# Canonical best-first ranking: position in QualityPlugin.qualities.
+# Lower number == higher quality, matching the profile ordering contract.
+CANONICAL_RANK = {
+    quality['identifier']: index
+    for index, quality in enumerate(QualityPlugin.qualities)
+}
+
+
+def _expanded(profile):
+    """The stored document a seeded profile turns into."""
+    return build_profile_doc(profile, order=0)
+
+
+def _rank_groups(doc):
+    """Split a profile's qualities into runs by their 3D flag, preserving
+    order, and map each to its canonical rank.
+
+    Grouping matters for `Prefer 3D HD`, which is deliberately "all 3D
+    first, then all non-3D". Ordering is only required to be best-first
+    *within* each group; a 3D 720p outranking a non-3D 1080p is the whole
+    point of that profile.
+    """
+    groups = {}
+    for identifier, is_3d in zip(doc['qualities'], doc['3d']):
+        groups.setdefault(bool(is_3d), []).append(CANONICAL_RANK[identifier])
+    return groups
+
+
+@pytest.mark.parametrize('profile', DEFAULT_PROFILES, ids=lambda p: p['label'])
+class TestDefaultProfileOrdering:
+
+    def test_qualities_are_best_first(self, profile):
+        """AC1 (bug repro): every seeded profile lists its qualities
+        best-first. Fails against the unfixed seeds for Best, HD, SD,
+        UHD 4K and Prefer 3D HD."""
+        doc = _expanded(profile)
+
+        for is_3d, ranks in _rank_groups(doc).items():
+            assert ranks == sorted(ranks), (
+                "%s: %s qualities are not best-first (canonical ranks %s, "
+                "expected ascending)" % (
+                    profile['label'],
+                    '3D' if is_3d else 'non-3D',
+                    ranks,
+                )
+            )
+
+    def test_positional_lists_match_qualities_length(self, profile):
+        """AC2: finish/wait_for/stop_after/3d are positional siblings of
+        qualities — a length mismatch silently detaches a flag from its
+        quality (or IndexErrors in MovieSearcher.single())."""
+        doc = _expanded(profile)
+        expected = len(doc['qualities'])
+
+        for key in ('finish', 'wait_for', 'stop_after', '3d'):
+            assert len(doc[key]) == expected, (
+                "%s: '%s' has %d entries, expected %d" % (
+                    profile['label'], key, len(doc[key]), expected,
+                )
+            )
+
+    def test_every_quality_identifier_is_real(self, profile):
+        """A typo'd identifier is silently skipped by the searcher
+        (`quality.single` returns nothing), quietly disabling that rung of
+        the profile."""
+        doc = _expanded(profile)
+
+        for identifier in doc['qualities']:
+            assert identifier in CANONICAL_RANK, (
+                "%s: unknown quality identifier %r" % (profile['label'], identifier)
+            )
+
+
+class TestSpecificDefaultProfiles:
+    """Targeted assertions for the profiles whose *names* make a promise the
+    ordering has to keep. The parametrised suite above proves ordering is
+    self-consistent; these pin the intent."""
+
+    def _by_label(self, label):
+        for profile in DEFAULT_PROFILES:
+            if profile['label'] == label:
+                return _expanded(profile)
+        raise AssertionError('no seeded profile labelled %r' % label)
+
+    def test_best_prefers_1080p_over_720p(self):
+        """AC1: the reported bug — 'Best' must not grab 720p first."""
+        doc = self._by_label('Best')
+        qualities = doc['qualities']
+
+        assert qualities.index('1080p') < qualities.index('720p'), (
+            "'Best' must prefer 1080p over 720p, got %s" % qualities
+        )
+
+    def test_best_does_not_silently_add_2160p(self):
+        """Deliberate scope limit: reordering must not change which
+        qualities are in the set. Adding 2160p to 'Best' would switch
+        existing users onto 20-60GB downloads without them asking."""
+        doc = self._by_label('Best')
+
+        assert '2160p' not in doc['qualities'], (
+            "'Best' gained 2160p — that is a behaviour change, not a reorder"
+        )
+
+    def test_uhd_4k_prefers_2160p_first(self):
+        """AC1: 'UHD 4K' led with 720p, so it could never deliver 4K while
+        any 720p release existed."""
+        doc = self._by_label('UHD 4K')
+
+        assert doc['qualities'][0] == '2160p', (
+            "'UHD 4K' must lead with 2160p, got %s" % doc['qualities']
+        )
+
+    def test_sd_prefers_dvdr_over_dvdrip(self):
+        """AC1: DVD-R (full disc) outranks DVD-Rip in the canonical list."""
+        doc = self._by_label('SD')
+        qualities = doc['qualities']
+
+        assert qualities.index('dvdr') < qualities.index('dvdrip'), (
+            "'SD' must prefer dvdr over dvdrip, got %s" % qualities
+        )
+
+    def test_prefer_3d_hd_keeps_3d_first_then_ordered_non_3d(self):
+        """AC3: the 3D head must stay 1080p-3D then 720p-3D, and the non-3D
+        tail must itself be 1080p then 720p. The flags come from
+        `threed.pop()`, so a careless reorder detaches them."""
+        doc = self._by_label('Prefer 3D HD')
+        pairs = list(zip(doc['qualities'], [bool(x) for x in doc['3d']]))
+
+        assert pairs == [
+            ('1080p', True),
+            ('720p', True),
+            ('1080p', False),
+            ('720p', False),
+        ], "'Prefer 3D HD' quality/3D pairing is wrong: %s" % pairs
+
+    def test_3d_hd_is_all_3d_and_ordered(self):
+        """Regression guard: '3D HD' was already correct and must stay so."""
+        doc = self._by_label('3D HD')
+        pairs = list(zip(doc['qualities'], [bool(x) for x in doc['3d']]))
+
+        assert pairs == [('1080p', True), ('720p', True)], (
+            "'3D HD' pairing is wrong: %s" % pairs
+        )
+
+
+class TestBuildProfileDoc:
+    """`build_profile_doc` is the seam that makes the seeds testable without
+    a database; pin its contract."""
+
+    def test_order_is_passed_through(self):
+        doc = build_profile_doc({'label': 'X', 'qualities': ['720p']}, order=7)
+        assert doc['order'] == 7
+
+    def test_defaults_are_finish_true_and_no_waiting(self):
+        """The seeds are 'take the best thing available now, then stop'."""
+        doc = build_profile_doc(
+            {'label': 'X', 'qualities': ['1080p', '720p']}, order=0,
+        )
+
+        assert doc['finish'] == [True, True]
+        assert doc['wait_for'] == [0, 0]
+        assert doc['stop_after'] == [0, 0]
+        assert doc['3d'] == [False, False]
+
+    def test_is_marked_as_a_profile_document(self):
+        doc = build_profile_doc({'label': 'X', 'qualities': ['720p']}, order=0)
+        assert doc['_t'] == 'profile'


### PR DESCRIPTION
Fixes two bugs reported from production: movies on the built-in **Best** profile all downloaded at 720p despite 1080p being available, and some newly-added movies downloaded before their release date.

## BUG-016 — "Best" downloads 720p

Index 0 of a profile is the **most preferred** quality (`quality/main.py`: *"a lower number means higher quality"*), and `MovieSearcher.single()` breaks out of the quality loop on the first successful download. `Profile.fill()` seeded `Best` as `['720p', '1080p', 'brrip', 'dvdrip']` — so it grabbed 720p and never reached 1080p. `finish: True` on every rung meant no later upgrade pass either.

`UHD 4K` was `['720p', '1080p', '2160p']`, so it could never deliver 4K. `HD` and `SD` were likewise inverted, as was the non-3D tail of `Prefer 3D HD`.

All seeded profiles are now ordered best-first per the canonical ranking in `QualityPlugin.qualities`, **without changing which qualities each set contains** — notably not adding 2160p to `Best`, which would silently switch existing users onto 20–60GB downloads.

`fill()` only runs on a fresh install, so a migration repairs existing rows. It rewrites a profile **only** when its label and stored quality order exactly match a known-bad seed; anything renamed, reordered or edited is left alone (which also makes it idempotent). All five positional lists are permuted together so per-rung flags stay attached to their quality.

## BUG-017 — downloads before the release date

The ETA gate has **never worked**. `movie.info.release_date` has no registered handler anywhere, `fireEvent` returns `[]` for an unhandled name, so `updateReleaseDate()` returned empty for every movie on every search — `not dates` was always true and `couldBeReleased()` always said yes.

That makes the obvious fix dangerous: removing `not dates` while nothing populates dates flips the gate from always-open to always-**closed** for current-year movies, stranding them ~16 months. So population and guard land together:

- **Populate.** `releaseDatesFromInfo()` derives `{'theater': epoch, 'dvd': 0}` from the `released` string the TMDB provider already stores. Parsed with `calendar.timegm` (the gate compares against UTC `time.time()`); rejects the literal `'None'`, the TMDB `1900-01-01` "no date" placeholder (a negative epoch would hit the pre-1972 "already out" sentinel and reopen this very bug), and impossible dates via `calendar.monthrange` (`timegm` silently normalises `2026-02-30` to `2026-03-02`). Not written back — deriving is free, and the old code's unconditional `db.update()` was a write per movie per search cycle.
- **Configurable wait.** The theatrical unlock was a hardcoded 12 weeks, written when waiting for physical media was the point. Now the `wait_for_release` setting, **default 0** — a film unlocks once its release date has passed; set 84 for the old behaviour.
- **Guard.** `not dates` removed from the pre-1972 branch; unknown now falls through to `return False`. `dates` is normalised by type, not truthiness — an unhandled `fireEvent` returns a *list*, and existing databases have `[]` cached.
- The `always_search` description now says it also bypasses the gate for **downloads**, not just searching (behaviour deliberately unchanged).

The dashboard's `soon`/`late` views call the same gate with the same never-populated field, so they now derive dates too — otherwise they would have flipped from listing everything to listing nothing.

## What users see

- Future-dated films are searched but not auto-downloaded; results still surface in the dashboard for manual selection, and manual download bypasses the gate entirely.
- `Best` prefers 1080p; `UHD 4K` actually delivers 4K.
- **Movies already downloaded at 720p and marked done are not retroactively upgraded** — the migration fixes the profile so *future* searches prefer 1080p. Re-add or clear the release to upgrade one.

## Verification

- `make verify` (lint + 1315 unit tests) green; full Playwright suite 132/133, the one failure being the known-flaky `networkidle` sidebar nav test, which passes in isolation and is unrelated (this branch touches no UI).
- Every bug-repro test was confirmed to fail against the pre-fix code.
- The `wait_for_release` wiring test drives `single()` and was mutation-checked: removing the kwarg from the call makes it fail.
- Residual risk (year known but release date underivable → held back until the "old movie" heuristic) is documented in the spec; TMDB derives `year` **from** `release_date`, so the combination is rare and `year=None` fails open.

Specs: `specs/BUG-016-default-profile-quality-order.md`, `specs/BUG-017-eta-unknown-release-dates.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01776dG2XJe9h9DWz9dSJ2KK