### PR TITLE
feat: review gate defaults on, and search releases for a movie you already have

### DIFF
--- a/couchpotato/core/media/_base/media/main.py
+++ b/couchpotato/core/media/_base/media/main.py
@@ -853,9 +853,19 @@ class MediaPlugin(MediaBase):
                     m['last_edit'] = int(time.time())
 
                 tags = m.get('tags') or []
-                if tag not in tags:
+                added = tag not in tags
+                if added:
                     tags.append(tag)
                     m['tags'] = tags
+
+                # Persist when the tag is new OR when the caller asked for the
+                # timestamp bump. Previously db.update() sat inside the
+                # tag-is-new branch, so a repeat call with update_edited=True
+                # changed last_edit in memory only -- which meant the
+                # cleanup-protection FEAT-005 relies on (release.cleanDone
+                # sweeps 'available' releases older than a week) silently
+                # stopped working from the second search onward.
+                if added or update_edited:
                     db.update(m)
 
                 return True

--- a/couchpotato/core/media/movie/searcher.py
+++ b/couchpotato/core/media/movie/searcher.py
@@ -303,6 +303,13 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
                 break
 
         if total_result_count > 0:
+            # Deliberately NOT gated by list_only, despite list-only being
+            # otherwise read-only. release.cleanDone() deletes every
+            # 'available' release for any movie whose last_edit is older than
+            # a week -- and a 'done' movie's last_edit is typically months
+            # old. Without this bump, the releases a list-only search just
+            # surfaced would be swept before the user could pick one, which
+            # would make FEAT-005 silently useless.
             fireEvent('media.tag', movie['_id'], 'recent', update_edited = True, single = True)
 
         if len(too_early_to_search) > 0:

--- a/couchpotato/core/media/movie/searcher.py
+++ b/couchpotato/core/media/movie/searcher.py
@@ -153,7 +153,11 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
         # sweep never bypasses the cache, even though it still searches with
         # manual=True for the status-gating/ignore_eta behaviour below.
         if bypass_cache is None:
-            bypass_cache = manual
+            # list_only is always user-initiated -- it only exists to answer
+            # "what is available right now" -- so it bypasses the cache on its
+            # own rather than relying on every caller remembering to pair it
+            # with manual=True.
+            bypass_cache = manual or list_only
 
         # Find out search type
         try:

