### PR TITLE
fix: one malformed release no longer aborts the snatched-status pass

### DIFF
--- a/couchpotato/core/helpers/variable.py
+++ b/couchpotato/core/helpers/variable.py
@@ -341,6 +341,15 @@ re_password = [re.compile(r'(.+){{([^{}]+)}}$'), re.compile(r'(.+)\s+password\s*
 
 
 def scanForPassword(name):
+    # "No name" is an ordinary answer of "no password", not an error. Without
+    # this, re.search() raises TypeError on None -- and every release created
+    # before v3.17.0 has an empty info dict, because createFromSearch's
+    # populate loop died on the Python 2 `unicode`/`long` names before it
+    # could store anything. bytes matters too: a str pattern against bytes
+    # raises the same TypeError.
+    if not name or not isinstance(name, str):
+        return None
+
     m = None
     for reg in re_password:
         m = reg.search(name)

--- a/couchpotato/core/plugins/base.py
+++ b/couchpotato/core/plugins/base.py
@@ -9,7 +9,7 @@ from couchpotato.core.event import fireEvent, addEvent
 from couchpotato.core.helpers.encoding import toSafeString, \
     toUnicode, sp
 from couchpotato.core.helpers.variable import md5, scanForPassword, tryInt, getIdentifier, \
-    randomString
+    randomString, getTitle
 from couchpotato.core.http_client import HttpClient
 from couchpotato.core.logger import CPLog
 from couchpotato.environment import Env
@@ -299,7 +299,13 @@ class Plugin:
         return value
 
     def createNzbName(self, data, media, unique_tag = False):
-        release_name = data.get('name')
+        # A release with no name falls back to the movie title. Every release
+        # created before v3.17.0 has an empty info dict (createFromSearch's
+        # populate loop died on the Python 2 names before storing anything),
+        # and toUnicode(None) yields the literal string 'None' -- which this
+        # function would otherwise hand to the downloaders as a filename,
+        # producing 'None.cp(tt123).nzb'.
+        release_name = data.get('name') or getTitle(media) or getIdentifier(media) or 'unknown'
         tag = self.cpTag(media, unique_tag = unique_tag)
 
         # Check if password is filename

--- a/couchpotato/core/plugins/base.py
+++ b/couchpotato/core/plugins/base.py
@@ -333,7 +333,9 @@ class Plugin:
 
         tag = ''
         if Env.setting('enabled', 'renamer') or unique_tag:
-            identifier = getIdentifier(media) or ''
+            # `media or {}` for the same reason as createNzbName above:
+            # getIdentifier() indexes its argument directly, unlike getTitle().
+            identifier = getIdentifier(media or {}) or ''
             unique_tag = ', ' + randomString() if unique_tag else ''
 
             tag = '.cp('

--- a/couchpotato/core/plugins/base.py
+++ b/couchpotato/core/plugins/base.py
@@ -305,7 +305,7 @@ class Plugin:
         # and toUnicode(None) yields the literal string 'None' -- which this
         # function would otherwise hand to the downloaders as a filename,
         # producing 'None.cp(tt123).nzb'.
-        release_name = data.get('name') or getTitle(media) or getIdentifier(media) or 'unknown'
+        release_name = data.get('name') or getTitle(media) or getIdentifier(media or {}) or 'unknown'
         tag = self.cpTag(media, unique_tag = unique_tag)
 
         # Check if password is filename

--- a/couchpotato/core/plugins/renamer/scanner.py
+++ b/couchpotato/core/plugins/renamer/scanner.py
@@ -74,6 +74,11 @@ class ScannerMixin:
                         continue
                     movie_dict = db.get('id', rel.get('media_id'))
                     download_info = rel.get('download_info')
+                    # Every release created before v3.17.0 has an empty info
+                    # dict (createFromSearch's populate loop died on the
+                    # Python 2 names before storing anything), so direct
+                    # rel['info']['name'] access KeyErrors on real data.
+                    rel_name = (rel.get('info') or {}).get('name') or ''
 
                     if not isinstance(download_info, dict):
                         log.error('Faulty release found without any info, ignoring.')
@@ -81,7 +86,7 @@ class ScannerMixin:
                         continue
 
                     if not download_info.get('id') or not download_info.get('downloader'):
-                        log.debug('Download status functionality is not implemented for downloader (%s) of release %s.', download_info.get('downloader', 'unknown'), rel['info']['name'])
+                        log.debug('Download status functionality is not implemented for downloader (%s) of release %s.', download_info.get('downloader', 'unknown'), rel_name or '<unnamed>')
                         scan_required = True
                         continue
 
@@ -96,7 +101,7 @@ class ScannerMixin:
                                 found_release = True
                                 break
                         else:
-                            if release_download['name'] == nzbname or rel['info']['name'] in release_download['name'] or getImdb(release_download['name']) == getIdentifier(movie_dict):
+                            if release_download['name'] == nzbname or (rel_name and rel_name in release_download['name']) or getImdb(release_download['name']) == getIdentifier(movie_dict):
                                 log.debug('Found release by release name or imdb ID: %s', release_download['name'])
                                 found_release = True
                                 break

--- a/couchpotato/core/plugins/renamer/scanner.py
+++ b/couchpotato/core/plugins/renamer/scanner.py
@@ -62,8 +62,14 @@ class ScannerMixin:
 
             log.debug('Checking status snatched releases...')
 
-            try:
-                for rel in rels:
+            # Per-release, NOT around the whole loop: this used to wrap
+            # `for rel in rels`, so one malformed document aborted the pass
+            # and every release behind it went unchecked -- a completed
+            # download was never noticed, so renaming never fired for it.
+            # Seen in production, where a single release with no info['name']
+            # was blocking status checks for the other 16.
+            for rel in rels:
+                try:
                     if not rel.get('media_id'):
                         continue
                     movie_dict = db.get('id', rel.get('media_id'))
@@ -148,8 +154,10 @@ class ScannerMixin:
                         else:
                             scan_required = True
 
-            except Exception:
-                log.error('Failed checking for release in downloader: %s', traceback.format_exc())
+                except Exception:
+                    log.error('Failed checking release %s in downloader, skipping it: %s',
+                              rel.get('_id'), traceback.format_exc())
+                    continue
 
             for release_download in scan_releases:
                 if release_download['scan']:

--- a/couchpotato/core/plugins/renamer/scanner.py
+++ b/couchpotato/core/plugins/renamer/scanner.py
@@ -78,7 +78,8 @@ class ScannerMixin:
                     # dict (createFromSearch's populate loop died on the
                     # Python 2 names before storing anything), so direct
                     # rel['info']['name'] access KeyErrors on real data.
-                    rel_name = (rel.get('info') or {}).get('name') or ''
+                    rel_info = rel.get('info') or {}
+                    rel_name = rel_info.get('name') or ''
 
                     if not isinstance(download_info, dict):
                         log.error('Faulty release found without any info, ignoring.')
@@ -90,7 +91,7 @@ class ScannerMixin:
                         scan_required = True
                         continue
 
-                    nzbname = self.createNzbName(rel['info'], movie_dict)
+                    nzbname = self.createNzbName(rel_info, movie_dict)
 
                     found_release = False
                     for release_download in release_downloads:

--- a/tests/unit/test_check_snatched_resilience.py
+++ b/tests/unit/test_check_snatched_resilience.py
@@ -72,14 +72,46 @@ class TestCreateNzbName:
         plugin = object.__new__(Plugin)
         return plugin
 
-    def test_a_release_with_no_name_does_not_raise(self):
-        """`info` is an empty dict on every pre-v3.17.0 release."""
+    def test_a_release_with_no_name_falls_back_to_the_title(self):
+        """`info` is an empty dict on every pre-v3.17.0 release.
+
+        Not raising is not enough: `toUnicode(None)` yields the literal string
+        'None', and this function names actual downloads (nzbget, sabnzbd,
+        pneumatic, and createFileName), so a nameless release produced a file
+        called 'None.cp(tt123).nzb'.
+        """
         plugin = self._plugin()
 
         with patch.object(type(plugin), 'cpTag', return_value='', create=True):
             name = plugin.createNzbName({}, {'title': 'Some Movie'})
 
-        assert isinstance(name, str)
+        assert 'None' not in name, (
+            "a nameless release must not be named after the string 'None', "
+            "got %r" % name
+        )
+        assert 'Some' in name
+
+    def test_a_release_with_a_name_is_unaffected(self):
+        """Regression guard: the normal path must not start consulting the
+        movie title."""
+        plugin = self._plugin()
+
+        with patch.object(type(plugin), 'cpTag', return_value='', create=True):
+            name = plugin.createNzbName(
+                {'name': 'Some.Movie.2026.1080p'}, {'title': 'Some Movie'},
+            )
+
+        assert name.startswith('Some.Movie.2026.1080p')
+
+    def test_no_name_and_no_title_still_yields_something_usable(self):
+        """Last resort: the imdb id, then a literal placeholder -- never an
+        empty filename."""
+        plugin = self._plugin()
+
+        with patch.object(type(plugin), 'cpTag', return_value='', create=True):
+            name = plugin.createNzbName({}, {'identifiers': {'imdb': 'tt1234567'}})
+
+        assert name and 'None' not in name
 
 
 class TestCheckSnatchedIsolatesBadReleases:
@@ -168,8 +200,6 @@ class TestCheckSnatchedIsolatesBadReleases:
         good = self._release('1', 'Good.One.1080p')
         bad = self._release('2', None)
         bad['download_info'] = {'status_support': True}     # no id, no downloader
-
-        errors = []
 
         def fake_fire_event(name, *args, **kwargs):
             if name == 'release.with_status':

--- a/tests/unit/test_check_snatched_resilience.py
+++ b/tests/unit/test_check_snatched_resilience.py
@@ -115,14 +115,21 @@ class TestCreateNzbName:
 
     def test_a_none_media_does_not_raise(self):
         """getTitle() is defensive about bad input; getIdentifier() is not.
-        This fallback chain introduced a getIdentifier call on a path that
-        previously had none, so guard what it introduced."""
+
+        Deliberately does NOT patch cpTag: an earlier version of this test did,
+        which meant it passed while the real cpTag -- which calls
+        getIdentifier(media) two lines later -- still crashed on None. Patching
+        the collaborator that holds the bug is how a test proves nothing.
+        Env.setting is patched instead so the renamer-enabled branch, the
+        normal case, is the one exercised.
+        """
         plugin = self._plugin()
 
-        with patch.object(type(plugin), 'cpTag', return_value='', create=True):
+        with patch('couchpotato.core.plugins.base.Env') as env:
+            env.setting.return_value = True          # renamer enabled
             name = plugin.createNzbName({}, None)
 
-        assert name == 'unknown'
+        assert name.startswith('unknown')
 
     def test_no_name_and_no_title_still_yields_something_usable(self):
         """Last resort: the imdb id, then a literal placeholder -- never an
@@ -249,6 +256,60 @@ class TestCheckSnatchedIsolatesBadReleases:
         assert not any("KeyError: 'name'" in e for e in errors), (
             'the no-status-support path raised on the empty info dict instead '
             'of skipping cleanly: %s' % errors
+        )
+
+    def _run_for_rescan(self, include_no_status_release):
+        """Return whether checkSnatched asked for a rescan.
+
+        `scan_required = True` has no direct observable, so this drives it via
+        the only thing that reads it: with fire_scan=True, the method calls
+        self.scan() at the end iff a rescan was requested.
+        """
+        scanner = self._scanner()
+        good = self._release('1', 'Good.One.1080p')
+        rels = [good]
+        if include_no_status_release:
+            bad = self._release('2', None)
+            bad['download_info'] = {'status_support': True}   # no id/downloader
+            rels.append(bad)
+
+        def fake_fire_event(name, *args, **kwargs):
+            if name == 'release.with_status':
+                return list(rels)
+            if name == 'download.status':
+                return [{'id': 'dl-1', 'downloader': 'sabnzbd', 'name': 'Good.One.1080p',
+                         'status': 'busy', 'timeleft': -1, 'scan': False,
+                         'folder': '/downloads/x'}]
+            return None
+
+        db = MagicMock()
+        db.get.return_value = {'_id': 'movie-1', 'title': 'Some Movie'}
+
+        with patch('couchpotato.core.plugins.renamer.scanner.fireEvent', side_effect=fake_fire_event), \
+                patch('couchpotato.core.plugins.renamer.scanner.get_db', return_value=db), \
+                patch.object(type(scanner), 'conf', return_value=False, create=True), \
+                patch.object(type(scanner), 'createNzbName', return_value='x', create=True), \
+                patch.object(type(scanner), 'untagRelease', return_value=None, create=True), \
+                patch.object(type(scanner), 'scan', return_value=None, create=True) as scan:
+            scanner.checkSnatched(fire_scan=True)
+
+        return scan.called
+
+    def test_the_rescan_signal_survives(self):
+        """The positive half of the claim, which the test above only implied.
+
+        A release whose downloader has no status support is meant to set
+        `scan_required = True` and continue. The KeyError used to fire on the
+        log line BEFORE that assignment, so the signal was lost. Differential
+        against a control run without that release, so this isolates the
+        signal rather than catching any incidental rescan.
+        """
+        assert self._run_for_rescan(include_no_status_release=False) is False, (
+            'control: the good release alone must not request a rescan, or '
+            'this test proves nothing'
+        )
+        assert self._run_for_rescan(include_no_status_release=True) is True, (
+            'the no-status-support release must still request a rescan'
         )
 
     def test_the_pass_still_completes(self):

--- a/tests/unit/test_check_snatched_resilience.py
+++ b/tests/unit/test_check_snatched_resilience.py
@@ -103,6 +103,16 @@ class TestCreateNzbName:
 
         assert name.startswith('Some.Movie.2026.1080p')
 
+    def test_no_name_no_title_and_no_id_uses_the_literal_fallback(self):
+        """The last tier of the chain, which nothing else covers -- a name is
+        going on a filesystem, so it must never end up empty."""
+        plugin = self._plugin()
+
+        with patch.object(type(plugin), 'cpTag', return_value='', create=True):
+            name = plugin.createNzbName({}, {})
+
+        assert name == 'unknown'
+
     def test_no_name_and_no_title_still_yields_something_usable(self):
         """Last resort: the imdb id, then a literal placeholder -- never an
         empty filename."""
@@ -206,7 +216,8 @@ class TestCheckSnatchedIsolatesBadReleases:
                 return [good, bad]
             if name == 'download.status':
                 return [{'id': 'dl-1', 'downloader': 'sabnzbd', 'name': 'x',
-                         'status': 'busy', 'timeleft': -1, 'scan': False}]
+                         'status': 'busy', 'timeleft': -1, 'scan': False,
+                         'folder': '/downloads/x'}]
             return None
 
         db = MagicMock()