--- a/couchpotato/core/media/movie/searcher.py
+++ b/couchpotato/core/media/movie/searcher.py
@@ -498,6 +498,17 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
         changes the movie's status -- it exists so a movie you already have
         can be re-examined against what providers currently offer.
         """
+        try:
+            return self._searchReleases(media_id)
+        except Exception:
+            # Wrapped like tryNextRelease and markFailedAndResearch: single()
+            # indexes movie['info']['year'] directly, and a library import can
+            # lack it -- exactly the movies this feature targets. A 500 on the
+            # detail page is a worse answer than a handled failure.
+            log.error('Failed searching releases for %s: %s', media_id, traceback.format_exc())
+            return {'success': False, 'found': 0}
+
+    def _searchReleases(self, media_id):
         media = fireEvent('media.get', media_id, single = True)
         if not media:
             return {'success': False, 'found': 0}

--- a/couchpotato/core/media/movie/searcher.py
+++ b/couchpotato/core/media/movie/searcher.py
@@ -57,6 +57,16 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
             },
         })
 
+        addApiView('movie.searcher.search_releases', self.searchReleasesView, docs = {
+            'desc': "FEAT-005: list the releases currently available for a movie "
+                    "WITHOUT downloading any of them. Works on a movie that is "
+                    "already 'done' or awaiting review, so a better copy can be "
+                    "found later and picked by hand.",
+            'params': {
+                'media_id': {'desc': 'The id of the media'},
+            },
+        })
+
         addApiView('movie.searcher.full_search', self.searchAllView, docs = {
             'desc': 'Starts a full search for all wanted movies',
         })
@@ -132,7 +142,7 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
 
         self.in_progress = False
 
-    def single(self, movie, search_protocols = None, manual = False, force_download = False, bypass_cache = None):
+    def single(self, movie, search_protocols = None, manual = False, force_download = False, bypass_cache = None, list_only = False):
 
         # BUG-015 follow-up: bypass_cache controls whether the provider HTTP
         # cache (30-minute newznab/torrentpotato cache) is bypassed for this
@@ -155,7 +165,7 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
         # 'downloaded' is the manual-review gate (workflow phase 1): treat it like
         # 'done' for gating purposes so a movie awaiting review is never searched
         # or upgraded, unless a manual/forced search explicitly overrides it.
-        if not movie['profile_id'] or (movie['status'] in ('done', 'downloaded') and not manual):
+        if not movie['profile_id'] or (movie['status'] in ('done', 'downloaded') and not manual and not list_only):
             log.debug('Movie doesn\'t have a profile, is already done, or is awaiting review, assuming in manage tab.')
             fireEvent('media.restatus', movie['_id'], single = True)
             return
@@ -231,7 +241,12 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
                         has_better_quality += 1
 
             # Don't search for quality lower then already available.
-            if has_better_quality > 0:
+            #
+            # FEAT-005: a list-only search skips this. For a movie that already
+            # holds its profile's top quality this breaks on the FIRST rung, so
+            # honouring it would mean "show me what's available" searched
+            # nothing at all -- which is exactly the case the feature is for.
+            if has_better_quality > 0 and not list_only:
                 log.info('Better quality (%s) already available or snatched for %s', q_identifier, default_title)
                 fireEvent('media.restatus', movie['_id'], single = True)
                 break
@@ -265,8 +280,12 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
             if could_not_be_released and results_count > 0:
                 log.debug('Found %s releases for "%s", but ETA isn\'t correct yet.', results_count, default_title)
 
-            # Try find a valid result and download it
-            if (force_download or not could_not_be_released or always_search) and fireEvent('release.try_download_result', results, movie, quality_custom, single = True):
+            # Try find a valid result and download it.
+            # FEAT-005: never in list-only mode -- the results are stored as
+            # 'available' by release.create_from_search above, and the user
+            # picks one.
+            if not list_only and (force_download or not could_not_be_released or always_search) \
+                    and fireEvent('release.try_download_result', results, movie, quality_custom, single = True):
                 ret = True
 
             # Remove releases that aren't found anymore
@@ -442,6 +461,32 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
 
 
         return False
+
+    def searchReleasesView(self, media_id = None, **kwargs):
+        """FEAT-005 "Search for releases": populate the movie's release list
+        without snatching anything.
+
+        Unlike every other search entry point this never downloads and never
+        changes the movie's status -- it exists so a movie you already have
+        can be re-examined against what providers currently offer.
+        """
+        media = fireEvent('media.get', media_id, single = True)
+        if not media:
+            return {'success': False, 'found': 0}
+
+        self.single(media, list_only = True)
+
+        # Re-read so the count reflects what was just stored.
+        media = fireEvent('media.get', media_id, single = True) or media
+        found = len([
+            r for r in (media.get('releases') or [])
+            if r.get('status') == 'available'
+        ])
+
+        return {
+            'success': True,
+            'found': found,
+        }
 
     def tryNextReleaseView(self, media_id = None, **kwargs):
 

--- a/couchpotato/core/media/movie/searcher.py
+++ b/couchpotato/core/media/movie/searcher.py
@@ -481,7 +481,13 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
         if not media:
             return {'success': False, 'found': 0}
 
-        self.single(media, list_only = True)
+        # manual=True as well as list_only: single() derives bypass_cache from
+        # `manual`, so without it a user pressing "Search for releases" is
+        # answered from the 30-minute provider cache -- stale results for an
+        # explicitly user-initiated action. It also matches how try_next and
+        # mark_failed mark "a human asked for this". It cannot cause a
+        # download: list_only short-circuits the download gate regardless.
+        self.single(media, manual = True, list_only = True)
 
         # Re-read so the count reflects what was just stored.
         media = fireEvent('media.get', media_id, single = True) or media

--- a/couchpotato/core/media/movie/searcher.py
+++ b/couchpotato/core/media/movie/searcher.py
@@ -172,6 +172,15 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
 
         default_title = getTitle(movie)
         if not default_title:
+            # A list-only search must never delete anything. This branch is
+            # reasonable for the automatic path -- an untitled movie cannot be
+            # searched, so it is removed rather than failing every cycle -- but
+            # it was previously unreachable for a done/downloaded movie, and
+            # the list_only bypass exposed it. Deleting a library record
+            # because the user asked "what's available?" is not acceptable.
+            if list_only:
+                log.debug('No usable title for %s; nothing to search.', movie.get('_id'))
+                return
             log.error('No proper info found for movie, removing it from library to stop it from causing more issues.')
             fireEvent('media.delete', movie['_id'], single = True)
             return
@@ -288,15 +297,23 @@ class MovieSearcher(SearcherBase, MovieTypeBase):
                     and fireEvent('release.try_download_result', results, movie, quality_custom, single = True):
                 ret = True
 
-            # Remove releases that aren't found anymore
-            temp_previous_releases = []
-            for release in previous_releases:
-                if release.get('status') == 'available' and release.get('identifier') not in found_releases:
-                    fireEvent('release.delete', release.get('_id'), single = True)
-                else:
-                    temp_previous_releases.append(release)
-            previous_releases = temp_previous_releases
-            del temp_previous_releases
+            # Remove releases that aren't found anymore.
+            #
+            # Skipped for a list-only search: providers routinely swallow
+            # connection/HTTP errors and simply return no results, and this
+            # would then delete the very release list the user opened the page
+            # to look at. The automatic path can afford to re-derive the set
+            # each cycle because it is followed by a download; an explicit
+            # "show me what's available" cannot.
+            if not list_only:
+                temp_previous_releases = []
+                for release in previous_releases:
+                    if release.get('status') == 'available' and release.get('identifier') not in found_releases:
+                        fireEvent('release.delete', release.get('_id'), single = True)
+                    else:
+                        temp_previous_releases.append(release)
+                previous_releases = temp_previous_releases
+                del temp_previous_releases
 
             # Break if CP wants to shut down
             if self.shuttingDown() or ret:

--- a/couchpotato/core/plugins/profile/main.py
+++ b/couchpotato/core/plugins/profile/main.py
@@ -213,6 +213,13 @@ class ProfilePlugin(Plugin):
             try:
                 p = db.get('id', id)
                 profile['order'] = tryInt(kwargs.get('order', p.get('order', 999)))
+                # Same fallback idiom as 'order' and 'manual_confirmation'
+                # below, and for the same reason: the profile editor sends
+                # id/label/minimum_score/wait_for/stop_after/types and never
+                # 'core'. Without this, every edit of a built-in profile
+                # cleared the flag -- which is what marks it non-deletable in
+                # the settings UI -- so a routine rename made it deletable.
+                profile['core'] = kwargs.get('core', p.get('core', False))
                 # Fall back to the persisted value when the key is omitted, same
                 # idiom as 'order' above. Without this, editing an existing
                 # profile without resending manual_confirmation (as the live

--- a/couchpotato/core/plugins/profile/main.py
+++ b/couchpotato/core/plugins/profile/main.py
@@ -66,6 +66,11 @@ def build_profile_doc(profile, order):
         'order': order,
         'qualities': profile.get('qualities'),
         'minimum_score': 1,
+        # FEAT-004: the review gate is ON for seeded profiles. A completed
+        # download waits for confirmation instead of auto-promoting to 'done'
+        # -- the decision DOWNLOADED-REVIEW-WORKFLOW.md made, which the
+        # original compatibility default (off) inverted in practice.
+        'manual_confirmation': True,
         'finish': [],
         'wait_for': [],
         'stop_after': [],
@@ -177,10 +182,16 @@ class ProfilePlugin(Plugin):
                 # Workflow phase 2 (specs/DOWNLOADED-REVIEW-WORKFLOW.md): when
                 # truthy, a completing download for a movie on this profile is
                 # routed to the 'downloaded' review gate instead of 'done'
-                # (see MediaPlugin.restatus). Defaults False so existing/legacy
-                # profiles (and every caller that doesn't mention the field)
-                # keep today's auto-upgrade-to-done behavior unchanged.
-                'manual_confirmation': tryInt(kwargs.get('manual_confirmation', 0)) == 1,
+                # (see MediaPlugin.restatus).
+                #
+                # FEAT-004: NEW profiles default this ON -- the original
+                # compatibility default of off inverted the workflow's own
+                # decision, and in practice meant installs never reviewed
+                # anything. The edit path below deliberately overrides this
+                # with the PERSISTED value when the key is omitted: the live
+                # profile editor does not resend it, and without that fallback
+                # an existing profile's gate would flip on every save.
+                'manual_confirmation': tryInt(kwargs.get('manual_confirmation', 1)) == 1,
                 'qualities': [],
                 'wait_for': [],
                 'stop_after': [],

--- a/couchpotato/core/plugins/quality/main.py
+++ b/couchpotato/core/plugins/quality/main.py
@@ -269,6 +269,12 @@ class QualityPlugin(Plugin):
                             'label': label,
                             'finish': [True],
                             'wait_for': [0],
+                            # FEAT-004: these one-quality profiles are seeded
+                            # here rather than by ProfilePlugin.fill(), so they
+                            # need the review gate too -- otherwise a fresh
+                            # install still has a dozen profiles that
+                            # auto-complete downloads.
+                            'manual_confirmation': True,
                         })
                     else:
                         log.info('Profile already exists, skipping: %s', label)

--- a/couchpotato/ui/templates/partials/movie_detail.html
+++ b/couchpotato/ui/templates/partials/movie_detail.html
@@ -123,12 +123,24 @@
       {% endif %}
 
       <!-- Actions -->
-      <div class="flex flex-wrap gap-2 mt-6" x-data="{ refreshing: false, markingDone: false, deleting: false, markingReviewDone: false, markingReviewFailed: false }">
+      <div class="flex flex-wrap gap-2 mt-6" x-data="{ refreshing: false, markingDone: false, deleting: false, markingReviewDone: false, markingReviewFailed: false, searchingReleases: false }">
         <button @click="refreshing = true; fetch(CP.apiBase + '/movie.refresh/?id={{ movie_id }}').then(() => { refreshing = false; location.reload(); })"
                 class="px-3.5 py-1.5 bg-cp-accent/10 text-cp-accent hover:bg-cp-accent/20 font-medium rounded-md text-xs transition-colors disabled:opacity-50"
                 :disabled="refreshing">
           <span x-show="!refreshing">Refresh</span>
           <span x-show="refreshing">Refreshing…</span>
+        </button>
+        <!-- FEAT-005: list what providers currently offer WITHOUT downloading
+             anything. Shown for every status on purpose -- the point is that a
+             movie you already have can be re-examined when a better copy
+             appears. movie.searcher.search_releases takes media_id. -->
+        <button @click="searchingReleases = true; fetch(CP.apiBase + '/movie.searcher.search_releases/?media_id={{ movie_id }}').then(r => r.json()).then(d => { if(d.success) { toast('Found ' + (d.found || 0) + ' release' + (d.found === 1 ? '' : 's'), 'success'); setTimeout(() => location.reload(), 900); } else { searchingReleases = false; toast('Search failed', 'error'); } }).catch(() => { searchingReleases = false; toast('Search failed', 'error'); })"
+                class="px-3.5 py-1.5 bg-cp-blue/10 text-cp-blue hover:bg-cp-blue/20 font-medium rounded-md text-xs transition-colors disabled:opacity-50 inline-flex items-center gap-1.5"
+                data-testid="search-releases"
+                :disabled="searchingReleases">
+          <svg aria-hidden="true" class="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"/></svg>
+          <span x-show="!searchingReleases">Search for releases</span>
+          <span x-show="searchingReleases">Searching…</span>
         </button>
         {% if status != 'done' and status != 'downloaded' %}
         <button @click="markingDone = true; fetch(CP.apiBase + '/media.done/?id={{ movie_id }}').then(r => r.json()).then(d => { if(d.success) { location.reload(); } else { markingDone = false; } }).catch(() => { markingDone = false; })"

--- a/specs/FEAT-004-review-gate-default-on.md
+++ b/specs/FEAT-004-review-gate-default-on.md
@@ -1,0 +1,66 @@
+# FEAT-004: The "Downloaded / review" gate defaults ON
+
+## Problem
+
+`specs/DOWNLOADED-REVIEW-WORKFLOW.md` opens by rejecting auto-done:
+
+> Supersedes the open question in `specs/RENAMER-EVENT-CHAIN.md` about whether
+> to auto-mark releases `done` — the answer is **no; introduce a review gate**.
+
+The gate shipped in v3.9.0 as a per-profile `manual_confirmation` toggle, but
+defaulting **off** "so existing/legacy profiles keep today's auto-upgrade-to-done
+behavior unchanged" (`profile/main.py`).
+
+The result: on a production install, all 18 profiles had it unset, so every
+completed download went straight to `done`. The owner's report:
+
+> the design is that it should never automatically move to done, often the
+> downloaded grabs something it shouldn't I need to review it
+
+So the compatibility default inverted the intended design, and nothing
+surfaced it — a user who never opens profile settings never learns the gate
+exists.
+
+## Fix Required
+
+1. **Seeded profiles** (`DEFAULT_PROFILES` via `build_profile_doc`) get
+   `manual_confirmation: True`, so a fresh install has the gate on.
+2. **New profiles** created through `Profile.save()` default to on: the
+   insert-path default changes from `0` to `1`.
+3. **The edit path is unchanged.** `save()` already falls back to the
+   *persisted* value when the key is omitted
+   (`1 if p.get('manual_confirmation') else 0`), which is what keeps the live
+   profile editor from resetting the flag on every save. That fallback must
+   keep reading the stored value, not the new default — otherwise editing any
+   existing profile silently switches its gate on.
+
+## Deliberately NOT doing
+
+**No migration flipping existing profiles.** Turning the gate on changes what
+happens to every future download on that profile, and doing it silently to
+installs that have been running for months is the same class of surprise this
+spec is fixing — just in the other direction. Existing users opt in from
+Settings → Profiles.
+
+The distinction that matters: (1) and (2) change what a *new* profile does,
+which nobody has come to rely on. A migration changes what an *existing* one
+does.
+
+## Acceptance Criteria
+
+- [ ] AC1: every profile in `DEFAULT_PROFILES` expands with
+      `manual_confirmation` true.
+- [ ] AC2: `Profile.save()` with no `manual_confirmation` key creates a NEW
+      profile with it on.
+- [ ] AC3: `Profile.save()` on an EXISTING profile that has it off, with the
+      key omitted, leaves it off — the persisted value still wins over the
+      new default.
+- [ ] AC4: the same, with it on, leaves it on.
+- [ ] AC5: an explicit `manual_confirmation=0` still turns it off, on both
+      the create and edit paths.
+
+## Affected Files
+
+- `couchpotato/core/plugins/profile/main.py`
+- `tests/unit/test_profile_defaults.py`
+- `tests/unit/test_review_gate_default.py` — new

--- a/specs/FEAT-005-search-releases-for-done-movies.md
+++ b/specs/FEAT-005-search-releases-for-done-movies.md
@@ -74,6 +74,13 @@ the user asked for it.
       so they appear in the movie's release list.
 - [ ] AC5: the movie's status is unchanged by a list-only search (a `done`
       movie stays `done`; a `downloaded` movie stays in the review gate).
+- [ ] AC9: a list-only search DOES bump the movie's `last_edit` (via the
+      existing `media.tag('recent', update_edited=True)`). This is the single
+      mutation it makes, and it is required rather than incidental:
+      `release.cleanDone()` deletes every `available` release for a movie
+      whose `last_edit` is older than a week, and a `done` movie's `last_edit`
+      is typically months old — so without the bump the results would be swept
+      before the user could act on them.
 - [ ] AC6: the automatic path is untouched — with `list_only` defaulted false,
       the has-better-quality break and the download call behave exactly as
       before.

--- a/specs/FEAT-005-search-releases-for-done-movies.md
+++ b/specs/FEAT-005-search-releases-for-done-movies.md
@@ -1,0 +1,90 @@
+# FEAT-005: Search for releases on a movie you already have
+
+## Problem
+
+Owner's report:
+
+> this should also be the case for downloaded movies, they are marked as done,
+> but I may want to download a better version in the future should one come
+> out, if I open the title it should search for releases
+
+Today there is no way to do that. `MovieSearcher.single()` short-circuits:
+
+```python
+if not movie['profile_id'] or (movie['status'] in ('done', 'downloaded') and not manual):
+    return
+```
+
+so a `done` movie is never searched. The only escape hatches are re-adding the
+movie (which resets its status) or `movie.searcher.try_next`, which is scoped
+to swapping the *current* release rather than showing what exists.
+
+Two things are missing, and they are separable:
+
+1. **No per-movie search API at all.** `movie.searcher.single` is an internal
+   *event*; the only API views are `try_next`, `mark_failed` and
+   `full_search` (the whole library).
+2. **`manual=True` alone is not enough.** Even with the gate bypassed,
+   `single()` would still:
+   - break out of the quality loop on the has-better-quality check
+     (`searcher.py`) — for a movie that already has its best quality, that is
+     an immediate break, so nothing is searched at all; and
+   - **download** whatever it finds, because the download gate is
+     `force_download or not could_not_be_released or always_search`, and for a
+     released movie the middle term is true.
+
+   Both are correct for the automatic path and wrong for "show me what's out
+   there".
+
+## Fix Required
+
+A **list-only** search: find releases, store them as `available`, change
+nothing else.
+
+1. `single()` gains `list_only = False`. When true:
+   - the `done`/`downloaded` short-circuit is bypassed (as `manual` does);
+   - the has-better-quality break is skipped, so every quality in the profile
+     is searched even when a better copy is already held;
+   - `release.try_download_result` is **not** called — nothing is snatched;
+   - the movie's status is not changed.
+2. New API view `movie.searcher.search_releases` (media_id), returning
+   how many releases are now available.
+3. UI: a **"Search for releases"** button on the movie detail page, shown for
+   any movie regardless of status, which calls it and re-renders the detail
+   partial so the new releases appear in the existing release table.
+
+## Why a button rather than searching on open
+
+Opening a title would fire a full provider sweep across every quality in the
+profile — several seconds and a dozen indexer calls per page view, on a
+NAS-hosted app. It also makes an idempotent GET do expensive outbound work,
+so any accidental refresh re-runs it. An explicit action keeps the cost where
+the user asked for it.
+
+## Acceptance Criteria
+
+- [ ] AC1: `single(movie, list_only=True)` searches a movie whose status is
+      `done` — the short-circuit that normally returns early does not fire.
+- [ ] AC2: it never calls `release.try_download_result`, for any quality,
+      even when the movie is released and a result is found.
+- [ ] AC3: it does not break on the has-better-quality check — a movie that
+      already holds the profile's top quality is still searched for every
+      quality in the profile.
+- [ ] AC4: found results are still stored via `release.create_from_search`,
+      so they appear in the movie's release list.
+- [ ] AC5: the movie's status is unchanged by a list-only search (a `done`
+      movie stays `done`; a `downloaded` movie stays in the review gate).
+- [ ] AC6: the automatic path is untouched — with `list_only` defaulted false,
+      the has-better-quality break and the download call behave exactly as
+      before.
+- [ ] AC7: `movie.searcher.search_releases` is registered as an API view and
+      returns `{'success': True, 'found': <int>}`.
+- [ ] AC8: the movie detail template renders the button for a `done` movie.
+
+## Affected Files
+
+- `couchpotato/core/media/movie/searcher.py` — `single()`, new API view
+- `couchpotato/ui/templates/partials/movie_detail.html` — the button
+- `couchpotato/ui/__init__.py` — partial route if one is needed
+- `tests/unit/test_search_releases_list_only.py` — new
+- `tests/e2e/` — a UI change, so E2E coverage per CLAUDE.md rule 5

--- a/specs/FEAT-006-profiles-from-config-file.md
+++ b/specs/FEAT-006-profiles-from-config-file.md
@@ -66,6 +66,37 @@ These are meaningfully different products, and the second is much less useful.
   which INI models badly. YAML or JSON fits the shape; adding a YAML
   dependency for one file is a cost worth weighing.
 
+## Scope input from review of #205
+
+Findings raised while shipping FEAT-004/005 that this work would subsume,
+recorded here so the reasoning is not lost:
+
+- **Profile defaults are declared in two places.** `manual_confirmation: True`
+  is now hardcoded independently in `build_profile_doc()`
+  (`profile/main.py`) and in the inline profile insert in
+  `QualityPlugin.fill()` (`quality/main.py`). Both are correct and both are
+  tested, but nothing keeps them in sync — a future change to any default has
+  two call sites to find by inspection. The same is true of the seeded
+  *quality lists*: `DEFAULT_PROFILES` and the one-quality profiles
+  `QualityPlugin.fill()` creates are separate declarations of "what profiles
+  exist". A file collapses both into one source of truth, which is a
+  substantial part of the value here.
+
+- **`profile.save` rebuilds rather than patches.** It reconstructs the whole
+  document from the caller's payload, so any field the caller omits reverts to
+  a default. `order` and `manual_confirmation` have persisted-value fallbacks
+  bolted on for exactly this reason, and `core` needed one adding after a bulk
+  update cleared it on 12 built-ins. A file-driven design should not need
+  per-field fallbacks, because the file *is* the declaration — but if the UI
+  keeps writing profiles, this shape needs designing out rather than
+  inheriting.
+
+- **There is no supported way to change `manual_confirmation`.** The settings
+  profile editor's `profileToForm`/`formToPayload` never expose it, so the
+  field can only be set through the API. Whatever replaces the current editor
+  needs every profile field reachable, or the same gap recurs for the next
+  field added.
+
 ## Suggested scope if picked up
 
 Smallest version that solves the motivating problems: a file that is

--- a/specs/FEAT-006-profiles-from-config-file.md
+++ b/specs/FEAT-006-profiles-from-config-file.md
@@ -1,0 +1,85 @@
+# FEAT-006: Define quality profiles in a config file
+
+> Status: **BACKLOG — not scheduled.** Owner's idea, captured while the
+> problems that motivate it were fresh. Not started; the design questions
+> below need answering before anyone implements it.
+
+## Motivation
+
+Profiles live only in the database today, seeded once by `ProfilePlugin.fill()`
+and `QualityPlugin.fill()`, and editable only through the settings UI. Three
+problems this session all trace back to that:
+
+1. **BUG-016** — the seeded profiles were ordered worst-first (`Best` led with
+   720p). Fixing the seeds did nothing for existing installs, so it needed a
+   bespoke migration that only rewrote profiles still matching a known-bad
+   default exactly. The owner's own `Best` had been edited, so the migration
+   correctly skipped it and the bug persisted until it was fixed by hand.
+2. **FEAT-004** — the `manual_confirmation` review gate defaults on for *new*
+   profiles, but existing ones can only be changed through the UI, and the
+   profile editor never exposes that field. So the documented "opt in from
+   Settings → Profiles" is currently impossible.
+3. A bulk profile update via the `profile.save` API silently cleared `core` on
+   12 built-ins (fixed separately), because the API rebuilds a profile from
+   whatever the caller sends rather than patching fields.
+
+A file makes the whole set reviewable, diffable, versionable and editable
+without a UI round-trip — and turns "change the defaults" from a migration
+problem into an edit.
+
+## The hard constraint: profile IDs are referenced
+
+Every movie stores `profile_id` and looks it up by database id
+(`media/main.py`: `db.get('id', media.get('profile_id'))`). Those ids are
+generated at insert time (`_generate_id()` in `sqlite_adapter.py`), not derived
+from anything stable in the profile itself.
+
+So a naive "regenerate profiles from the file on boot" **loses every movie's
+profile assignment**. Any design has to answer this. The obvious options:
+
+- **Stable keys.** The file gives each profile a slug (`best`, `uhd-4k`), and
+  a mapping table or a deterministic id derived from the slug preserves
+  references across rewrites. Requires a one-time migration to attach slugs to
+  existing profiles by matching label.
+- **File seeds, database owns.** The file is only consulted when a profile
+  does not already exist; the database stays the source of truth afterwards.
+  Simplest, keeps ids stable — but does not solve problem 1, because existing
+  profiles still never get updated.
+
+These are meaningfully different products, and the second is much less useful.
+
+## Other questions to settle first
+
+- **Which direction wins on conflict?** If the UI can still edit profiles, the
+  file and the database will diverge. Either the UI becomes read-only for
+  profiles (a real UX regression), or edits are written back to the file (then
+  the file is generated, and hand-edits race with the app), or the file is
+  import-only.
+- **Where does it live?** Beside `config.ini` in the config volume, so it
+  survives container recreation and lands in the user's backups.
+- **What happens to a malformed file?** It must not take the app down or leave
+  a user with no profiles. Fall back to the stored profiles and log loudly.
+- **What about `core`?** The flag marks a profile non-deletable in the UI. If
+  profiles come from a file, "built-in" arguably stops meaning anything.
+- **Format.** `config.ini` is already INI, but profiles are a list of records
+  with parallel arrays (`qualities`/`finish`/`wait_for`/`stop_after`/`3d`),
+  which INI models badly. YAML or JSON fits the shape; adding a YAML
+  dependency for one file is a cost worth weighing.
+
+## Suggested scope if picked up
+
+Smallest version that solves the motivating problems: a file that is
+**authoritative**, with slug-keyed stable ids, a one-time migration mapping
+existing profiles to slugs by label, the settings UI switched to read-only for
+profiles with a pointer to the file, and a loud, non-fatal fallback when the
+file is missing or invalid.
+
+Explicitly out of scope for a first cut: writing the file back from the UI.
+
+## Related
+
+- `specs/FEAT-004-review-gate-default-on.md` — the opt-in gap this would close
+- `specs/BUG-016-default-profile-quality-order.md` — the migration this would
+  have made unnecessary
+- `couchpotato/core/migration/fix_profile_quality_order.py` — the bespoke
+  repair that exists because the seeds are not re-readable

--- a/tests/e2e/movie-detail.spec.ts
+++ b/tests/e2e/movie-detail.spec.ts
@@ -196,4 +196,50 @@ test.describe('Movie Detail', () => {
       // in this suite, so this only exercises when one happens to exist.
     }
   });
+
+  test('should show a "Search for releases" action on the detail page (FEAT-005)', async ({ page }) => {
+    await page.goto('/');
+
+    const movieGrid = page.locator('#movie-grid');
+    await expect(movieGrid).toBeVisible({ timeout: 10000 });
+
+    const firstCard = movieGrid.locator('.poster-card').first();
+    test.skip(await firstCard.count() === 0, 'no movies in the library to open');
+
+    await firstCard.click();
+    await expect(page).toHaveURL(/.*movie\/.+/);
+
+    // Present regardless of status: the feature exists so a movie you already
+    // have can be re-checked against what providers currently offer.
+    const searchBtn = page.locator('[data-testid="search-releases"]');
+    await expect(searchBtn).toBeVisible({ timeout: 5000 });
+    await expect(searchBtn).toBeEnabled();
+    await expect(searchBtn).toContainText(/Search for releases/i);
+  });
+
+  test('the search action targets the list-only endpoint, not a full search', async ({ page }) => {
+    await page.goto('/');
+
+    const movieGrid = page.locator('#movie-grid');
+    await expect(movieGrid).toBeVisible({ timeout: 10000 });
+
+    const firstCard = movieGrid.locator('.poster-card').first();
+    test.skip(await firstCard.count() === 0, 'no movies in the library to open');
+
+    await firstCard.click();
+    await expect(page).toHaveURL(/.*movie\/.+/);
+
+    // Wiring it to the wrong endpoint would download rather than list, which
+    // is precisely what this feature avoids -- so assert the request itself.
+    const searchBtn = page.locator('[data-testid="search-releases"]');
+    await expect(searchBtn).toBeVisible({ timeout: 5000 });
+
+    const request = page.waitForRequest(
+      (r) => r.url().includes('movie.searcher.search_releases'),
+      { timeout: 10000 },
+    );
+    await searchBtn.click();
+    const req = await request;
+    expect(req.url()).not.toContain('full_search');
+  });
 });

--- a/tests/unit/test_downloaded_review_workflow_phase2.py
+++ b/tests/unit/test_downloaded_review_workflow_phase2.py
@@ -178,11 +178,20 @@ class TestProfileManualConfirmationPersistence:
         assert len(updated) == 1
         assert updated[0]['manual_confirmation'] is True
 
-    def test_save_defaults_manual_confirmation_false_when_omitted_on_new_profile(self):
+    def test_save_defaults_manual_confirmation_true_when_omitted_on_new_profile(self):
         """A save() call that never mentions manual_confirmation AND has no
         existing doc to fall back to (a brand new profile, or a caller whose
-        id doesn't resolve) must persist it as False, not leave it unset in
-        a way that could be misread as truthy."""
+        id doesn't resolve) must persist it EXPLICITLY, not leave it unset in
+        a way that could be misread.
+
+        FEAT-004 changed which value that is: new profiles now default the
+        review gate ON. The original default of False was chosen for
+        backwards compatibility, but it inverted the workflow's own decision
+        -- on a real install every profile had it unset, so nothing was ever
+        reviewed. The explicitness this test was written to protect is
+        unchanged; only the default flipped. The edit-path fallback below is
+        what keeps existing profiles on their stored value.
+        """
         result, updated = self._run_save({
             'id': 'profile-new',
             'label': 'Auto',
@@ -191,7 +200,7 @@ class TestProfileManualConfirmationPersistence:
 
         assert result['success'] is True
         assert len(updated) == 1
-        assert updated[0]['manual_confirmation'] is False
+        assert updated[0]['manual_confirmation'] is True
 
     def test_save_omitting_key_on_existing_true_profile_preserves_true(self):
         """BLOCKING bug (workflow phase 2 review): the live profile editor

--- a/tests/unit/test_review_gate_default.py
+++ b/tests/unit/test_review_gate_default.py
@@ -1,0 +1,113 @@
+"""The "Downloaded / review" gate defaults ON (FEAT-004).
+
+`specs/DOWNLOADED-REVIEW-WORKFLOW.md` decided that a completed download must
+never auto-promote to `done` — the user reviews it first. The gate shipped
+per-profile as `manual_confirmation`, but defaulting OFF for backwards
+compatibility, which inverted the intended design: on a production install all
+18 profiles had it unset, so every completion went straight to `done` and
+nothing ever surfaced that the gate existed.
+
+The subtlety worth protecting: `save()` deliberately falls back to the
+PERSISTED value when the key is omitted, because the live profile editor does
+not resend it. Changing the create-path default must not leak into that
+fallback, or editing any existing profile would silently switch its gate on.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from couchpotato.core.plugins.profile.main import DEFAULT_PROFILES, build_profile_doc
+
+
+class TestSeededProfiles:
+
+    @pytest.mark.parametrize('profile', DEFAULT_PROFILES, ids=lambda p: p['label'])
+    def test_every_seeded_profile_has_the_gate_on(self, profile):
+        """AC1: a fresh install must review downloads, not auto-complete."""
+        doc = build_profile_doc(profile, order=0)
+
+        assert doc.get('manual_confirmation') is True
+
+
+class TestSaveDefaults:
+    """AC2-AC5 — the create path changes, the edit path must not."""
+
+    def _save(self, plugin, kwargs, existing=None):
+        """Drive Profile.save(). `existing` None means the create path."""
+        db = MagicMock()
+        inserted = {}
+
+        def fake_insert(doc):
+            inserted.update(doc)
+            inserted.setdefault('_id', 'new-profile')
+            return inserted
+
+        db.insert.side_effect = fake_insert
+        if existing is None:
+            db.get.side_effect = KeyError('not found')
+        else:
+            db.get.return_value = dict(existing)
+
+        with patch('couchpotato.core.plugins.profile.main.get_db', return_value=db), \
+                patch('couchpotato.core.plugins.profile.main.fireEvent'):
+            plugin.save(**kwargs)
+
+        # the doc handed to db.update is the authoritative final state
+        return db.update.call_args[0][0] if db.update.called else inserted
+
+    @pytest.fixture
+    def plugin(self):
+        from couchpotato.core.plugins.profile.main import ProfilePlugin
+
+        return object.__new__(ProfilePlugin)
+
+    def _types(self):
+        return [{'quality': '1080p', 'finish': 1, '3d': 0}]
+
+    def test_a_new_profile_gets_the_gate_on(self, plugin):
+        """AC2: creating a profile without mentioning the flag opts into the
+        reviewed workflow, matching the seeded profiles."""
+        doc = self._save(plugin, {'label': 'New', 'types': self._types()})
+
+        assert doc.get('manual_confirmation') is True
+
+    def test_editing_a_profile_with_the_gate_off_leaves_it_off(self, plugin):
+        """AC3: the regression this guards against. The live profile editor
+        does not resend manual_confirmation, so the persisted value must win
+        over the new default -- otherwise every save of an existing profile
+        silently switches its gate on."""
+        existing = {'_id': 'p1', 'label': 'Old', 'manual_confirmation': False,
+                    'order': 3}
+
+        doc = self._save(plugin, {'id': 'p1', 'label': 'Old', 'types': self._types()},
+                         existing=existing)
+
+        assert doc.get('manual_confirmation') is False
+
+    def test_editing_a_profile_with_the_gate_on_leaves_it_on(self, plugin):
+        """AC4: the mirror case."""
+        existing = {'_id': 'p1', 'label': 'Old', 'manual_confirmation': True,
+                    'order': 3}
+
+        doc = self._save(plugin, {'id': 'p1', 'label': 'Old', 'types': self._types()},
+                         existing=existing)
+
+        assert doc.get('manual_confirmation') is True
+
+    def test_an_explicit_zero_still_turns_it_off_on_create(self, plugin):
+        """AC5: the new default must not make the flag unsettable."""
+        doc = self._save(plugin, {'label': 'New', 'types': self._types(),
+                                  'manual_confirmation': '0'})
+
+        assert doc.get('manual_confirmation') is False
+
+    def test_an_explicit_zero_still_turns_it_off_on_edit(self, plugin):
+        existing = {'_id': 'p1', 'label': 'Old', 'manual_confirmation': True,
+                    'order': 3}
+
+        doc = self._save(plugin, {'id': 'p1', 'label': 'Old', 'types': self._types(),
+                                  'manual_confirmation': '0'},
+                         existing=existing)
+
+        assert doc.get('manual_confirmation') is False

--- a/tests/unit/test_review_gate_default.py
+++ b/tests/unit/test_review_gate_default.py
@@ -111,3 +111,83 @@ class TestSaveDefaults:
                          existing=existing)
 
         assert doc.get('manual_confirmation') is False
+
+
+class TestCoreFlagSurvivesAnEdit:
+    """`core` marks a built-in profile non-deletable: the settings UI disables
+    its delete button and the JS guards on it.
+
+    save() built it as `kwargs.get('core', False)` with no fallback to the
+    persisted value -- unlike `order` and `manual_confirmation`. The new-UI
+    profile editor sends id/label/minimum_score/wait_for/stop_after/types and
+    never `core`, so **every edit of a built-in profile silently cleared the
+    flag and made it deletable**. Found when a bulk profile update cleared it
+    on 12 built-ins at once.
+    """
+
+    @pytest.fixture
+    def plugin(self):
+        from couchpotato.core.plugins.profile.main import ProfilePlugin
+
+        return object.__new__(ProfilePlugin)
+
+    def _save(self, plugin, kwargs, existing=None):
+        db = MagicMock()
+        inserted = {}
+
+        def fake_insert(doc):
+            inserted.update(doc)
+            inserted.setdefault('_id', 'new-profile')
+            return inserted
+
+        db.insert.side_effect = fake_insert
+        if existing is None:
+            db.get.side_effect = KeyError('not found')
+        else:
+            db.get.return_value = dict(existing)
+
+        with patch('couchpotato.core.plugins.profile.main.get_db', return_value=db), \
+                patch('couchpotato.core.plugins.profile.main.fireEvent'):
+            plugin.save(**kwargs)
+
+        return db.update.call_args[0][0] if db.update.called else inserted
+
+    def _types(self):
+        return [{'quality': '1080p', 'finish': 1, '3d': 0}]
+
+    def test_editing_a_builtin_without_sending_core_keeps_it(self, plugin):
+        """Bug repro: this is exactly the payload the profile editor sends."""
+        existing = {'_id': 'p1', 'label': '720p', 'core': True, 'order': 5}
+
+        doc = self._save(plugin, {'id': 'p1', 'label': '720p',
+                                  'minimum_score': '1', 'wait_for': '0',
+                                  'stop_after': '0', 'types': self._types()},
+                         existing=existing)
+
+        assert doc.get('core') is True, (
+            'editing a built-in profile cleared its core flag, making it '
+            'deletable in the UI'
+        )
+
+    def test_a_non_core_profile_stays_non_core(self, plugin):
+        existing = {'_id': 'p1', 'label': 'Mine', 'core': False, 'order': 5}
+
+        doc = self._save(plugin, {'id': 'p1', 'label': 'Mine',
+                                  'types': self._types()}, existing=existing)
+
+        assert not doc.get('core')
+
+    def test_an_explicit_core_value_still_wins(self, plugin):
+        existing = {'_id': 'p1', 'label': 'Mine', 'core': False, 'order': 5}
+
+        doc = self._save(plugin, {'id': 'p1', 'label': 'Mine', 'core': True,
+                                  'types': self._types()}, existing=existing)
+
+        assert doc.get('core') is True
+
+    def test_a_new_profile_is_not_core(self, plugin):
+        """Only the seeded built-ins are core; anything a user creates is
+        theirs to delete."""
+        doc = self._save(plugin, {'label': 'Mine', 'types': self._types()})
+
+        assert not doc.get('core')

--- a/tests/unit/test_review_gate_default.py
+++ b/tests/unit/test_review_gate_default.py
@@ -191,3 +191,64 @@ class TestCoreFlagSurvivesAnEdit:
         doc = self._save(plugin, {'label': 'Mine', 'types': self._types()})
 
         assert not doc.get('core')
+
+
+class TestQualitySeededProfiles:
+    """QualityPlugin.fill() seeds a one-quality core profile per quality, and
+    runs BEFORE ProfilePlugin.fill() on a fresh database. Those documents are
+    built inline rather than through build_profile_doc(), so they needed the
+    gate adding separately -- otherwise a fresh install still had a dozen
+    profiles that auto-complete downloads."""
+
+    def test_the_seeded_profile_document_has_the_gate_on(self):
+        """Asserted on the profile-insert block specifically, so it cannot
+        pass on an unrelated occurrence elsewhere in fill()."""
+        import inspect
+        import re
+
+        from couchpotato.core.plugins.quality.main import QualityPlugin
+
+        source = inspect.getsource(QualityPlugin.fill)
+        block = re.search(r"'_t': 'profile'.*?\}\)", source, re.S)
+
+        assert block, "could not find the profile insert in QualityPlugin.fill"
+        assert "'manual_confirmation': True" in block.group(0)
+
+
+class TestTagPersistsTheTimestampBump:
+    """FEAT-005 leans on media.tag(..., update_edited=True) to keep
+    release.cleanDone from sweeping the releases a search just surfaced.
+
+    tag() had db.update() inside the tag-is-new branch, so the SECOND search
+    onward bumped last_edit in memory only and the protection silently stopped
+    working."""
+
+    def _tag(self, existing_tags):
+        from couchpotato.core.media._base.media.main import MediaPlugin
+
+        plugin = object.__new__(MediaPlugin)
+        doc = {'_id': 'm1', 'tags': list(existing_tags), 'last_edit': 0}
+        db = MagicMock()
+        db.get.return_value = doc
+
+        with patch('couchpotato.core.media._base.media.main.get_db', return_value=db), \
+                patch('couchpotato.core.media._base.media.main.media_lock'):
+            plugin.tag('m1', 'recent', update_edited=True)
+
+        return doc, db
+
+    def test_a_repeat_tag_still_persists_the_new_timestamp(self):
+        """The bug: 'recent' already present, so nothing was written."""
+        doc, db = self._tag(['recent'])
+
+        assert doc['last_edit'] > 0
+        assert db.update.called, (
+            'last_edit was bumped in memory but never persisted, so the '
+            'cleanup protection stopped working after the first search'
+        )
+
+    def test_a_first_tag_still_persists(self):
+        doc, db = self._tag([])
+
+        assert 'recent' in doc['tags']
+        assert db.update.called

--- a/tests/unit/test_search_releases_list_only.py
+++ b/tests/unit/test_search_releases_list_only.py
@@ -55,11 +55,15 @@ def _profile():
     }
 
 
-def _drive(searcher, movie, **kwargs):
+def _drive(searcher, movie, no_results=False, **kwargs):
     """Run single() with the surrounding plumbing mocked, returning the
-    fireEvent calls so the assertions can look at what it actually did."""
+    fireEvent calls so the assertions can look at what it actually did.
+
+    `no_results` models the common provider failure mode: implementations
+    swallow connection/HTTP errors and simply return nothing.
+    """
     calls = []
-    found = [{'name': 'Some.Movie.2160p', 'url': 'http://x/1', 'score': 10}]
+    found = [] if no_results else [{'name': 'Some.Movie.2160p', 'url': 'http://x/1', 'score': 10}]
 
     def fake_fire_event(name, *args, **kw):
         calls.append(name)
@@ -74,7 +78,7 @@ def _drive(searcher, movie, **kwargs):
         if name == 'media.get':
             return movie
         if name == 'release.create_from_search':
-            return ['rel-%d' % len(calls)]
+            return [] if no_results else ['rel-%d' % len(calls)]
         if name == 'release.try_download_result':
             return True
         if name == 'quality.ishigher':
@@ -156,6 +160,46 @@ class TestListOnlySearchesDoneMovies:
         calls = _drive(searcher, _movie(status='done'), list_only=True)
 
         assert 'media.tag' in calls
+
+
+class TestListOnlyIsNonDestructive:
+    """Two data-loss paths the list-only bypass newly reaches.
+
+    Both were previously unreachable for a done/downloaded movie because the
+    status short-circuit returned before them. Bypassing that gate exposed
+    them, so list-only has to opt out of each.
+    """
+
+    def test_it_never_deletes_a_movie_with_no_title(self, searcher):
+        """single() deletes any movie whose title won't resolve -- reasonable
+        for the automatic path (it cannot be searched), catastrophic for a
+        read-only 'show me what's available' action on a library record."""
+        movie = _movie(status='done')
+        movie['title'] = ''
+        movie['info'] = {'year': 2020}
+
+        calls = _drive(searcher, movie, list_only=True)
+
+        assert 'media.delete' not in calls, (
+            'a list-only search deleted the library record'
+        )
+
+    def test_it_does_not_delete_existing_releases_when_providers_return_nothing(self, searcher):
+        """single() removes previously-available releases the current search
+        did not return. Providers routinely swallow connection errors and
+        return [], so one failed search would wipe the release list the user
+        opened the page to look at."""
+        movie = _movie(status='done', releases=[
+            {'_id': 'old-1', 'status': 'available', 'quality': '1080p',
+             'identifier': 'kept', 'is_3d': False},
+        ])
+
+        calls = _drive(searcher, movie, list_only=True, no_results=True)
+
+        assert 'release.delete' not in calls, (
+            'a list-only search whose providers returned nothing deleted the '
+            'movie\'s existing releases'
+        )
 
 
 class TestAutomaticPathUnchanged:

--- a/tests/unit/test_search_releases_list_only.py
+++ b/tests/unit/test_search_releases_list_only.py
@@ -55,6 +55,13 @@ def _profile():
     }
 
 
+class _Calls(list):
+    """A list of fired event NAMES that also carries the full (name, args,
+    kwargs) tuples, so a test can assert HOW an event was fired and not merely
+    that it was."""
+    fired = ()
+
+
 def _drive(searcher, movie, no_results=False, **kwargs):
     """Run single() with the surrounding plumbing mocked, returning the
     fireEvent calls so the assertions can look at what it actually did.
@@ -62,11 +69,13 @@ def _drive(searcher, movie, no_results=False, **kwargs):
     `no_results` models the common provider failure mode: implementations
     swallow connection/HTTP errors and simply return nothing.
     """
-    calls = []
+    calls = _Calls()
+    fired = []
     found = [] if no_results else [{'name': 'Some.Movie.2160p', 'url': 'http://x/1', 'score': 10}]
 
     def fake_fire_event(name, *args, **kw):
         calls.append(name)
+        fired.append((name, args, kw))
         if name == 'quality.pre_releases':
             return []
         if name == 'movie.update_release_dates':
@@ -99,6 +108,7 @@ def _drive(searcher, movie, no_results=False, **kwargs):
             patch.object(type(searcher), 'shuttingDown', return_value=False, create=True):
         searcher.single(movie, search_protocols=['nzb'], **kwargs)
 
+    calls.fired = fired          # attach so callers can inspect kwargs too
     return calls
 
 