@@ -239,7 +250,8 @@ class TestCheckSnatchedIsolatesBadReleases:
                 return [self._release('1', None)]
             if name == 'download.status':
                 return [{'id': 'dl-1', 'downloader': 'sabnzbd', 'name': '',
-                         'status': 'busy', 'timeleft': -1, 'scan': False}]
+                         'status': 'busy', 'timeleft': -1, 'scan': False,
+                         'folder': '/downloads/x'}]
             return None
 
         db = MagicMock()

--- a/tests/unit/test_check_snatched_resilience.py
+++ b/tests/unit/test_check_snatched_resilience.py
@@ -1,0 +1,180 @@
+"""One malformed release must not abort the whole snatched-status pass.
+
+Found on production running v3.17.0. `renamer.check_snatched` runs every
+minute and was failing with:
+
+    File "couchpotato/core/plugins/renamer/scanner.py", line 82, in checkSnatched
+        nzbname = self.createNzbName(rel['info'], movie_dict)
+    File "couchpotato/core/helpers/variable.py", line 346, in scanForPassword
+        m = reg.search(name)
+    TypeError: expected string or bytes-like object, got 'NoneType'
+
+Three separate defects chain together:
+
+1. `scanForPassword()` calls `reg.search(name)` with no type guard, so a
+   missing name raises TypeError instead of "no password found".
+2. `rel['info']['name']` is None for every release created before v3.17.0 —
+   the `createFromSearch` loop raised NameError on `unicode`/`long` before it
+   could populate `info`, so those documents have an empty dict. 1133 of 1454
+   releases on the production box are in that state.
+3. **The `try:` in `checkSnatched` wraps the entire `for rel in rels:` loop**,
+   so the exception aborts the pass. Releases after the bad one are never
+   checked at all — a completed download is never noticed, so renaming and
+   post-processing never fire for it.
+
+(3) is the one that costs something: on the affected box a single malformed
+release was blocking status checks for the other 16.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from couchpotato.core.helpers.variable import scanForPassword
+
+
+class TestScanForPassword:
+
+    @pytest.mark.parametrize('value', [None, '', 0, [], {}], ids=repr)
+    def test_falsy_input_is_not_a_password(self, value):
+        """Bug repro: None raised TypeError out of a helper whose job is to
+        answer "is there a password in this name" -- "no name" is a perfectly
+        ordinary answer of "no"."""
+        assert scanForPassword(value) is None
+
+    @pytest.mark.parametrize('value', [123, object(), b'bytes'], ids=lambda v: type(v).__name__)
+    def test_non_string_input_is_not_a_password(self, value):
+        """bytes matter specifically: `re.search` with a str pattern against
+        bytes raises TypeError too, so this is not hypothetical."""
+        assert scanForPassword(value) is None
+
+    def test_curly_brace_password_still_parsed(self):
+        """Regression guard: the two real formats must keep working."""
+        assert scanForPassword('Some.Movie.2026.1080p{{hunter2}}') == (
+            'Some.Movie.2026.1080p', 'hunter2',
+        )
+
+    def test_password_keyword_still_parsed(self):
+        assert scanForPassword('Some.Movie.2026 password = hunter2') == (
+            'Some.Movie.2026', 'hunter2',
+        )
+
+    def test_a_plain_name_has_no_password(self):
+        assert scanForPassword('Some.Movie.2026.1080p.BluRay') is None
+
+
+class TestCreateNzbName:
+    """The caller, which reaches scanForPassword with whatever `info` holds."""
+
+    def _plugin(self):
+        from couchpotato.core.plugins.base import Plugin
+
+        plugin = object.__new__(Plugin)
+        return plugin
+
+    def test_a_release_with_no_name_does_not_raise(self):
+        """`info` is an empty dict on every pre-v3.17.0 release."""
+        plugin = self._plugin()
+
+        with patch.object(type(plugin), 'cpTag', return_value='', create=True):
+            name = plugin.createNzbName({}, {'title': 'Some Movie'})
+
+        assert isinstance(name, str)
+
+
+class TestCheckSnatchedIsolatesBadReleases:
+    """The structural fix: a per-release failure must not end the pass."""
+
+    def _scanner(self):
+        from couchpotato.core.plugins.renamer.scanner import ScannerMixin
+
+        scanner = object.__new__(ScannerMixin)
+        scanner.checking_snatched = False
+        return scanner
+
+    def _release(self, rel_id, name):
+        """`name=None` reproduces a pre-v3.17.0 release with empty info."""
+        return {
+            '_id': rel_id,
+            'media_id': 'movie-%s' % rel_id,
+            'status': 'snatched',
+            'info': {'name': name} if name is not None else {},
+            'download_info': {'id': 'dl-%s' % rel_id, 'downloader': 'sabnzbd',
+                              'status_support': True},
+        }
+
+    def test_one_failing_release_does_not_stop_the_others(self):
+        """The structural property, tested independently of the specific bug.
+
+        The landmine here is a db.get() failure on the middle release rather
+        than the nameless-release TypeError -- that one is fixed at source
+        now, so it can no longer demonstrate isolation. What matters is that
+        ANY per-release exception is contained: releases behind it must still
+        be processed.
+        """
+        scanner = self._scanner()
+        rels = [
+            self._release('1', 'Good.One.1080p'),
+            self._release('2', 'Boom.1080p'),
+            self._release('3', 'Good.Two.1080p'),
+        ]
+        checked = []
+
+        def fake_fire_event(name, *args, **kwargs):
+            if name == 'release.with_status':
+                return list(rels)
+            if name == 'download.status':
+                return [{'id': 'dl-%s' % r['_id'], 'downloader': 'sabnzbd',
+                         'name': r['info'].get('name') or '', 'status': 'busy',
+                         'timeleft': -1, 'scan': False} for r in rels]
+            if name == 'release.update_status':
+                checked.append(str(args[0]) if args else None)
+            return None
+
+        def flaky_get(index, key):
+            if key == 'movie-2':
+                raise RuntimeError('simulated per-release failure')
+            return {'_id': key, 'title': 'Some Movie', 'identifiers': {'imdb': 'tt1'}}
+
+        db = MagicMock()
+        db.get.side_effect = flaky_get
+
+        with patch('couchpotato.core.plugins.renamer.scanner.fireEvent', side_effect=fake_fire_event), \
+                patch('couchpotato.core.plugins.renamer.scanner.get_db', return_value=db), \
+                patch.object(type(scanner), 'conf', return_value=False, create=True), \
+                patch.object(type(scanner), 'createNzbName', return_value='x', create=True), \
+                patch.object(type(scanner), 'untagRelease', return_value=None, create=True), \
+                patch.object(type(scanner), 'scan', return_value=None, create=True):
+            scanner.checkSnatched(fire_scan=False)
+
+        assert '3' in checked, (
+            'the release after the failing one was never processed -- one bad '
+            'document is blocking status checks for everything behind it '
+            '(processed: %s)' % checked
+        )
+
+    def test_the_pass_still_completes(self):
+        """It must not leave `checking_snatched` latched either, or every
+        later run short-circuits."""
+        scanner = self._scanner()
+
+        def fake_fire_event(name, *args, **kwargs):
+            if name == 'release.with_status':
+                return [self._release('1', None)]
+            if name == 'download.status':
+                return [{'id': 'dl-1', 'downloader': 'sabnzbd', 'name': '',
+                         'status': 'busy', 'timeleft': -1, 'scan': False}]
+            return None
+
+        db = MagicMock()
+        db.get.return_value = {'_id': 'movie-1', 'title': 'Some Movie'}
+
+        with patch('couchpotato.core.plugins.renamer.scanner.fireEvent', side_effect=fake_fire_event), \
+                patch('couchpotato.core.plugins.renamer.scanner.get_db', return_value=db), \
+                patch.object(type(scanner), 'conf', return_value=False, create=True), \
+                patch.object(type(scanner), 'createNzbName', return_value='x', create=True), \
+                patch.object(type(scanner), 'untagRelease', return_value=None, create=True), \
+                patch.object(type(scanner), 'scan', return_value=None, create=True):
+            scanner.checkSnatched(fire_scan=False)
+
+        assert scanner.checking_snatched is False

--- a/tests/unit/test_check_snatched_resilience.py
+++ b/tests/unit/test_check_snatched_resilience.py
@@ -126,7 +126,7 @@ class TestCheckSnatchedIsolatesBadReleases:
             if name == 'download.status':
                 return [{'id': 'dl-%s' % r['_id'], 'downloader': 'sabnzbd',
                          'name': r['info'].get('name') or '', 'status': 'busy',
-                         'timeleft': -1, 'scan': False} for r in rels]
+                         'timeleft': -1, 'scan': False, 'folder': '/downloads/x'} for r in rels]
             if name == 'release.update_status':
                 checked.append(str(args[0]) if args else None)
             return None
@@ -151,6 +151,52 @@ class TestCheckSnatchedIsolatesBadReleases:
             'the release after the failing one was never processed -- one bad '
             'document is blocking status checks for everything behind it '
             '(processed: %s)' % checked
+        )
+
+    def test_a_downloader_without_status_support_does_not_raise(self):
+        """Second instance of the same root cause, found in review.
+
+        When download_info lacks an id/downloader, the code logs which release
+        it is skipping using `rel['info']['name']` -- direct key access, which
+        KeyErrors on the empty info dict every pre-v3.17.0 release has. The
+        raise happens BEFORE `scan_required = True`, so that release's rescan
+        signal is lost as well.
+        """
+        scanner = self._scanner()
+        # A MIX is required: with no download ids at all, checkSnatched
+        # returns before the loop, so the offending line is unreachable.
+        good = self._release('1', 'Good.One.1080p')
+        bad = self._release('2', None)
+        bad['download_info'] = {'status_support': True}     # no id, no downloader
+
+        errors = []
+
+        def fake_fire_event(name, *args, **kwargs):
+            if name == 'release.with_status':
+                return [good, bad]
+            if name == 'download.status':
+                return [{'id': 'dl-1', 'downloader': 'sabnzbd', 'name': 'x',
+                         'status': 'busy', 'timeleft': -1, 'scan': False}]
+            return None
+
+        db = MagicMock()
+        db.get.return_value = {'_id': 'movie-1', 'title': 'Some Movie'}
+
+        with patch('couchpotato.core.plugins.renamer.scanner.fireEvent', side_effect=fake_fire_event), \
+                patch('couchpotato.core.plugins.renamer.scanner.get_db', return_value=db), \
+                patch('couchpotato.core.plugins.renamer.scanner.log') as mock_log, \
+                patch.object(type(scanner), 'conf', return_value=False, create=True), \
+                patch.object(type(scanner), 'createNzbName', return_value='x', create=True), \
+                patch.object(type(scanner), 'untagRelease', return_value=None, create=True), \
+                patch.object(type(scanner), 'scan', return_value=None, create=True):
+            scanner.checkSnatched(fire_scan=False)
+            # Inspect the real arguments -- str(call) escapes the quotes, so a
+            # naive substring search silently never matches.
+            errors = [str(a) for c in mock_log.error.call_args_list for a in c.args]
+
+        assert not any("KeyError: 'name'" in e for e in errors), (
+            'the no-status-support path raised on the empty info dict instead '
+            'of skipping cleanly: %s' % errors
         )
 
     def test_the_pass_still_completes(self):

--- a/tests/unit/test_check_snatched_resilience.py
+++ b/tests/unit/test_check_snatched_resilience.py
@@ -113,6 +113,17 @@ class TestCreateNzbName:
 
         assert name == 'unknown'
 
+    def test_a_none_media_does_not_raise(self):
+        """getTitle() is defensive about bad input; getIdentifier() is not.
+        This fallback chain introduced a getIdentifier call on a path that
+        previously had none, so guard what it introduced."""
+        plugin = self._plugin()
+
+        with patch.object(type(plugin), 'cpTag', return_value='', create=True):
+            name = plugin.createNzbName({}, None)
+
+        assert name == 'unknown'
+
     def test_no_name_and_no_title_still_yields_something_usable(self):
         """Last resort: the imdb id, then a literal placeholder -- never an
         empty filename."""


### PR DESCRIPTION
Found on the production box running v3.17.0, and it traces back to the bug #202 fixed.

## The symptom

`renamer.check_snatched` runs every minute. It was failing every time:

```
scanner.py:82 in checkSnatched -> createNzbName(rel['info'], ...)
variable.py:346 in scanForPassword -> reg.search(name)
TypeError: expected string or bytes-like object, got 'NoneType'
```

## Three defects chained

1. **`scanForPassword()` had no type guard.** `re.search(None)` raises `TypeError` instead of the function answering "no password here".

2. **The name is `None` for every release created before v3.17.0.** `createFromSearch`'s populate loop died on the Python 2 `unicode`/`long` names before it could store anything (fixed in #202), so those documents carry an empty `info` dict. On the affected box that is **1133 of 1454 releases** — not an edge case there.

3. **The `try:` wrapped the entire `for rel in rels:` loop**, so the exception ended the pass. Releases behind the bad one were never checked at all — a completed download is never noticed, so renaming and post-processing never fire for it. On the affected box a single malformed release was blocking status checks for the other 16.

(3) is what actually costs something, and it's the structural fix: the `try` is now per-release, naming the release that failed and continuing.

## Second commit

A local review round caught two more direct `rel['info']['name']` reads in the same function. One sits in the no-status-support branch and raises **before** `scan_required = True`, so that release's rescan signal was being lost as well. The other is in a branch that's unreachable today (the guard above `continue`s whenever `download_info` lacks an id, and that branch only runs when it does) — same landmine, disarmed for free. Both now read a `rel_name` computed once.

## Verification

- `make verify` (lint + 1419 unit tests) green. Playwright 130/133; the three failures are the known `waitForLoadState('networkidle')` family in `interactions.e2e.spec.ts` — this branch touches no UI.
- Mutation-checked both structural fixes: restoring the loop-wide `try` fails the isolation test; restoring the direct `rel['info']['name']` fails with the exact `KeyError: 'name'` the test targets; dropping the `isinstance` guard fails the non-str cases.
- **Reaching the second defect needed a MIX of releases in the test.** With no download ids at all, `checkSnatched` returns before the loop and the offending line is unreachable — my first attempt at that test passed for that reason rather than because the code was correct, and the commit says so.
- A reviewer reported seeing the isolation test fail once in ~55 runs and could not reproduce it. I ran it 60× in isolation and the full suite 12× — all green. Most likely observed during their own mutation window; recorded rather than dismissed.

## Not addressed here

The 1133 existing releases keep their empty `info`. These fixes stop that crashing anything, but `fix_release_quality` will continue skipping them. A backfill migration is worth doing and is deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01776dG2XJe9h9DWz9dSJ2KK