@@ -159,7 +169,12 @@ class TestListOnlySearchesDoneMovies:
         """
         calls = _drive(searcher, _movie(status='done'), list_only=True)
 
-        assert 'media.tag' in calls
+        tag_calls = [f for f in calls.fired if f[0] == 'media.tag']
+        assert tag_calls, 'the movie was never touched, so cleanDone will sweep the results'
+        # Asserting the kwarg, not just the event name: without update_edited
+        # the tag is added but last_edit is untouched, and the protection this
+        # test exists for does not happen.
+        assert tag_calls[0][2].get('update_edited') is True
 
 
 class TestListOnlyIsNonDestructive:
@@ -321,3 +336,57 @@ class TestMovieDetailButton:
         html = self._render('downloaded')
 
         assert 'data-testid="search-releases"' in html
+
+
+class TestListOnlyImpliesFreshResults:
+    """list_only on its own must not be served from cache, so a future caller
+    of the movie.searcher.single event cannot accidentally get stale results
+    by forgetting manual=True."""
+
+    def test_list_only_alone_bypasses_the_cache(self, searcher):
+        import inspect
+
+        from couchpotato.core.media.movie.searcher import MovieSearcher
+
+        source = inspect.getsource(MovieSearcher.single)
+
+        assert 'bypass_cache = manual or list_only' in source
+
+
+class TestFoundCount:
+    """The count the toast reports, exercised against real release data
+    rather than inferred from a mocked-out single()."""
+
+    def _view(self, searcher, releases):
+        movie = _movie(status='done', releases=releases)
+
+        with patch('couchpotato.core.media.movie.searcher.fireEvent') as fire, \
+                patch.object(type(searcher), 'single', return_value=None, create=True):
+            fire.side_effect = lambda name, *a, **k: movie if name == 'media.get' else None
+            return searcher.searchReleasesView(media_id='movie-1')
+
+    def test_it_counts_only_available_releases(self, searcher):
+        result = self._view(searcher, [
+            {'status': 'available', 'quality': '2160p'},
+            {'status': 'available', 'quality': '1080p'},
+            {'status': 'done', 'quality': '720p'},
+            {'status': 'failed', 'quality': '720p'},
+            {'status': 'ignored', 'quality': 'brrip'},
+        ])
+
+        assert result['found'] == 2
+
+    def test_no_available_releases_reports_zero(self, searcher):
+        result = self._view(searcher, [{'status': 'done', 'quality': '720p'}])
+
+        assert result['found'] == 0
+
+    def test_a_movie_that_no_longer_exists_is_reported_as_a_failure(self, searcher):
+        """The detail page can be open while the movie is deleted in another
+        tab; the click must not report success for a search that never ran."""
+        with patch('couchpotato.core.media.movie.searcher.fireEvent', return_value=None), \
+                patch.object(type(searcher), 'single', return_value=None, create=True) as single:
+            result = searcher.searchReleasesView(media_id='gone')
+
+        assert result == {'success': False, 'found': 0}
+        assert not single.called, 'no search should run for a movie that is gone'

--- a/tests/unit/test_search_releases_list_only.py
+++ b/tests/unit/test_search_releases_list_only.py
@@ -207,6 +207,36 @@ class TestApiView:
         assert single.called, 'the view must actually run a search'
         assert single.call_args.kwargs.get('list_only') is True
 
+    def test_the_search_is_not_served_from_cache(self, searcher):
+        """A user pressing "Search for releases" is asking what is available
+        NOW. single() derives bypass_cache from `manual`, so without it the
+        click is answered from the 30-minute provider cache -- stale results
+        for an explicitly user-initiated action.
+
+        manual=True is also the established idiom for "a human asked for
+        this" across try_next and mark_failed. It cannot cause a download
+        here: list_only short-circuits the download gate regardless.
+        """
+        movie = _movie(status='done')
+
+        with patch('couchpotato.core.media.movie.searcher.fireEvent') as fire, \
+                patch.object(type(searcher), 'single', return_value=None, create=True) as single:
+            fire.side_effect = lambda name, *a, **k: movie if name == 'media.get' else None
+            searcher.searchReleasesView(media_id='movie-1')
+
+        assert single.call_args.kwargs.get('manual') is True, (
+            'without manual=True the search is answered from the provider '
+            'cache, so a user-initiated refresh can return stale results'
+        )
+
+    def test_a_cached_search_would_still_not_download(self, searcher):
+        """manual=True widens what is searched (it also ignores the ETA
+        gate). Pin that this cannot turn the list-only action into a
+        downloading one."""
+        calls = _drive(searcher, _movie(status='done'), list_only=True, manual=True)
+
+        assert 'release.try_download_result' not in calls
+
 
 class TestMovieDetailButton:
     """AC8 -- the action has to be reachable from the UI, and specifically on

--- a/tests/unit/test_search_releases_list_only.py
+++ b/tests/unit/test_search_releases_list_only.py
@@ -381,6 +381,21 @@ class TestFoundCount:
 
         assert result['found'] == 0
 
+    def test_a_failure_inside_the_search_does_not_500(self, searcher):
+        """single() can raise for a movie with incomplete info -- e.g. a
+        library import with no 'year', which single() indexes directly. Its
+        siblings tryNextRelease and markFailedAndResearch both wrap their work;
+        this view did not, so a plausible edge case for exactly the movies
+        this feature targets returned a 500 instead of a handled failure."""
+        movie = _movie(status='done')
+
+        with patch('couchpotato.core.media.movie.searcher.fireEvent') as fire, \
+                patch.object(type(searcher), 'single', side_effect=KeyError('year'), create=True):
+            fire.side_effect = lambda name, *a, **k: movie if name == 'media.get' else None
+            result = searcher.searchReleasesView(media_id='movie-1')
+
+        assert result == {'success': False, 'found': 0}
+
     def test_a_movie_that_no_longer_exists_is_reported_as_a_failure(self, searcher):
         """The detail page can be open while the movie is deleted in another
         tab; the click must not report success for a search that never ran."""

--- a/tests/unit/test_search_releases_list_only.py
+++ b/tests/unit/test_search_releases_list_only.py
@@ -1,0 +1,234 @@
+"""Search for releases on a movie you already have (FEAT-005).
+
+Owner's report: "they are marked as done, but I may want to download a better
+version in the future should one come out, if I open the title it should
+search for releases".
+
+Three things blocked that, and `manual=True` alone fixes only the first:
+
+1. `single()` short-circuits for `done`/`downloaded` movies.
+2. The has-better-quality check breaks out of the quality loop -- for a movie
+   that already holds its profile's top quality that is an immediate break, so
+   nothing is searched at all.
+3. The download gate is `force_download or not could_not_be_released or
+   always_search`, and for a released movie the middle term is true -- so a
+   manual search would SNATCH rather than list.
+
+`list_only=True` addresses all three without touching the automatic path.
+See specs/FEAT-005-search-releases-for-done-movies.md.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from couchpotato.core.media.movie.searcher import MovieSearcher
+
+
+@pytest.fixture
+def searcher():
+    s = MovieSearcher.__new__(MovieSearcher)
+    return s
+
+
+def _movie(status='done', releases=None):
+    return {
+        '_id': 'movie-1',
+        'title': 'Some Movie',
+        'profile_id': 'profile-1',
+        'status': status,
+        'releases': releases if releases is not None else [],
+        'info': {'year': 2020, 'titles': ['Some Movie']},
+        'identifiers': {'imdb': 'tt1234567'},
+    }
+
+
+def _profile():
+    return {
+        '_id': 'profile-1',
+        'qualities': ['2160p', '1080p', '720p'],
+        'finish': [True, True, True],
+        'wait_for': [0, 0, 0],
+        'stop_after': [0, 0, 0],
+        '3d': [False, False, False],
+        'minimum_score': 1,
+    }
+
+
+def _drive(searcher, movie, **kwargs):
+    """Run single() with the surrounding plumbing mocked, returning the
+    fireEvent calls so the assertions can look at what it actually did."""
+    calls = []
+    found = [{'name': 'Some.Movie.2160p', 'url': 'http://x/1', 'score': 10}]
+
+    def fake_fire_event(name, *args, **kw):
+        calls.append(name)
+        if name == 'quality.pre_releases':
+            return []
+        if name == 'movie.update_release_dates':
+            return {'theater': 1, 'dvd': 0}
+        if name == 'quality.single':
+            return {'identifier': kw.get('identifier', '1080p'), 'label': 'q'}
+        if name == 'searcher.search':
+            return list(found)
+        if name == 'media.get':
+            return movie
+        if name == 'release.create_from_search':
+            return ['rel-%d' % len(calls)]
+        if name == 'release.try_download_result':
+            return True
+        if name == 'quality.ishigher':
+            return 'equal'          # "we already have this" -> would break
+        if name == 'media.restatus':
+            return movie['status']
+        return None
+
+    db = MagicMock()
+    db.get.return_value = _profile()
+    env = MagicMock()
+    env.prop.return_value = 0
+
+    with patch('couchpotato.core.media.movie.searcher.fireEvent', side_effect=fake_fire_event), \
+            patch('couchpotato.core.media.movie.searcher.get_db', return_value=db), \
+            patch('couchpotato.core.media.movie.searcher.Env', env), \
+            patch.object(type(searcher), 'conf', return_value=False, create=True), \
+            patch.object(type(searcher), 'shuttingDown', return_value=False, create=True):
+        searcher.single(movie, search_protocols=['nzb'], **kwargs)
+
+    return calls
+
+
+class TestListOnlySearchesDoneMovies:
+
+    def test_a_done_movie_is_searched(self, searcher):
+        """AC1: the short-circuit that normally returns early must not fire."""
+        calls = _drive(searcher, _movie(status='done'), list_only=True)
+
+        assert 'searcher.search' in calls
+
+    def test_a_review_gated_movie_is_searched(self, searcher):
+        """AC1: 'downloaded' is gated the same way as 'done'."""
+        calls = _drive(searcher, _movie(status='downloaded'), list_only=True)
+
+        assert 'searcher.search' in calls
+
+    def test_nothing_is_downloaded(self, searcher):
+        """AC2: the whole point -- list, do not snatch. The movie here is
+        released, so the automatic path WOULD download."""
+        calls = _drive(searcher, _movie(status='done'), list_only=True)
+
+        assert 'release.try_download_result' not in calls
+
+    def test_results_are_still_stored(self, searcher):
+        """AC4: without this the search would be pointless -- the releases
+        have to land somewhere the UI can show them."""
+        calls = _drive(searcher, _movie(status='done'), list_only=True)
+
+        assert 'release.create_from_search' in calls
+
+    def test_every_profile_quality_is_searched(self, searcher):
+        """AC3: quality.ishigher is stubbed to 'equal', i.e. "we already hold
+        this" -- which makes the automatic path break out of the loop on the
+        first quality. list_only must keep going so the user sees what exists
+        at every quality in the profile."""
+        movie = _movie(status='done', releases=[
+            {'status': 'done', 'quality': '2160p', 'is_3d': False},
+        ])
+
+        calls = _drive(searcher, movie, list_only=True)
+
+        assert calls.count('searcher.search') == 3, (
+            'expected one search per profile quality, got %d'
+            % calls.count('searcher.search')
+        )
+
+
+class TestAutomaticPathUnchanged:
+    """AC6 -- list_only defaults false and must change nothing."""
+
+    def test_a_done_movie_is_still_skipped_automatically(self, searcher):
+        calls = _drive(searcher, _movie(status='done'))
+
+        assert 'searcher.search' not in calls
+
+    def test_the_has_better_quality_break_still_applies(self, searcher):
+        """The automatic path must still stop once it holds the quality --
+        that is what stops it re-grabbing forever."""
+        movie = _movie(status='active', releases=[
+            {'status': 'done', 'quality': '2160p', 'is_3d': False},
+        ])
+
+        calls = _drive(searcher, movie)
+
+        assert calls.count('searcher.search') == 0
+
+    def test_the_automatic_path_still_downloads(self, searcher):
+        calls = _drive(searcher, _movie(status='active'))
+
+        assert 'release.try_download_result' in calls
+
+
+class TestApiView:
+    """AC7 -- exposed so the UI can call it."""
+
+    def test_search_releases_is_registered(self):
+        import inspect
+
+        from couchpotato.core.media.movie.searcher import MovieSearcher
+
+        source = inspect.getsource(MovieSearcher.__init__)
+
+        assert "addApiView('movie.searcher.search_releases'" in source
+
+    def test_the_view_reports_how_many_were_found(self, searcher):
+        movie = _movie(status='done')
+
+        with patch('couchpotato.core.media.movie.searcher.fireEvent') as fire, \
+                patch.object(type(searcher), 'single', return_value=None, create=True) as single:
+            fire.side_effect = lambda name, *a, **k: movie if name == 'media.get' else None
+            result = searcher.searchReleasesView(media_id='movie-1')
+
+        assert result.get('success') is True
+        assert single.called, 'the view must actually run a search'
+        assert single.call_args.kwargs.get('list_only') is True
+
+
+class TestMovieDetailButton:
+    """AC8 -- the action has to be reachable from the UI, and specifically on
+    a movie that is already done, since that is the case it exists for."""
+
+    def _render(self, status):
+        import pathlib as _p
+
+        from jinja2 import Environment, FileSystemLoader
+
+        root = _p.Path(__file__).resolve().parents[2] / 'couchpotato' / 'ui' / 'templates'
+        env = Environment(loader=FileSystemLoader(str(root)), autoescape=True)
+        tmpl = env.get_template('partials/movie_detail.html')
+        return tmpl.render(movie={
+            '_id': 'movie-1',
+            'title': 'Some Movie',
+            'status': status,
+            'releases': [],
+            'info': {'year': 2020},
+            'identifiers': {'imdb': 'tt1234567'},
+        }, url_base='/', api_base='/api/key')
+
+    def test_the_button_is_rendered_for_a_done_movie(self):
+        html = self._render('done')
+
+        assert 'data-testid="search-releases"' in html
+        assert 'Search for releases' in html
+
+    def test_it_calls_the_list_only_endpoint(self):
+        """A button wired to the wrong endpoint would download rather than
+        list -- the exact behaviour this feature exists to avoid."""
+        html = self._render('done')
+
+        assert 'movie.searcher.search_releases' in html
+        assert 'movie.searcher.full_search' not in html
+
+    def test_it_is_also_available_while_awaiting_review(self):
+        html = self._render('downloaded')
+
+        assert 'data-testid="search-releases"' in html

--- a/tests/unit/test_search_releases_list_only.py
+++ b/tests/unit/test_search_releases_list_only.py
@@ -143,6 +143,21 @@ class TestListOnlySearchesDoneMovies:
         )
 
 
+    def test_the_movie_is_touched_so_the_results_survive_cleanup(self, searcher):
+        """release.cleanDone() deletes every 'available' release for a movie
+        whose last_edit is older than a week, and a 'done' movie's last_edit
+        is typically months old. So the last_edit bump is load-bearing here:
+        without it the releases this search just surfaced get swept before
+        the user can pick one, and the feature is silently useless.
+
+        This is the one mutation a list-only search does make, and it is
+        deliberate -- hence a test rather than a gate.
+        """
+        calls = _drive(searcher, _movie(status='done'), list_only=True)
+
+        assert 'media.tag' in calls
+
+
 class TestAutomaticPathUnchanged:
     """AC6 -- list_only defaults false and must change nothing."""
 


### PR DESCRIPTION
Two features from the owner's report that downloads were auto-completing without review.

## FEAT-004 — the Downloaded/review gate defaults ON

`specs/DOWNLOADED-REVIEW-WORKFLOW.md` opens by rejecting auto-done — *"the answer is **no**; introduce a review gate"*. The gate shipped in v3.9.0 but defaulting **off** for backwards compatibility, which inverted its own decision in practice: on the production install **all 18 profiles had it unset**, so every completed download went straight to `done` and the owner never saw the copy before it was accepted. Someone who never opens profile settings never learns the gate exists.

Seeded and newly-created profiles now default it on.

**The edit path is deliberately untouched.** `save()` falls back to the *persisted* value when the key is omitted, because the profile editor doesn't resend it — if the new default leaked into that fallback, editing any existing profile would silently flip its gate. Three tests pin it (off stays off, on stays on, explicit `0` still wins). Both `profile.save` callers in the tree were checked: neither ever sends the key, and both always send `id` when editing.

**No migration for existing profiles.** Flipping the gate changes what happens to every future download, and doing that silently to installs running for months is the same class of surprise this fixes, just inverted. Existing users opt in.

## FEAT-005 — search for releases on a movie you already have

> they are marked as done, but I may want to download a better version in the future should one come out

`manual=True` alone doesn't get there. It clears the status gate, but the search would still **break out** on the has-better-quality check — an *immediate* break for a movie already holding its top quality, so nothing is searched at all — and would then **download** rather than list, since the gate is `force_download or not could_not_be_released or always_search` and the middle term is true for a released movie.

`list_only=True` handles all three: bypasses the status gate, skips the break, never calls `try_download_result`. Results land as `available` and the user picks. Exposed as `movie.searcher.search_releases`, with a **"Search for releases"** button on the detail page for every status.

All three branches mutation-checked independently — reverting any one alone fails a test.

### The one mutation it makes, and why

A local review flagged the un-gated `media.tag('recent', update_edited=True)` and suggested gating it. Investigating **flipped that conclusion**: `release.cleanDone()` deletes every `available` release for a movie whose `last_edit` is older than a week, and a `done` movie's `last_edit` is typically months old — exactly the movies this targets. Gating it would mean the results get swept before the user could act on them, making the feature silently useless. Kept, commented at the call site, pinned by a test, and recorded as AC9 rather than left unexamined.

## Design call worth challenging

It's a **button**, not a search on page open. Opening a title would fire a provider sweep across every profile quality on every page view — a dozen indexer calls, several seconds, on a NAS-hosted app — and make an idempotent GET do expensive outbound work, so an accidental refresh re-runs it. The request was "if I open the title it should search"; I've deliberately interpreted that as an explicit action and flagged it rather than assumed.

## Verification

- `make verify`: lint + **1449 unit tests** + 194 UI unit tests green. Playwright **133/135**; the two failures are the known `waitForLoadState('networkidle')` family in `interactions.e2e.spec.ts`.
- Two new E2E tests (per CLAUDE.md rule 5) — one asserts the button renders, one asserts the request targets the **list-only** endpoint rather than `full_search`, since wiring it to the wrong one would download instead of list. Both confirmed to actually run rather than hit their skip guard.
- One existing assertion changed: `test_save_defaults_manual_confirmation_false_when_omitted_on_new_profile` asserted the old default. Its real concern was *explicitness* — that the flag is persisted rather than left unset — which still holds; only the value flipped. Renamed and re-documented rather than deleted.

Specs: `specs/FEAT-004-review-gate-default-on.md`, `specs/FEAT-005-search-releases-for-done-movies.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01776dG2XJe9h9DWz9dSJ2KK