### PR TITLE
feat: preferred download source — name it, share one sort, fix unknown-protocol ordering (FEAT-007 Part A)

### DIFF
--- a/couchpotato/core/helpers/protocol.py
+++ b/couchpotato/core/helpers/protocol.py
@@ -1,16 +1,21 @@
 """Ordering releases by the user's preferred download source.
 
 `searcher.preferred_method` ('both' | 'nzb' | 'torrent') is a HARD preference
-that FALLS BACK: every release of the preferred protocol outranks every release
-of the other one, but nothing is excluded, so when the preferred protocol has
-no usable release the other one is still downloaded.
+that orders every release of the preferred protocol before every release of
+the other one; nothing is excluded by this ordering step. Falls back to the
+other protocol if no acceptable release of the preferred one is found --
+"acceptable" meaning it passes `Release.tryDownloadResult`'s FILTERS (status /
+minimum_score / size / seeders). If the preferred release passes those filters
+but the download itself then fails (downloader disabled/unreachable,
+provider error), `tryDownloadResult` does not advance to the next candidate --
+that is a pre-existing, separate limitation of this ordering, not something
+this module can fix. See tests/unit/test_protocol_preference.py::
+TestFallbackToTheOtherProtocol for both the covered and the known-gap cases.
 
 Both call sites — `Searcher.search()` (what gets downloaded) and
 `Release.forMedia()` (what the UI lists) — sort by score first and then apply
 this, relying on a stable sort to keep score order inside each protocol group.
 """
-
-NO_PREFERENCE = 'both'
 
 _NZB_PROTOCOLS = ('nzb',)
 _TORRENT_PROTOCOLS = ('torrent', 'torrent_magnet')
@@ -21,7 +26,7 @@ _OTHER = 1
 _UNKNOWN = 2
 
 
-def protocol_rank(protocol, preference):
+def _protocol_rank(protocol, preference):
     """Rank `protocol` against `preference`.
 
     Returns 0 for the preferred family, 1 for the other known family, and 2 for
@@ -59,4 +64,4 @@ def sort_by_protocol_preference(items, preference, get_protocol):
     if preference not in ('nzb', 'torrent'):
         return list(items)
 
-    return sorted(items, key = lambda item: protocol_rank(get_protocol(item), preference))
+    return sorted(items, key = lambda item: _protocol_rank(get_protocol(item), preference))

--- a/couchpotato/core/helpers/protocol.py
+++ b/couchpotato/core/helpers/protocol.py
@@ -30,7 +30,10 @@ def protocol_rank(protocol, preference):
     way the preference points.
     """
 
-    normalised = (protocol or '').strip().lower()
+    if not isinstance(protocol, str):
+        return _UNKNOWN
+
+    normalised = protocol.strip().lower()
 
     if normalised in _NZB_PROTOCOLS:
         family = 'nzb'

--- a/couchpotato/core/helpers/protocol.py
+++ b/couchpotato/core/helpers/protocol.py
@@ -1,0 +1,59 @@
+"""Ordering releases by the user's preferred download source.
+
+`searcher.preferred_method` ('both' | 'nzb' | 'torrent') is a HARD preference
+that FALLS BACK: every release of the preferred protocol outranks every release
+of the other one, but nothing is excluded, so when the preferred protocol has
+no usable release the other one is still downloaded.
+
+Both call sites — `Searcher.search()` (what gets downloaded) and
+`Release.forMedia()` (what the UI lists) — sort by score first and then apply
+this, relying on a stable sort to keep score order inside each protocol group.
+"""
+
+NO_PREFERENCE = 'both'
+
+_NZB_PROTOCOLS = ('nzb',)
+_TORRENT_PROTOCOLS = ('torrent', 'torrent_magnet')
+
+#: Ranks, low sorts first.
+_PREFERRED = 0
+_OTHER = 1
+_UNKNOWN = 2
+
+
+def protocol_rank(protocol, preference):
+    """Rank `protocol` against `preference`.
+
+    Returns 0 for the preferred family, 1 for the other known family, and 2 for
+    anything unrecognised. Unknown ranks last in BOTH directions: a release
+    whose protocol we cannot identify must never outrank one we can, whichever
+    way the preference points.
+    """
+
+    normalised = (protocol or '').strip().lower()
+
+    if normalised in _NZB_PROTOCOLS:
+        family = 'nzb'
+    elif normalised in _TORRENT_PROTOCOLS:
+        family = 'torrent'
+    else:
+        return _UNKNOWN
+
+    return _PREFERRED if family == preference else _OTHER
+
+
+def sort_by_protocol_preference(items, preference, get_protocol):
+    """Stable-sort `items` so the preferred protocol comes first.
+
+    `preference` is 'both' | 'nzb' | 'torrent'; anything else (including None,
+    as a config read can yield before defaults are applied) is treated as no
+    preference and the incoming order is returned unchanged.
+
+    `get_protocol` maps an item to its protocol string — the two call sites
+    hold it at different key paths.
+    """
+
+    if preference not in ('nzb', 'torrent'):
+        return list(items)
+
+    return sorted(items, key = lambda item: protocol_rank(get_protocol(item), preference))

--- a/couchpotato/core/media/_base/searcher/__init__.py
+++ b/couchpotato/core/media/_base/searcher/__init__.py
@@ -17,7 +17,7 @@ config = [{
                 {
                     'name': 'preferred_method',
                     'label': 'Preferred download source',
-                    'description': 'Prefer this source when both have acceptable releases. Falls back to the other if nothing suitable is found.',
+                    'description': 'Prefer this source when both have acceptable releases. Falls back to the other if no acceptable release of this type is found.',
                     'default': 'both',
                     'type': 'dropdown',
                     'values': [('No preference', 'both'), ('Usenet (NZB)', 'nzb'), ('Torrents', 'torrent')],

--- a/couchpotato/core/media/_base/searcher/__init__.py
+++ b/couchpotato/core/media/_base/searcher/__init__.py
@@ -16,11 +16,11 @@ config = [{
             'options': [
                 {
                     'name': 'preferred_method',
-                    'label': 'First search',
-                    'description': 'Which of the methods do you prefer',
+                    'label': 'Preferred download source',
+                    'description': 'Prefer this source when both have acceptable releases. Falls back to the other if nothing suitable is found.',
                     'default': 'both',
                     'type': 'dropdown',
-                    'values': [('usenet & torrents', 'both'), ('usenet', 'nzb'), ('torrents', 'torrent')],
+                    'values': [('No preference', 'both'), ('Usenet (NZB)', 'nzb'), ('Torrents', 'torrent')],
                 },
             ],
         }, {

--- a/couchpotato/core/media/_base/searcher/main.py
+++ b/couchpotato/core/media/_base/searcher/main.py
@@ -5,6 +5,7 @@ from couchpotato.api import addApiView
 from couchpotato.core.event import addEvent, fireEvent
 from couchpotato.core.helpers.encoding import simplifyString
 from couchpotato.core.helpers.variable import splitString, removeEmpty, removeDuplicate
+from couchpotato.core.helpers.protocol import sort_by_protocol_preference
 from couchpotato.core.logger import CPLog
 from couchpotato.core.media._base.searcher.base import SearcherBase
 
@@ -58,9 +59,11 @@ class Searcher(SearcherBase):
 
         sorted_results = sorted(results, key = lambda k: k['score'], reverse = True)
 
+        # Hard preference, applied after the score sort and relying on its
+        # stability: every release of the preferred protocol outranks the
+        # other, but nothing is excluded, so an unmatched preference falls back.
         download_preference = self.conf('preferred_method', section = 'searcher')
-        if download_preference != 'both':
-            sorted_results = sorted(sorted_results, key = lambda k: k['protocol'][:3], reverse = (download_preference == 'torrent'))
+        sorted_results = sort_by_protocol_preference(sorted_results, download_preference, lambda k: k.get('protocol'))
 
         return sorted_results
 

--- a/couchpotato/core/plugins/release/main.py
+++ b/couchpotato/core/plugins/release/main.py
@@ -10,7 +10,7 @@ from couchpotato.api import addApiView
 from couchpotato.core.event import fireEvent, addEvent
 from couchpotato.core.helpers.encoding import toUnicode, sp
 from couchpotato.core.helpers.protocol import sort_by_protocol_preference
-from couchpotato.core.helpers.variable import getTitle, tryInt
+from couchpotato.core.helpers.variable import getTitle, tryFloat, tryInt
 from couchpotato.core.logger import CPLog
 from couchpotato.core.plugins.base import Plugin
 from couchpotato.core.media_lock import media_lock
@@ -672,7 +672,10 @@ class Release(Plugin):
             except Exception:
                 log.debug('Skipping unreadable release %s: %s', r.get('_id', '?'), traceback.format_exc())
 
-        releases = sorted(releases, key = lambda k: tryInt((k.get('info') or {}).get('score', 0)), reverse = True)
+        # tryFloat, not tryInt: scores are floats (score/main.py adds
+        # seeders * 100 / 15), so truncating would tie releases whose scores
+        # differ only in the fraction and lose the real ranking.
+        releases = sorted(releases, key = lambda k: tryFloat((k.get('info') or {}).get('score', 0)), reverse = True)
 
         # Sort based on the preferred download source. Same helper as
         # Searcher.search(), so the list the user sees is ordered the same way

--- a/couchpotato/core/plugins/release/main.py
+++ b/couchpotato/core/plugins/release/main.py
@@ -672,7 +672,7 @@ class Release(Plugin):
             except Exception:
                 log.debug('Skipping unreadable release %s: %s', r.get('_id', '?'), traceback.format_exc())
 
-        releases = sorted(releases, key = lambda k: (k.get('info') or {}).get('score', 0), reverse = True)
+        releases = sorted(releases, key = lambda k: tryInt((k.get('info') or {}).get('score', 0)), reverse = True)
 
         # Sort based on the preferred download source. Same helper as
         # Searcher.search(), so the list the user sees is ordered the same way

--- a/couchpotato/core/plugins/release/main.py
+++ b/couchpotato/core/plugins/release/main.py
@@ -9,6 +9,7 @@ from couchpotato.core.db.sqlite_adapter import ConflictError
 from couchpotato.api import addApiView
 from couchpotato.core.event import fireEvent, addEvent
 from couchpotato.core.helpers.encoding import toUnicode, sp
+from couchpotato.core.helpers.protocol import sort_by_protocol_preference
 from couchpotato.core.helpers.variable import getTitle, tryInt
 from couchpotato.core.logger import CPLog
 from couchpotato.core.plugins.base import Plugin
@@ -671,11 +672,12 @@ class Release(Plugin):
             except Exception:
                 log.debug('Skipping unreadable release %s: %s', r.get('_id', '?'), traceback.format_exc())
 
-        releases = sorted(releases, key = lambda k: k.get('info', {}).get('score', 0), reverse = True)
+        releases = sorted(releases, key = lambda k: (k.get('info') or {}).get('score', 0), reverse = True)
 
-        # Sort based on preferred search method
+        # Sort based on the preferred download source. Same helper as
+        # Searcher.search(), so the list the user sees is ordered the same way
+        # the automatic picker orders its candidates.
         download_preference = self.conf('preferred_method', section = 'searcher')
-        if download_preference != 'both':
-            releases = sorted(releases, key = lambda k: k.get('info', {}).get('protocol', '')[:3], reverse = (download_preference == 'torrent'))
+        releases = sort_by_protocol_preference(releases, download_preference, lambda k: (k.get('info') or {}).get('protocol'))
 
         return releases or []

--- a/docs/plans/2026-07-29-preferred-download-source.md
+++ b/docs/plans/2026-07-29-preferred-download-source.md
@@ -1,0 +1,895 @@
+# Preferred Download Source (FEAT-007 Part A) Implementation Plan
+
+> **For agentic workers:** implement this plan task-by-task. Steps use checkbox
+> (`- [ ]`) syntax for tracking. TDD is mandatory (CLAUDE.md rule 1): write the
+> failing test, run it and *see it fail*, then write the minimum code to pass.
+> Commit after each task. **Do not push** — the orchestrator runs the local
+> agent review gate and pushes (CLAUDE.md rule 4).
+
+**Goal:** Make the existing `searcher.preferred_method` setting discoverable,
+consistent across its two call sites, and covered by tests — without changing
+the behaviour the owner chose (hard preference, falls back to the other source).
+
+**Architecture:** One shared pure function,
+`couchpotato/core/helpers/protocol.py::sort_by_protocol_preference`, replaces
+the two hand-rolled `protocol[:3]` sorts in `Searcher.search()` and
+`Release.forMedia()`. Ranking is explicit (preferred = 0, other known = 1,
+unknown = 2), which also fixes today's direction-dependent placement of
+unknown protocols. The config option is relabelled; its **stored values are
+unchanged**, so existing `settings.conf` files keep working.
+
+**Tech Stack:** Python 3.10+, pytest, ruff (line-length 160), FastAPI/Jinja UI.
+Gate: `make verify` (or `PYTHON="$(pwd)/.venv/bin/python" make verify` locally
+— system `python3` lacks the deps).
+
+**Spec:** `specs/FEAT-007-preferred-source-and-release-list-controls.md` (Part A
+and acceptance criteria A1–A10). Part B (release list sort/filter) is a
+separate plan, written after this lands.
+
+---
+
+## File Structure
+
+| File | Responsibility | Status |
+|---|---|---|
+| `couchpotato/core/helpers/protocol.py` | Rank a protocol against a preference; stable-sort a list by that rank. No imports from the plugin tree. | Create |
+| `couchpotato/core/media/_base/searcher/main.py:59-65` | Call the helper instead of its own sort (decides what gets downloaded). | Modify |
+| `couchpotato/core/plugins/release/main.py:674-681` | Call the helper instead of its own sort (orders the list the UI shows). | Modify |
+| `couchpotato/core/media/_base/searcher/__init__.py:16-25` | Config option label, description, value labels. | Modify |
+| `tests/unit/test_protocol_preference.py` | Helper unit tests + both call sites + fallback + config. | Create |
+
+`couchpotato/core/helpers/` is the right home: both call sites already import
+from `couchpotato.core.helpers.variable`, so it adds no import cycle. Putting
+it under the `searcher` package would make `release/main.py` import a package
+whose `__init__.py` pulls in `Searcher` and the plugin base.
+
+---
+
+## Task 1: The shared ranking helper
+
+**Files:**
+- Create: `couchpotato/core/helpers/protocol.py`
+- Test: `tests/unit/test_protocol_preference.py`
+
+Covers A1–A6, A8.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/test_protocol_preference.py`:
+
+```python
+"""The download-source preference (`searcher.preferred_method`) ordering.
+
+FEAT-007 Part A. The preference is a HARD preference that FALLS BACK: every
+release of the preferred protocol outranks every release of the other one,
+but when the preferred protocol has nothing usable the other is still used.
+
+Before this change the ordering was hand-rolled twice — in `Searcher.search()`
+and in `Release.forMedia()` — using a `protocol[:3]` string trick against two
+different key paths, with no test coverage at all. The two copies disagreed on
+unknown protocols: sorting `''` ascending floated unknown-protocol releases
+ABOVE nzb when preferring usenet, and buried them when preferring torrents.
+"""
+
+import pytest
+
+from couchpotato.core.helpers.protocol import sort_by_protocol_preference
+
+
+def _items(*protocols):
+    """Items in descending-score order, as both call sites hand them over.
+
+    `pos` records the incoming order so stability can be asserted.
+    """
+    return [{'pos': i, 'protocol': p} for i, p in enumerate(protocols)]
+
+
+def _get(item):
+    return item.get('protocol')
+
+
+def _protocols(items):
+    return [item['protocol'] for item in items]
+
+
+class TestSortByProtocolPreference:
+
+    def test_nzb_preference_puts_every_nzb_before_every_torrent(self):
+        """A1: hard preference — even a last-place nzb beats a first-place torrent."""
+        items = _items('torrent', 'torrent', 'nzb', 'torrent')
+        result = sort_by_protocol_preference(items, 'nzb', _get)
+        assert _protocols(result) == ['nzb', 'torrent', 'torrent', 'torrent']
+
+    def test_torrent_preference_puts_every_torrent_before_every_nzb(self):
+        """A2: the mirror image."""
+        items = _items('nzb', 'nzb', 'torrent', 'nzb')
+        result = sort_by_protocol_preference(items, 'torrent', _get)
+        assert _protocols(result) == ['torrent', 'nzb', 'nzb', 'nzb']
+
+    def test_both_leaves_the_incoming_order_untouched(self):
+        """A3: 'both' means score order only — the caller already sorted by score."""
+        items = _items('torrent', 'nzb', 'torrent', 'nzb')
+        result = sort_by_protocol_preference(items, 'both', _get)
+        assert _protocols(result) == ['torrent', 'nzb', 'torrent', 'nzb']
+        assert [i['pos'] for i in result] == [0, 1, 2, 3]
+
+    def test_score_order_is_preserved_within_each_protocol_group(self):
+        """A4: the sort must be stable — callers sort by score first, then by protocol.
+
+        An unstable sort here would silently scramble score ranking within a
+        group, which is the whole basis for picking a release.
+        """
+        items = _items('torrent', 'nzb', 'torrent', 'nzb', 'torrent')
+        result = sort_by_protocol_preference(items, 'nzb', _get)
+        assert [i['pos'] for i in result] == [1, 3, 0, 2, 4]
+
+    def test_torrent_magnet_ranks_with_torrent(self):
+        """A5: a magnet link is a torrent as far as the preference is concerned."""
+        items = _items('torrent_magnet', 'nzb')
+        assert _protocols(sort_by_protocol_preference(items, 'nzb', _get)) == ['nzb', 'torrent_magnet']
+        assert _protocols(sort_by_protocol_preference(items, 'torrent', _get)) == ['torrent_magnet', 'nzb']
+
+    def test_unknown_protocol_sorts_last_when_preferring_nzb(self):
+        """A6: the bug being fixed — `''` used to sort BEFORE 'nzb' ascending."""
+        items = _items('mystery', 'torrent', 'nzb')
+        result = sort_by_protocol_preference(items, 'nzb', _get)
+        assert _protocols(result) == ['nzb', 'torrent', 'mystery']
+
+    def test_unknown_protocol_sorts_last_when_preferring_torrent_too(self):
+        """A6: unknown is last in BOTH directions, not direction-dependent."""
+        items = _items('mystery', 'torrent', 'nzb')
+        result = sort_by_protocol_preference(items, 'torrent', _get)
+        assert _protocols(result) == ['torrent', 'nzb', 'mystery']
+
+    @pytest.mark.parametrize('bad', [None, '', '   ', 'ftp'])
+    def test_missing_or_unrecognised_protocols_are_treated_as_unknown(self, bad):
+        """A6: absent data must not outrank real data."""
+        items = _items(bad, 'nzb')
+        result = sort_by_protocol_preference(items, 'nzb', _get)
+        assert _protocols(result) == ['nzb', bad]
+
+    def test_protocol_matching_is_case_and_whitespace_insensitive(self):
+        """Provider data is not guaranteed to be normalised."""
+        items = _items('torrent', ' NZB ')
+        result = sort_by_protocol_preference(items, 'nzb', _get)
+        assert _protocols(result) == [' NZB ', 'torrent']
+
+    @pytest.mark.parametrize('preference', ['both', 'nzb', 'torrent', None, '', 'nonsense'])
+    def test_empty_and_single_item_lists_are_safe(self, preference):
+        """A8: no crash on the degenerate cases, for any preference value."""
+        assert sort_by_protocol_preference([], preference, _get) == []
+        single = _items('nzb')
+        assert _protocols(sort_by_protocol_preference(single, preference, _get)) == ['nzb']
+
+    @pytest.mark.parametrize('preference', [None, '', 'nonsense'])
+    def test_an_unrecognised_preference_behaves_as_no_preference(self, preference):
+        """A config read can return None/'' before defaults are applied.
+
+        The safe reading of "I don't understand this setting" is "don't
+        reorder", never "reorder arbitrarily".
+        """
+        items = _items('torrent', 'nzb', 'torrent')
+        result = sort_by_protocol_preference(items, preference, _get)
+        assert _protocols(result) == ['torrent', 'nzb', 'torrent']
+
+    def test_the_input_list_is_not_mutated(self):
+        """Callers reuse their list; sorting must return a new one."""
+        items = _items('torrent', 'nzb')
+        sort_by_protocol_preference(items, 'nzb', _get)
+        assert _protocols(items) == ['torrent', 'nzb']
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_protocol_preference.py -v
+```
+
+Expected: **collection error** —
+`ModuleNotFoundError: No module named 'couchpotato.core.helpers.protocol'`.
+That is the correct failure: the module does not exist yet.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `couchpotato/core/helpers/protocol.py`:
+
+```python
+"""Ordering releases by the user's preferred download source.
+
+`searcher.preferred_method` ('both' | 'nzb' | 'torrent') is a HARD preference
+that FALLS BACK: every release of the preferred protocol outranks every release
+of the other one, but nothing is excluded, so when the preferred protocol has
+no usable release the other one is still downloaded.
+
+Both call sites — `Searcher.search()` (what gets downloaded) and
+`Release.forMedia()` (what the UI lists) — sort by score first and then apply
+this, relying on a stable sort to keep score order inside each protocol group.
+"""
+
+NO_PREFERENCE = 'both'
+
+_NZB_PROTOCOLS = ('nzb',)
+_TORRENT_PROTOCOLS = ('torrent', 'torrent_magnet')
+
+#: Ranks, low sorts first.
+_PREFERRED = 0
+_OTHER = 1
+_UNKNOWN = 2
+
+
+def protocol_rank(protocol, preference):
+    """Rank `protocol` against `preference`.
+
+    Returns 0 for the preferred family, 1 for the other known family, and 2 for
+    anything unrecognised. Unknown ranks last in BOTH directions: a release
+    whose protocol we cannot identify must never outrank one we can, whichever
+    way the preference points.
+    """
+
+    normalised = (protocol or '').strip().lower()
+
+    if normalised in _NZB_PROTOCOLS:
+        family = 'nzb'
+    elif normalised in _TORRENT_PROTOCOLS:
+        family = 'torrent'
+    else:
+        return _UNKNOWN
+
+    return _PREFERRED if family == preference else _OTHER
+
+
+def sort_by_protocol_preference(items, preference, get_protocol):
+    """Stable-sort `items` so the preferred protocol comes first.
+
+    `preference` is 'both' | 'nzb' | 'torrent'; anything else (including None,
+    as a config read can yield before defaults are applied) is treated as no
+    preference and the incoming order is returned unchanged.
+
+    `get_protocol` maps an item to its protocol string — the two call sites
+    hold it at different key paths.
+    """
+
+    if preference not in ('nzb', 'torrent'):
+        return list(items)
+
+    return sorted(items, key = lambda item: protocol_rank(get_protocol(item), preference))
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_protocol_preference.py -v
+```
+
+Expected: **all PASS** (23 tests, counting parametrised cases).
+
+- [ ] **Step 5: Lint**
+
+```bash
+.venv/bin/python -m ruff check couchpotato/core/helpers/protocol.py tests/unit/test_protocol_preference.py
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add couchpotato/core/helpers/protocol.py tests/unit/test_protocol_preference.py
+git commit -m "feat: shared protocol-preference ordering helper (FEAT-007 A1-A6, A8)"
+```
+
+---
+
+## Task 2: Wire `Searcher.search()` to the helper
+
+This is the call site that decides **what gets downloaded** —
+`release.try_download_result` walks the list it returns in order.
+
+**Files:**
+- Modify: `couchpotato/core/media/_base/searcher/main.py:59-65`
+- Test: `tests/unit/test_protocol_preference.py` (append)
+
+Covers A1, A2, A7.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_protocol_preference.py`:
+
+```python
+class TestSearcherSearchOrdering:
+    """`Searcher.search()` — the order here decides what gets downloaded."""
+
+    @pytest.fixture
+    def searcher(self):
+        # __init__ registers events and API views; bypass it.
+        from couchpotato.core.media._base.searcher.main import Searcher
+        return object.__new__(Searcher)
+
+    def _search(self, searcher, preference, results):
+        """Drive search() with one provider event per protocol, as in production."""
+        from unittest.mock import patch
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'provider.search.nzb.movie':
+                return [r for r in results if r['protocol'] == 'nzb']
+            if event == 'provider.search.torrent.movie':
+                return [r for r in results if r['protocol'] != 'nzb']
+            return []
+
+        with patch('couchpotato.core.media._base.searcher.main.fireEvent',
+                   side_effect = fake_fire_event), \
+                patch.object(searcher, 'conf', return_value = preference):
+            return searcher.search(['nzb', 'torrent'], {'type': 'movie'}, {'identifier': '1080p'})
+
+    def test_nzb_preference_orders_nzb_first_regardless_of_score(self, searcher):
+        """A1: a 900-seeder torrent scoring 3400 still loses to a 210-score nzb."""
+        results = [
+            {'name': 'big.torrent', 'protocol': 'torrent', 'score': 3400},
+            {'name': 'good.nzb', 'protocol': 'nzb', 'score': 210},
+        ]
+        ordered = self._search(searcher, 'nzb', results)
+        assert [r['name'] for r in ordered] == ['good.nzb', 'big.torrent']
+
+    def test_torrent_preference_orders_torrents_first(self, searcher):
+        """A2."""
+        results = [
+            {'name': 'big.nzb', 'protocol': 'nzb', 'score': 3400},
+            {'name': 'ok.torrent', 'protocol': 'torrent', 'score': 210},
+        ]
+        ordered = self._search(searcher, 'torrent', results)
+        assert [r['name'] for r in ordered] == ['ok.torrent', 'big.nzb']
+
+    def test_both_preserves_pure_score_order(self, searcher):
+        """A3."""
+        results = [
+            {'name': 'mid.nzb', 'protocol': 'nzb', 'score': 500},
+            {'name': 'big.torrent', 'protocol': 'torrent', 'score': 3400},
+            {'name': 'small.torrent', 'protocol': 'torrent', 'score': 10},
+        ]
+        ordered = self._search(searcher, 'both', results)
+        assert [r['name'] for r in ordered] == ['big.torrent', 'mid.nzb', 'small.torrent']
+
+    def test_score_order_survives_inside_the_preferred_group(self, searcher):
+        """A4 at the call site, not just in the helper."""
+        results = [
+            {'name': 'best.nzb', 'protocol': 'nzb', 'score': 900},
+            {'name': 'worst.nzb', 'protocol': 'nzb', 'score': 5},
+            {'name': 'mid.nzb', 'protocol': 'nzb', 'score': 400},
+            {'name': 'a.torrent', 'protocol': 'torrent', 'score': 5000},
+        ]
+        ordered = self._search(searcher, 'nzb', results)
+        assert [r['name'] for r in ordered] == ['best.nzb', 'mid.nzb', 'worst.nzb', 'a.torrent']
+
+    def test_search_uses_the_shared_helper(self, searcher):
+        """A7: no second hand-rolled copy of this logic may survive."""
+        from unittest.mock import patch
+
+        results = [{'name': 'x.nzb', 'protocol': 'nzb', 'score': 1}]
+        with patch('couchpotato.core.media._base.searcher.main.sort_by_protocol_preference',
+                   return_value = results) as helper, \
+                patch('couchpotato.core.media._base.searcher.main.fireEvent',
+                      side_effect = lambda event, *a, **k: results if event.endswith('.nzb.movie') else []), \
+                patch.object(searcher, 'conf', return_value = 'nzb'):
+            searcher.search(['nzb'], {'type': 'movie'}, {'identifier': '1080p'})
+
+        assert helper.called, 'Searcher.search must delegate to sort_by_protocol_preference'
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_protocol_preference.py::TestSearcherSearchOrdering -v
+```
+
+Expected: `test_search_uses_the_shared_helper` FAILS with
+`AttributeError: <module 'couchpotato.core.media._base.searcher.main'> does not have the attribute 'sort_by_protocol_preference'`.
+The ordering tests may already pass — the existing `[:3]` sort happens to be
+correct for these inputs. That is expected and fine: they are being added as
+regression cover for behaviour the refactor must not change.
+
+- [ ] **Step 3: Make the change**
+
+In `couchpotato/core/media/_base/searcher/main.py`, add to the imports (after
+the existing `couchpotato.core.helpers.variable` import on line 7):
+
+```python
+from couchpotato.core.helpers.protocol import sort_by_protocol_preference
+```
+
+Then replace lines 59-65 — currently:
+
+```python
+        sorted_results = sorted(results, key = lambda k: k['score'], reverse = True)
+
+        download_preference = self.conf('preferred_method', section = 'searcher')
+        if download_preference != 'both':
+            sorted_results = sorted(sorted_results, key = lambda k: k['protocol'][:3], reverse = (download_preference == 'torrent'))
+
+        return sorted_results
+```
+
+with:
+
+```python
+        sorted_results = sorted(results, key = lambda k: k['score'], reverse = True)
+
+        # Hard preference, applied after the score sort and relying on its
+        # stability: every release of the preferred protocol outranks the
+        # other, but nothing is excluded, so an unmatched preference falls back.
+        download_preference = self.conf('preferred_method', section = 'searcher')
+        sorted_results = sort_by_protocol_preference(sorted_results, download_preference, lambda k: k.get('protocol'))
+
+        return sorted_results
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_protocol_preference.py -v
+```
+
+Expected: **all PASS**.
+
+- [ ] **Step 5: Run the searcher's existing tests for regressions**
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_searcher_matching.py tests/unit/test_movie_searcher_eta.py tests/unit/test_search_releases_list_only.py -q
+```
+
+Expected: all pass, no change in counts.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add couchpotato/core/media/_base/searcher/main.py tests/unit/test_protocol_preference.py
+git commit -m "refactor: Searcher.search uses the shared preference helper (FEAT-007 A7)"
+```
+
+---
+
+## Task 3: Wire `Release.forMedia()` to the helper
+
+This is the call site that orders **what the UI shows**, and the one carrying
+the unknown-protocol bug.
+
+**Files:**
+- Modify: `couchpotato/core/plugins/release/main.py:674-681`
+- Test: `tests/unit/test_protocol_preference.py` (append)
+
+Covers A1, A2, A6, A7.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_protocol_preference.py`:
+
+```python
+class TestReleaseForMediaOrdering:
+    """`Release.forMedia()` — the order the movie detail page renders."""
+
+    @pytest.fixture
+    def plugin(self):
+        from couchpotato.core.plugins.release.main import Release
+        return object.__new__(Release)
+
+    def _for_media(self, plugin, preference, docs):
+        from unittest.mock import MagicMock, patch
+
+        db = MagicMock()
+        db.get_many.return_value = [{'_id': d['_id']} for d in docs]
+        db.get.side_effect = lambda _index, _id: next(d for d in docs if d['_id'] == _id)
+
+        with patch('couchpotato.core.plugins.release.main.get_db', return_value = db), \
+                patch.object(plugin, 'conf', return_value = preference):
+            return plugin.forMedia('movie-1')
+
+    @staticmethod
+    def _doc(_id, protocol, score):
+        return {'_id': _id, 'info': {'protocol': protocol, 'score': score}}
+
+    def test_nzb_preference_lists_nzb_first(self, plugin):
+        """A1 on the display path."""
+        docs = [self._doc('t1', 'torrent', 3400), self._doc('n1', 'nzb', 210)]
+        assert [r['_id'] for r in self._for_media(plugin, 'nzb', docs)] == ['n1', 't1']
+
+    def test_torrent_preference_lists_torrents_first(self, plugin):
+        """A2 on the display path."""
+        docs = [self._doc('n1', 'nzb', 3400), self._doc('t1', 'torrent', 210)]
+        assert [r['_id'] for r in self._for_media(plugin, 'torrent', docs)] == ['t1', 'n1']
+
+    def test_both_lists_in_score_order(self, plugin):
+        """A3 on the display path."""
+        docs = [self._doc('n1', 'nzb', 500), self._doc('t1', 'torrent', 3400)]
+        assert [r['_id'] for r in self._for_media(plugin, 'both', docs)] == ['t1', 'n1']
+
+    def test_a_release_with_no_protocol_is_listed_last_not_first(self, plugin):
+        """A6: THE BUG. `''[:3]` sorted ascending put this at the TOP under 'nzb'."""
+        docs = [
+            self._doc('unknown', '', 999),
+            self._doc('t1', 'torrent', 500),
+            self._doc('n1', 'nzb', 100),
+        ]
+        assert [r['_id'] for r in self._for_media(plugin, 'nzb', docs)] == ['n1', 't1', 'unknown']
+
+    def test_a_release_with_no_info_block_does_not_crash_the_list(self, plugin):
+        """Defensive: a partially-written document must not break the page."""
+        docs = [{'_id': 'broken'}, self._doc('n1', 'nzb', 100)]
+        assert [r['_id'] for r in self._for_media(plugin, 'nzb', docs)] == ['n1', 'broken']
+
+    def test_for_media_uses_the_shared_helper(self, plugin):
+        """A7: the second copy of the logic must be gone."""
+        from unittest.mock import MagicMock, patch
+
+        docs = [self._doc('n1', 'nzb', 100)]
+        db = MagicMock()
+        db.get_many.return_value = [{'_id': 'n1'}]
+        db.get.side_effect = lambda _index, _id: docs[0]
+
+        with patch('couchpotato.core.plugins.release.main.sort_by_protocol_preference',
+                   return_value = docs) as helper, \
+                patch('couchpotato.core.plugins.release.main.get_db', return_value = db), \
+                patch.object(plugin, 'conf', return_value = 'nzb'):
+            plugin.forMedia('movie-1')
+
+        assert helper.called, 'Release.forMedia must delegate to sort_by_protocol_preference'
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_protocol_preference.py::TestReleaseForMediaOrdering -v
+```
+
+Expected: **two failures** —
+`test_a_release_with_no_protocol_is_listed_last_not_first` fails with
+`['unknown', 'n1', 't1'] != ['n1', 't1', 'unknown']` (the bug, now pinned), and
+`test_for_media_uses_the_shared_helper` fails with `AttributeError` on the
+patch target.
+
+- [ ] **Step 3: Make the change**
+
+In `couchpotato/core/plugins/release/main.py`, add to the imports:
+
+```python
+from couchpotato.core.helpers.protocol import sort_by_protocol_preference
+```
+
+Then replace lines 674-681 — currently:
+
+```python
+        releases = sorted(releases, key = lambda k: k.get('info', {}).get('score', 0), reverse = True)
+
+        # Sort based on preferred search method
+        download_preference = self.conf('preferred_method', section = 'searcher')
+        if download_preference != 'both':
+            releases = sorted(releases, key = lambda k: k.get('info', {}).get('protocol', '')[:3], reverse = (download_preference == 'torrent'))
+
+        return releases or []
+```
+
+with:
+
+```python
+        releases = sorted(releases, key = lambda k: (k.get('info') or {}).get('score', 0), reverse = True)
+
+        # Sort based on the preferred download source. Same helper as
+        # Searcher.search(), so the list the user sees is ordered the same way
+        # the automatic picker orders its candidates.
+        download_preference = self.conf('preferred_method', section = 'searcher')
+        releases = sort_by_protocol_preference(releases, download_preference, lambda k: (k.get('info') or {}).get('protocol'))
+
+        return releases or []
+```
+
+Note `(k.get('info') or {})` rather than `k.get('info', {})`: a document with
+an explicit `'info': None` would make the original raise `AttributeError`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_protocol_preference.py -v
+```
+
+Expected: **all PASS**.
+
+- [ ] **Step 5: Run the release plugin's existing tests for regressions**
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_release_info_population.py tests/unit/test_release_add_lookup_narrowing.py tests/unit/test_release_create_from_search_cas.py tests/unit/test_release_update_status_cas.py -q
+```
+
+Expected: all pass, no change in counts.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add couchpotato/core/plugins/release/main.py tests/unit/test_protocol_preference.py
+git commit -m "fix: unknown-protocol releases sort last in both directions (FEAT-007 A6, A7)"
+```
+
+---
+
+## Task 4: Prove the fallback (A10)
+
+The spec asserts fallback works today, from reading `tryDownloadResult`. It is
+untested, so **verify it rather than assume it**. If these tests fail, the
+fallback is broken and that is a bug fix belonging to this PR — report it
+before changing production code.
+
+**Files:**
+- Test: `tests/unit/test_protocol_preference.py` (append)
+- Modify (only if the tests fail): `couchpotato/core/plugins/release/main.py:418-468`
+
+Covers A10.
+
+- [ ] **Step 1: Write the test**
+
+Append to `tests/unit/test_protocol_preference.py`:
+
+```python
+class TestFallbackToTheOtherProtocol:
+    """A10: the preference orders candidates; it never excludes them.
+
+    `tryDownloadResult` walks the preference-ordered list and takes the first
+    release that passes the filters — so when the preferred protocol has
+    nothing usable, the other one is still downloaded. That is the designed
+    behaviour ("fall back to torrent"), and it is what makes the preference
+    safe to turn on.
+    """
+
+    @pytest.fixture
+    def plugin(self):
+        from couchpotato.core.plugins.release.main import Release
+        return object.__new__(Release)
+
+    def _try(self, plugin, results, minimum_score = 1):
+        from unittest.mock import MagicMock, patch
+
+        downloaded = []
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'release.download':
+                downloaded.append(kwargs.get('data', {}).get('name'))
+                return True
+            return None
+
+        env = MagicMock()
+        env.setting.return_value = 1  # torrent.minimum_seeders
+
+        with patch('couchpotato.core.plugins.release.main.fireEvent', side_effect = fake_fire_event), \
+                patch('couchpotato.core.plugins.release.main.Env', env):
+            plugin.tryDownloadResult(results, {'_id': 'movie-1'}, {'minimum_score': minimum_score, 'index': 0})
+
+        return downloaded
+
+    def test_a_torrent_is_downloaded_when_no_nzb_was_found(self, plugin):
+        """Preference nzb, but the search returned torrents only."""
+        results = [
+            {'name': 'only.torrent', 'protocol': 'torrent', 'score': 100, 'size': 4000, 'seeders': 20, 'age': 5},
+        ]
+        assert self._try(plugin, results) == ['only.torrent']
+
+    def test_a_torrent_is_downloaded_when_the_preferred_nzb_fails_the_filters(self, plugin):
+        """The real fallback path: an nzb ranked first but rejected on score.
+
+        The list arrives nzb-first (the preference already applied); the nzb is
+        filtered out for scoring below `minimum_score`, and the torrent behind
+        it is taken.
+        """
+        results = [
+            {'name': 'weak.nzb', 'protocol': 'nzb', 'score': 2, 'size': 4000, 'age': 5},
+            {'name': 'fine.torrent', 'protocol': 'torrent', 'score': 800, 'size': 4000, 'seeders': 20, 'age': 5},
+        ]
+        assert self._try(plugin, results, minimum_score = 500) == ['fine.torrent']
+
+    def test_the_preferred_release_still_wins_when_it_passes(self, plugin):
+        """The complement — fallback must not fire when it should not."""
+        results = [
+            {'name': 'good.nzb', 'protocol': 'nzb', 'score': 800, 'size': 4000, 'age': 5},
+            {'name': 'big.torrent', 'protocol': 'torrent', 'score': 5000, 'size': 4000, 'seeders': 900, 'age': 5},
+        ]
+        assert self._try(plugin, results) == ['good.nzb']
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_protocol_preference.py::TestFallbackToTheOtherProtocol -v
+```
+
+Expected: **all PASS** with no production change — these pin existing
+behaviour. **If any fail, stop and report it**: the spec's A10 assumption is
+wrong, fallback is broken, and the fix needs deciding before proceeding.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/test_protocol_preference.py
+git commit -m "test: pin fallback to the non-preferred protocol (FEAT-007 A10)"
+```
+
+---
+
+## Task 5: Relabel the setting
+
+**Files:**
+- Modify: `couchpotato/core/media/_base/searcher/__init__.py:16-25`
+- Test: `tests/unit/test_protocol_preference.py` (append)
+
+Covers A9.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_protocol_preference.py`:
+
+```python
+class TestPreferredMethodConfigOption:
+    """A9: named for what it does, without changing what it stores."""
+
+    @staticmethod
+    def _option():
+        from couchpotato.core.media._base.searcher import config
+        for section in config:
+            if section['name'] != 'searcher':
+                continue
+            for group in section['groups']:
+                for option in group['options']:
+                    if option['name'] == 'preferred_method':
+                        return option
+        raise AssertionError('preferred_method option not found in searcher config')
+
+    def test_the_label_says_what_the_setting_does(self):
+        option = self._option()
+        assert option['label'] == 'Preferred download source'
+
+    def test_the_description_explains_the_hard_preference_and_the_fallback(self):
+        description = self._option()['description'].lower()
+        assert 'prefer' in description
+        assert 'falls back' in description
+
+    def test_the_value_labels_are_plain_english(self):
+        labels = [label for label, _stored in self._option()['values']]
+        assert labels == ['No preference', 'Usenet (NZB)', 'Torrents']
+
+    def test_the_stored_values_are_unchanged(self):
+        """Backwards compatibility: existing settings.conf files must keep working.
+
+        Only the display strings change. `preferred_method = nzb` written by an
+        older build must still be read as 'nzb'.
+        """
+        stored = [value for _label, value in self._option()['values']]
+        assert stored == ['both', 'nzb', 'torrent']
+        assert self._option()['default'] == 'both'
+        assert self._option()['type'] == 'dropdown'
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_protocol_preference.py::TestPreferredMethodConfigOption -v
+```
+
+Expected: three FAIL (`'First search' != 'Preferred download source'`, the
+description assertion, and the value labels);
+`test_the_stored_values_are_unchanged` PASSES already — that is the point of
+it, it is the guard against the refactor breaking existing configs.
+
+- [ ] **Step 3: Make the change**
+
+In `couchpotato/core/media/_base/searcher/__init__.py`, replace lines 17-24:
+
+```python
+                {
+                    'name': 'preferred_method',
+                    'label': 'First search',
+                    'description': 'Which of the methods do you prefer',
+                    'default': 'both',
+                    'type': 'dropdown',
+                    'values': [('usenet & torrents', 'both'), ('usenet', 'nzb'), ('torrents', 'torrent')],
+                },
+```
+
+with:
+
+```python
+                {
+                    'name': 'preferred_method',
+                    'label': 'Preferred download source',
+                    'description': 'Prefer this source when both have acceptable releases. Falls back to the other if nothing suitable is found.',
+                    'default': 'both',
+                    'type': 'dropdown',
+                    'values': [('No preference', 'both'), ('Usenet (NZB)', 'nzb'), ('Torrents', 'torrent')],
+                },
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_protocol_preference.py -v
+```
+
+Expected: **all PASS**.
+
+- [ ] **Step 5: Check no test or template hard-codes the old label**
+
+```bash
+grep -rn "First search" tests/ couchpotato/ specs/ docs/ 2>/dev/null
+```
+
+Expected: **no hits in `tests/` or `couchpotato/`**. The only known reference is
+`QA/QA_SESSION_2026-02-16.md`, a point-in-time session log — leave it alone. If
+anything in `tests/e2e/settings.spec.ts` asserts on the old label, update it
+here (CLAUDE.md rule 5).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add couchpotato/core/media/_base/searcher/__init__.py tests/unit/test_protocol_preference.py
+git commit -m "feat: name the download-source setting for what it does (FEAT-007 A9)"
+```
+
+---
+
+## Task 6: Full gate and hand-off
+
+- [ ] **Step 1: Run the full local gate**
+
+```bash
+PYTHON="$(pwd)/.venv/bin/python" make verify
+```
+
+Expected: ruff clean, Python unit suite green (previous baseline **1465
+passed**, plus the new tests), UI unit tests green.
+
+If the E2E stage dies with `[WebServer] /bin/sh: python: command not found`
+(exit 127), that is a known local-environment quirk, not a failure. Start the
+server yourself with a **fresh** data dir and run Playwright against it:
+
+```bash
+rm -rf .e2e-feat007-data
+.venv/bin/python CouchPotato.py --data_dir=.e2e-feat007-data --console_log &
+CP_TEST_URL=http://localhost:5050 npx playwright test --project=chromium --workers=1
+```
+
+Two Navigation tests in `tests/e2e/interactions.e2e.spec.ts` are known-flaky in
+the full single-worker run and pass in isolation; re-run any failure with
+`-g "<test name>"` before treating it as real.
+
+- [ ] **Step 2: Confirm the acceptance criteria**
+
+Walk `specs/FEAT-007-preferred-source-and-release-list-controls.md` A1–A10 and
+tick each box in the spec, citing the test that covers it. A10 is a
+verification, not an implementation — record what you found.
+
+- [ ] **Step 3: Commit the ticked spec**
+
+```bash
+git add specs/FEAT-007-preferred-source-and-release-list-controls.md
+git commit -m "docs: tick FEAT-007 Part A acceptance criteria"
+```
+
+- [ ] **Step 4: STOP**
+
+Do **not** push. Report back with: the test count delta, the A10 finding
+(fallback confirmed or broken), and anything in the spec that turned out to be
+wrong. The orchestrator runs the local agent review gate (≥2 independent
+`general-purpose` reviewers on the branch diff) and pushes only once it is
+clean.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** A1 (T1, T2, T3), A2 (T1, T2, T3), A3 (T1, T2, T3),
+  A4 (T1, T2), A5 (T1), A6 (T1, T3), A7 (T2, T3), A8 (T1), A9 (T5),
+  A10 (T4). All ten covered.
+- **Not in this plan, by design:** every Part B criterion (B1–B14) — separate
+  plan once this lands. The seeder score bias is out of scope per the spec.
+- **Naming is consistent** across tasks: `sort_by_protocol_preference` and
+  `protocol_rank` are defined in Task 1 and used under those exact names in
+  Tasks 2 and 3, patched at
+  `couchpotato.core.media._base.searcher.main.sort_by_protocol_preference` and
+  `couchpotato.core.plugins.release.main.sort_by_protocol_preference` — the
+  module-level names created by the `from ... import ...` lines those tasks add.
+- **Expected-failure honesty:** Tasks 2 and 4 note upfront that some tests pass
+  before the change. They are regression cover, and the plan says so rather
+  than pretending to a red-green cycle that will not happen.

--- a/specs/FEAT-007-preferred-source-and-release-list-controls.md
+++ b/specs/FEAT-007-preferred-source-and-release-list-controls.md
@@ -104,15 +104,19 @@ choosing between releases by hand are invisible.
   sort LAST, where under the old direction-dependent behaviour they sorted
   FIRST for one preference direction. Verified side by side: master orders
   `['done-no-info', 'nzb', 'torrent', 'magnet']` under an nzb preference,
-  this change orders `['nzb', 'torrent', 'magnet', 'done-no-info']` (identical
-  to a torrent preference, which is the point -- direction-independent). This
-  has a knock-on: `movie_detail.html` picks `completed_releases[0]` for the
-  header's downloaded quality/status, so for a movie with both a
-  scanner-created `done` release and another completed release carrying
-  protocol info, which one the header shows can flip. This is accepted as a
-  correct consequence of fixing the direction-dependent bug, not a new defect,
-  and is pinned by a test (see Acceptance criteria A10 note and
-  `tests/unit/test_protocol_preference.py`).
+  this change orders `['nzb', 'torrent', 'magnet', 'done-no-info']`. The point
+  is that the unknown release now sorts LAST under both preference
+  directions, rather than first under one of them. This has a knock-on: BOTH
+  `couchpotato/ui/templates/partials/movie_detail.html:20-23` and
+  `couchpotato/ui/templates/partials/movie_cards.html:12-16` pick
+  `completed_releases[0]` for the downloaded quality/status they display (the
+  detail header and the poster-grid badge respectively), so for a movie with
+  both a scanner-created `done` release and another completed release carrying
+  protocol info, which one they show can flip. Those two templates are the
+  only order-sensitive consumers of `release.for_media`; every other caller
+  iterates the whole list. This is accepted as a correct consequence of fixing
+  the direction-dependent bug, not a new defect, and is pinned by a test (see
+  Acceptance criteria A10 note and `tests/unit/test_protocol_preference.py`).
 - **Server-side sort/filter over htmx**, not client-side Alpine. It keeps a
   single Jinja rendering path and fits the htmx-first architecture; the cost is
   a round-trip per interaction, which is acceptable for a LAN app.
@@ -183,7 +187,9 @@ each protocol group.
 - [x] A4: within a protocol group, score-descending order is preserved (sort
       stability) for all three preference values.
       (`test_score_order_is_preserved_within_each_protocol_group`,
-      `test_score_order_survives_inside_the_preferred_group`)
+      `test_score_order_is_preserved_within_the_group_under_a_torrent_preference`,
+      `test_score_order_survives_inside_the_preferred_group`,
+      `test_both_leaves_the_incoming_order_untouched`)
 - [x] A5: `torrent_magnet` is ranked with `torrent`, not as unknown.
       (`test_torrent_magnet_ranks_with_torrent`)
 - [x] A6: a release with a missing, empty or unrecognised protocol sorts
@@ -198,11 +204,15 @@ each protocol group.
       `call_args`, not just `.called`)
 - [x] A8: an empty list, and a list with a single item, are handled without
       error for every preference value. (`test_empty_and_single_item_lists_are_safe`)
-- [x] A9: the config option renders in Settings → Searcher → Basics with the
-      new label and value labels, and an existing `settings.conf` containing
-      `preferred_method = nzb` is still read correctly (stored values unchanged).
-      (`TestPreferredMethodConfigOption`; real config-file read verified end to
-      end by `TestPreferredMethodRealSettingsPlumbing::test_preferred_method_is_read_through_the_real_settings_and_env_plumbing`)
+- [x] A9: the config option is defined with the new label and value labels, and
+      an existing `settings.conf` containing `preferred_method = nzb` is still
+      read correctly (stored values unchanged).
+      (`TestPreferredMethodConfigOption` asserts on the config data structure —
+      it does NOT assert rendering; that the settings page renders the option
+      was verified manually against a running instance via the settings API,
+      not by an automated test. The real config-file read is covered by
+      `TestPreferredMethodRealSettingsPlumbing::test_preferred_method_is_read_through_the_real_settings_and_env_plumbing`,
+      which goes through `Settings` → `Env.setting` → `Plugin.conf`.)
 - [x] A10: fallback is explicit — when the preferred protocol has no release
       passing `tryDownloadResult`'s filters, a release of the other protocol is
       still downloaded. **Verification, not implementation** — this was

--- a/specs/FEAT-007-preferred-source-and-release-list-controls.md
+++ b/specs/FEAT-007-preferred-source-and-release-list-controls.md
@@ -96,7 +96,23 @@ choosing between releases by hand are invisible.
 - **`torrent_magnet` groups with `torrent`.** It is a torrent as far as the
   preference is concerned.
 - **Unknown protocol sorts last** in both directions, replacing the current
-  direction-dependent behaviour.
+  direction-dependent behaviour. **Accepted consequence:** `Release.add()`
+  (`couchpotato/core/plugins/release/main.py`, around lines 180-188) creates
+  release documents with no `info` key at all -- these represent movies the
+  library scanner found, i.e. copies the user already owns. Under a non-`both`
+  `preferred_method`, these scanner-created releases now rank as unknown and
+  sort LAST, where under the old direction-dependent behaviour they sorted
+  FIRST for one preference direction. Verified side by side: master orders
+  `['done-no-info', 'nzb', 'torrent', 'magnet']` under an nzb preference,
+  this change orders `['nzb', 'torrent', 'magnet', 'done-no-info']` (identical
+  to a torrent preference, which is the point -- direction-independent). This
+  has a knock-on: `movie_detail.html` picks `completed_releases[0]` for the
+  header's downloaded quality/status, so for a movie with both a
+  scanner-created `done` release and another completed release carrying
+  protocol info, which one the header shows can flip. This is accepted as a
+  correct consequence of fixing the direction-dependent bug, not a new defect,
+  and is pinned by a test (see Acceptance criteria A10 note and
+  `tests/unit/test_protocol_preference.py`).
 - **Server-side sort/filter over htmx**, not client-side Alpine. It keeps a
   single Jinja rendering path and fits the htmx-first architecture; the cost is
   a round-trip per interaction, which is acceptable for a LAN app.

--- a/specs/FEAT-007-preferred-source-and-release-list-controls.md
+++ b/specs/FEAT-007-preferred-source-and-release-list-controls.md
@@ -1,0 +1,283 @@
+# FEAT-007: Preferred download source, and sort/filter for the release list
+
+> Owner-approved design, 2026-07-29. Two parts. Part A makes an existing but
+> undiscoverable and untested behaviour explicit and safe; Part B adds the
+> controls that let you see and act on what each source actually offers.
+> They may ship as two PRs, but A lands first: B's default ordering is
+> A's output.
+
+## Problem
+
+Two separate problems, reported together as "I want to prefer NZB, and most
+results are torrents".
+
+**A. The preference already exists but is unfindable, unsafe to rely on, and
+undermined by scoring.**
+
+A tri-state `preferred_method` setting is already defined
+(`couchpotato/core/media/_base/searcher/__init__.py:18-24`) with values
+`both` / `nzb` / `torrent`, and it is honoured in two places:
+
+- `couchpotato/core/media/_base/searcher/main.py:61-63` — orders the candidate
+  list that `release.try_download_result` walks, so it decides what gets
+  downloaded automatically.
+- `couchpotato/core/plugins/release/main.py:677-679` — orders the release list
+  the UI shows (via `release.for_media`, reached from
+  `couchpotato/core/media/_base/library/main.py:122`).
+
+Three things are wrong with it:
+
+1. **It is labelled "First search"**, described as "Which of the methods do you
+   prefer", with values "usenet & torrents / usenet / torrents". Nothing about
+   that says "this decides which source wins". The production instance has no
+   `[searcher]` section in `settings.conf` at all, i.e. it has sat at the
+   `both` default since install.
+2. **It has zero test coverage.** `grep -rn preferred_method tests/` returns
+   nothing. The behaviour is implemented twice, by hand, with a
+   `protocol[:3]` string trick, against two different key paths
+   (`rel['protocol']` vs `rel['info']['protocol']`). Nothing stops the two
+   copies drifting, and nothing catches it if they do.
+3. **The two copies already differ in a way that is a latent bug.** In
+   `forMedia`, a release with a missing or unknown protocol yields `''`, which
+   sorts *before* `'nzb'` ascending — so unknown-protocol releases float to the
+   **top** of the list when you prefer usenet, and sink when you prefer
+   torrents. Direction-dependent placement of unknown data is not intended
+   behaviour in either direction.
+
+Separately, and the actual reason torrents dominate today:
+`couchpotato/core/plugins/score/main.py:36-42` adds
+`seeders * 100/15 + leechers * 100/30` to a torrent's score. A torrent with 50
+seeders gains **+333**. The entire name/quality scoring vocabulary in
+`couchpotato/core/plugins/score/scores.py:14-28` spans roughly -40 to +15, with
+preferred-word matches at +100 each. So under `both`, torrents do not compete
+with NZBs on merit — they outrank them by an order of magnitude regardless of
+quality. See *Out of scope* below.
+
+**B. The release list cannot be sorted or filtered.**
+
+The releases table (`couchpotato/ui/templates/partials/movie_detail.html:244`
+onward) is a static server-rendered table: Name, Quality, Score, Source,
+Status, Age, Action. There are no controls. `info.size` and `info.seeders` are
+carried in the data but never rendered, so the two fields most useful for
+choosing between releases by hand are invisible.
+
+## Goal
+
+- **A:** the preference is named for what it does, behaves identically in both
+  call sites, is covered by tests, and treats unknown protocols consistently.
+  No change to the *semantics* the owner already chose: a hard preference that
+  falls back.
+- **B:** the release list can be filtered by source, quality and status, and
+  sorted by any meaningful column including size and seeders — without changing
+  what the page shows when no control has been touched.
+
+## Decisions (owner-approved 2026-07-29)
+
+- **Hard preference, not a score bonus.** Any release of the preferred protocol
+  that passes the existing filters (`minimum_score`, `minimum_seeders`, size,
+  ignored/failed status) is taken over any release of the other protocol, even
+  a substantially better one. This is what the code already does; it is now the
+  documented, tested contract.
+- **Fallback, not exclusion.** When no acceptable release of the preferred
+  protocol exists, the other protocol is used. There is no "usenet only" mode
+  and no "wait for an NZB" mode; a fourth strict state was considered and
+  rejected.
+- **`torrent_magnet` groups with `torrent`.** It is a torrent as far as the
+  preference is concerned.
+- **Unknown protocol sorts last** in both directions, replacing the current
+  direction-dependent behaviour.
+- **Server-side sort/filter over htmx**, not client-side Alpine. It keeps a
+  single Jinja rendering path and fits the htmx-first architecture; the cost is
+  a round-trip per interaction, which is acceptable for a LAN app.
+- **Controls are real links, htmx-enhanced.** They render as
+  `<a href="/movie/{id}?source=nzb&sort=size&dir=desc">` and the full-page
+  route (`ui/__init__.py:106-107`, which registers both the trailing-slash and
+  bare forms — both must accept the params) honours the same query params, so
+  they work with JavaScript disabled. htmx intercepts to swap only the table.
+- **Defaults preserve today's output.** With no query params the list renders
+  exactly as it does now: score order, then Part A's protocol preference.
+
+## Part A — Preferred download source
+
+### Design
+
+**Relabel** in `couchpotato/core/media/_base/searcher/__init__.py`:
+
+| Field | From | To |
+|---|---|---|
+| `label` | `First search` | `Preferred download source` |
+| `description` | `Which of the methods do you prefer` | `Prefer this source when both have acceptable releases. Falls back to the other if nothing suitable is found.` |
+| `values` | `usenet & torrents` / `usenet` / `torrents` | `No preference` / `Usenet (NZB)` / `Torrents` |
+
+The stored values (`both`, `nzb`, `torrent`) are **unchanged** — only display
+strings change, so existing `settings.conf` files keep working untouched.
+
+**Extract one helper.** A new module `couchpotato/core/helpers/protocol.py`
+exposing:
+
+```python
+def sort_by_protocol_preference(items, preference, get_protocol):
+    """Stable-sort `items` so the preferred protocol comes first.
+
+    preference: 'both' | 'nzb' | 'torrent'. 'both' returns items unchanged.
+    get_protocol: callable mapping an item to its protocol string.
+    Rank: preferred = 0, other known = 1, unknown/missing = 2.
+    """
+```
+
+Ranking is explicit rather than the `[:3]` string trick. Both call sites
+(`searcher/main.py:61-63` and `release/main.py:677-679`) delegate to it,
+passing the getter appropriate to their data shape.
+
+`couchpotato/core/helpers/` is the right home: both call sites already import
+from `couchpotato.core.helpers.variable`, so the import path is established and
+adds no cycle. Putting the helper under the `searcher` package instead would
+make `release/main.py` import a package whose `__init__.py` pulls in
+`Searcher` and the plugin base — a cycle risk for no benefit.
+
+Stability matters and is load-bearing: both callers sort by score *first*, then
+by protocol, and rely on Python's stable sort to preserve score order within
+each protocol group.
+
+### Acceptance criteria — Part A
+
+- [ ] A1: with `preferred_method = 'nzb'`, every NZB release precedes every
+      torrent release in both `Searcher.search()` and `Release.forMedia()`,
+      regardless of score.
+- [ ] A2: with `preferred_method = 'torrent'`, the reverse holds.
+- [ ] A3: with `preferred_method = 'both'`, order is score-descending only —
+      the helper returns the list unchanged.
+- [ ] A4: within a protocol group, score-descending order is preserved (sort
+      stability) for all three preference values.
+- [ ] A5: `torrent_magnet` is ranked with `torrent`, not as unknown.
+- [ ] A6: a release with a missing, empty or unrecognised protocol sorts
+      **last** under `'nzb'` *and* under `'torrent'`.
+- [ ] A7: both call sites use the shared helper — no remaining hand-rolled
+      protocol sort, verified by test, not by eye.
+- [ ] A8: an empty list, and a list with a single item, are handled without
+      error for every preference value.
+- [ ] A9: the config option renders in Settings → Searcher → Basics with the
+      new label and value labels, and an existing `settings.conf` containing
+      `preferred_method = nzb` is still read correctly (stored values unchanged).
+- [ ] A10: fallback is explicit — when the preferred protocol has no release
+      passing `tryDownloadResult`'s filters, a release of the other protocol is
+      still downloaded.
+
+## Part B — Sort/filter for the release list
+
+### Design
+
+**Route.** `GET /partial/movie/{movie_id}/releases`, registered in
+`couchpotato/ui/__init__.py` beside the existing
+`/partial/movie/{movie_id}/collections` (line 311), with the same
+`Depends(require_auth)` guard. Query params: `source`, `quality`, `status`,
+`sort`, `dir`.
+
+**One pure function.** `couchpotato/ui/releases_view.py`:
+
+```python
+def filter_and_sort_releases(releases, *, source='all', quality='all',
+                             status='all', sort='default', dir='desc'):
+```
+
+No FastAPI, no Jinja, no database — a list in, a list out, so it is unit
+testable directly. It is the only place release ordering logic lives.
+
+- `source`: `all` | `nzb` | `torrent` (the latter matches `torrent_magnet` too)
+- `quality`: `all` | any quality identifier present in the supplied list.
+  Release documents store `quality` as an identifier **string**
+  (`release/main.py:183`, `:501`), but the template already defends against a
+  dict (`movie_detail.html:279`), so the filter reads the identifier from
+  either shape and treats anything else as no-match.
+- `status`: `all` | `available` | `snatched` | `done` | `ignored` | `failed`
+- `sort`: `default` | `name` | `quality` | `score` | `source` | `status` |
+  `age` | `size` | `seeders`
+- `dir`: `asc` | `desc`
+- `sort='default'` returns the input order untouched — i.e. whatever
+  `release.for_media` already produced, which is Part A's output. `dir` is
+  ignored in this case rather than reversing the default order.
+
+**Templates.** The releases block moves out of `movie_detail.html` into
+`partials/movie_releases.html`, which `movie_detail.html` `{% include %}`s.
+First paint stays server-rendered with no extra round-trip; the partial route
+renders the same template for htmx swaps. The `releaseDownloader()` Alpine
+component (`movie_detail.html:412`) moves with the block it serves, and the
+existing Download / Skip actions must keep working after a swap.
+
+**Columns.** Add **Size** (from `info.size`, MB) and **Seeders** (from
+`info.seeders`, blank for NZB). Existing columns are unchanged.
+
+**Accessibility.** Sortable headers are buttons inside `<th>` carrying
+`aria-sort="ascending|descending|none"`, updated to match current state. The
+filter controls are a labelled group. A result count lives in an
+`aria-live="polite"` region so a filter change is announced. Touch targets on
+the controls meet the 44px floor from the global standards.
+
+**Error handling.** Unrecognised `sort`, `dir`, `source`, `quality` or `status`
+values fall back to their defaults rather than raising — these values arrive
+from URLs that can be bookmarked, shared or hand-edited. Releases missing
+`size`/`seeders` sort last rather than crashing the comparison. A failed
+`media.get` renders the existing empty state.
+
+### Acceptance criteria — Part B
+
+- [ ] B1: `filter_and_sort_releases` with all defaults returns the input list
+      in its original order, unmodified.
+- [ ] B2: `source='nzb'` returns only NZB releases; `source='torrent'` returns
+      both `torrent` and `torrent_magnet`.
+- [ ] B3: `quality` and `status` filters each return only matching releases,
+      and compose with `source` (all three applied together).
+- [ ] B4: every `sort` key orders correctly in both directions, including
+      `size` and `seeders`.
+- [ ] B5: releases missing the sorted-on field sort last in both directions and
+      never raise.
+- [ ] B6: unrecognised values for any param fall back to the default and return
+      a 200, not a 500.
+- [ ] B7: `GET /partial/movie/{id}/releases` requires auth, returns the table
+      HTML, and honours all five params.
+- [ ] B8: the full-page movie route honours the same params, so the controls
+      work as plain links with JavaScript disabled.
+- [ ] B9: Size and Seeders columns render; Seeders is blank (not `0`) for NZB
+      releases.
+- [ ] B10: sortable headers expose `aria-sort` reflecting the active sort, and
+      the result count is in an `aria-live` region.
+- [ ] B11: E2E — filter to NZB, confirm only NZB rows remain; sort by size,
+      confirm row order and that `aria-sort` updated (CLAUDE.md rule 5).
+- [ ] B12: E2E/axe — no new accessibility violations on the detail page with
+      filters applied.
+- [ ] B13: Download and Skip still work on a row after an htmx swap (the Alpine
+      component rebinds).
+- [ ] B14: a movie with no releases still renders the existing empty state,
+      with controls either hidden or inert.
+
+## Out of scope
+
+- **The seeder score bias** (`couchpotato/core/plugins/score/main.py:36-42`).
+  The hard preference routes around it, but it still means "No preference" is
+  not neutral, and it distorts score ordering *within* the torrent group. Worth
+  its own spec; deliberately not smuggled into this change.
+- **Per-profile or per-movie source preference.** The setting stays global.
+- **A strict "usenet only, never torrent" mode.** Considered and rejected.
+- **Persisting the user's chosen sort/filter** across visits. The params live
+  in the URL only.
+
+## Affected files
+
+- `couchpotato/core/media/_base/searcher/__init__.py` — config label,
+  description, value labels
+- `couchpotato/core/media/_base/searcher/main.py` — call the shared helper
+- `couchpotato/core/plugins/release/main.py` — call the shared helper
+- new: `couchpotato/core/helpers/protocol.py` —
+  `sort_by_protocol_preference()`
+- new: `couchpotato/ui/releases_view.py` — `filter_and_sort_releases`
+- `couchpotato/ui/__init__.py` — new partial route; full-page route accepts the
+  same params
+- new: `couchpotato/ui/templates/partials/movie_releases.html` — extracted from
+  `movie_detail.html`
+- `couchpotato/ui/templates/partials/movie_detail.html` — include the partial;
+  Size/Seeders columns; controls
+- new: `tests/unit/` — helper tests (Part A), `filter_and_sort_releases` tests
+  and route tests (Part B)
+- `tests/e2e/` — filter/sort coverage per CLAUDE.md rule 5
+- `docs/design-system/CONFORMANCE.md` — if the new controls introduce patterns
+  the conformance gate checks

--- a/specs/FEAT-007-preferred-source-and-release-list-controls.md
+++ b/specs/FEAT-007-preferred-source-and-release-list-controls.md
@@ -168,27 +168,51 @@ each protocol group.
 
 ### Acceptance criteria — Part A
 
-- [ ] A1: with `preferred_method = 'nzb'`, every NZB release precedes every
+- [x] A1: with `preferred_method = 'nzb'`, every NZB release precedes every
       torrent release in both `Searcher.search()` and `Release.forMedia()`,
-      regardless of score.
-- [ ] A2: with `preferred_method = 'torrent'`, the reverse holds.
-- [ ] A3: with `preferred_method = 'both'`, order is score-descending only —
-      the helper returns the list unchanged.
-- [ ] A4: within a protocol group, score-descending order is preserved (sort
+      regardless of score. (`test_nzb_preference_puts_every_nzb_before_every_torrent`,
+      `test_nzb_preference_orders_nzb_first_regardless_of_score`,
+      `test_nzb_preference_lists_nzb_first`)
+- [x] A2: with `preferred_method = 'torrent'`, the reverse holds.
+      (`test_torrent_preference_puts_every_torrent_before_every_nzb`,
+      `test_torrent_preference_orders_torrents_first`,
+      `test_torrent_preference_lists_torrents_first`)
+- [x] A3: with `preferred_method = 'both'`, order is score-descending only —
+      the helper returns the list unchanged. (`test_both_leaves_the_incoming_order_untouched`,
+      `test_both_preserves_pure_score_order`, `test_both_lists_in_score_order`)
+- [x] A4: within a protocol group, score-descending order is preserved (sort
       stability) for all three preference values.
-- [ ] A5: `torrent_magnet` is ranked with `torrent`, not as unknown.
-- [ ] A6: a release with a missing, empty or unrecognised protocol sorts
+      (`test_score_order_is_preserved_within_each_protocol_group`,
+      `test_score_order_survives_inside_the_preferred_group`)
+- [x] A5: `torrent_magnet` is ranked with `torrent`, not as unknown.
+      (`test_torrent_magnet_ranks_with_torrent`)
+- [x] A6: a release with a missing, empty or unrecognised protocol sorts
       **last** under `'nzb'` *and* under `'torrent'`.
-- [ ] A7: both call sites use the shared helper — no remaining hand-rolled
-      protocol sort, verified by test, not by eye.
-- [ ] A8: an empty list, and a list with a single item, are handled without
-      error for every preference value.
-- [ ] A9: the config option renders in Settings → Searcher → Basics with the
+      (`test_unknown_protocol_sorts_last_when_preferring_nzb`,
+      `test_unknown_protocol_sorts_last_when_preferring_torrent_too`,
+      `test_missing_or_unrecognised_protocols_are_treated_as_unknown`,
+      `test_a_release_with_no_protocol_is_listed_last_not_first`)
+- [x] A7: both call sites use the shared helper — no remaining hand-rolled
+      protocol sort, verified by test, not by eye. (`test_search_uses_the_shared_helper`,
+      `test_for_media_uses_the_shared_helper` — strengthened to assert on
+      `call_args`, not just `.called`)
+- [x] A8: an empty list, and a list with a single item, are handled without
+      error for every preference value. (`test_empty_and_single_item_lists_are_safe`)
+- [x] A9: the config option renders in Settings → Searcher → Basics with the
       new label and value labels, and an existing `settings.conf` containing
       `preferred_method = nzb` is still read correctly (stored values unchanged).
-- [ ] A10: fallback is explicit — when the preferred protocol has no release
+      (`TestPreferredMethodConfigOption`; real config-file read verified end to
+      end by `TestPreferredMethodRealSettingsPlumbing::test_preferred_method_is_read_through_the_real_settings_and_env_plumbing`)
+- [x] A10: fallback is explicit — when the preferred protocol has no release
       passing `tryDownloadResult`'s filters, a release of the other protocol is
-      still downloaded.
+      still downloaded. **Verification, not implementation** — this was
+      confirmed working for filter rejections
+      (`test_a_torrent_is_downloaded_when_no_nzb_was_found`,
+      `test_a_torrent_is_downloaded_when_the_preferred_nzb_fails_the_filters`,
+      `test_the_preferred_release_still_wins_when_it_passes`), with the
+      download-failure limitation called out and pinned separately
+      (`test_a_download_failure_does_not_fall_through_to_the_other_protocol`
+      — see "Fallback, not exclusion" above).
 
 ## Part B — Sort/filter for the release list
 

--- a/specs/FEAT-007-preferred-source-and-release-list-controls.md
+++ b/specs/FEAT-007-preferred-source-and-release-list-controls.md
@@ -81,7 +81,18 @@ choosing between releases by hand are invisible.
 - **Fallback, not exclusion.** When no acceptable release of the preferred
   protocol exists, the other protocol is used. There is no "usenet only" mode
   and no "wait for an NZB" mode; a fourth strict state was considered and
-  rejected.
+  rejected. **Known limitation, carried forward unchanged from before this
+  change:** "acceptable" means the release passes `tryDownloadResult`'s
+  FILTERS (status / minimum_score / size / seeders). Fallback happens when
+  the preferred release is filtered out, NOT when its download fails --
+  if a preferred-protocol release passes every filter but the download
+  itself then fails (downloader disabled/unreachable, provider error),
+  `tryDownloadResult` does not advance to the next candidate and the other
+  protocol is never tried for that search. This is pre-existing behaviour,
+  not introduced by this PR; it is pinned by
+  `tests/unit/test_protocol_preference.py::TestFallbackToTheOtherProtocol::test_a_download_failure_does_not_fall_through_to_the_other_protocol`
+  so the gap stays visible rather than contradicted by the setting's
+  description.
 - **`torrent_magnet` groups with `torrent`.** It is a torrent as far as the
   preference is concerned.
 - **Unknown protocol sorts last** in both directions, replacing the current

--- a/tests/unit/test_protocol_preference.py
+++ b/tests/unit/test_protocol_preference.py
@@ -88,6 +88,17 @@ class TestSortByProtocolPreference:
         result = sort_by_protocol_preference(items, 'nzb', _get)
         assert _protocols(result) == ['nzb', bad]
 
+    def test_a_non_string_protocol_does_not_crash_and_ranks_as_unknown(self):
+        """A corrupt document can carry a non-None non-string 'protocol'
+        (e.g. a list). `(protocol or '').strip().lower()` raises
+        AttributeError for that; master's `[:3]` slice tolerated sequences.
+        Since this feeds forMedia and therefore the movie-detail page, a
+        non-string protocol must rank as unknown rather than raising.
+        """
+        items = _items(['not', 'a', 'string'], 'torrent', 'nzb')
+        result = sort_by_protocol_preference(items, 'nzb', _get)
+        assert _protocols(result) == ['nzb', 'torrent', ['not', 'a', 'string']]
+
     def test_protocol_matching_is_case_and_whitespace_insensitive(self):
         """Provider data is not guaranteed to be normalised."""
         items = _items('torrent', ' NZB ')

--- a/tests/unit/test_protocol_preference.py
+++ b/tests/unit/test_protocol_preference.py
@@ -196,3 +196,73 @@ class TestSearcherSearchOrdering:
             searcher.search(['nzb'], {'type': 'movie'}, {'identifier': '1080p'})
 
         assert helper.called, 'Searcher.search must delegate to sort_by_protocol_preference'
+
+
+class TestReleaseForMediaOrdering:
+    """`Release.forMedia()` — the order the movie detail page renders."""
+
+    @pytest.fixture
+    def plugin(self):
+        from couchpotato.core.plugins.release.main import Release
+        return object.__new__(Release)
+
+    def _for_media(self, plugin, preference, docs):
+        from unittest.mock import MagicMock, patch
+
+        db = MagicMock()
+        db.get_many.return_value = [{'_id': d['_id']} for d in docs]
+        db.get.side_effect = lambda _index, _id: next(d for d in docs if d['_id'] == _id)
+
+        with patch('couchpotato.core.plugins.release.main.get_db', return_value = db), \
+                patch.object(plugin, 'conf', return_value = preference):
+            return plugin.forMedia('movie-1')
+
+    @staticmethod
+    def _doc(_id, protocol, score):
+        return {'_id': _id, 'info': {'protocol': protocol, 'score': score}}
+
+    def test_nzb_preference_lists_nzb_first(self, plugin):
+        """A1 on the display path."""
+        docs = [self._doc('t1', 'torrent', 3400), self._doc('n1', 'nzb', 210)]
+        assert [r['_id'] for r in self._for_media(plugin, 'nzb', docs)] == ['n1', 't1']
+
+    def test_torrent_preference_lists_torrents_first(self, plugin):
+        """A2 on the display path."""
+        docs = [self._doc('n1', 'nzb', 3400), self._doc('t1', 'torrent', 210)]
+        assert [r['_id'] for r in self._for_media(plugin, 'torrent', docs)] == ['t1', 'n1']
+
+    def test_both_lists_in_score_order(self, plugin):
+        """A3 on the display path."""
+        docs = [self._doc('n1', 'nzb', 500), self._doc('t1', 'torrent', 3400)]
+        assert [r['_id'] for r in self._for_media(plugin, 'both', docs)] == ['t1', 'n1']
+
+    def test_a_release_with_no_protocol_is_listed_last_not_first(self, plugin):
+        """A6: THE BUG. `''[:3]` sorted ascending put this at the TOP under 'nzb'."""
+        docs = [
+            self._doc('unknown', '', 999),
+            self._doc('t1', 'torrent', 500),
+            self._doc('n1', 'nzb', 100),
+        ]
+        assert [r['_id'] for r in self._for_media(plugin, 'nzb', docs)] == ['n1', 't1', 'unknown']
+
+    def test_a_release_with_no_info_block_does_not_crash_the_list(self, plugin):
+        """Defensive: a partially-written document must not break the page."""
+        docs = [{'_id': 'broken'}, self._doc('n1', 'nzb', 100)]
+        assert [r['_id'] for r in self._for_media(plugin, 'nzb', docs)] == ['n1', 'broken']
+
+    def test_for_media_uses_the_shared_helper(self, plugin):
+        """A7: the second copy of the logic must be gone."""
+        from unittest.mock import MagicMock, patch
+
+        docs = [self._doc('n1', 'nzb', 100)]
+        db = MagicMock()
+        db.get_many.return_value = [{'_id': 'n1'}]
+        db.get.side_effect = lambda _index, _id: docs[0]
+
+        with patch('couchpotato.core.plugins.release.main.sort_by_protocol_preference',
+                   return_value = docs) as helper, \
+                patch('couchpotato.core.plugins.release.main.get_db', return_value = db), \
+                patch.object(plugin, 'conf', return_value = 'nzb'):
+            plugin.forMedia('movie-1')
+
+        assert helper.called, 'Release.forMedia must delegate to sort_by_protocol_preference'

--- a/tests/unit/test_protocol_preference.py
+++ b/tests/unit/test_protocol_preference.py
@@ -266,3 +266,67 @@ class TestReleaseForMediaOrdering:
             plugin.forMedia('movie-1')
 
         assert helper.called, 'Release.forMedia must delegate to sort_by_protocol_preference'
+
+
+class TestFallbackToTheOtherProtocol:
+    """A10: the preference orders candidates; it never excludes them.
+
+    `tryDownloadResult` walks the preference-ordered list and takes the first
+    release that passes the filters — so when the preferred protocol has
+    nothing usable, the other one is still downloaded. That is the designed
+    behaviour ("fall back to torrent"), and it is what makes the preference
+    safe to turn on.
+    """
+
+    @pytest.fixture
+    def plugin(self):
+        from couchpotato.core.plugins.release.main import Release
+        return object.__new__(Release)
+
+    def _try(self, plugin, results, minimum_score = 1):
+        from unittest.mock import MagicMock, patch
+
+        downloaded = []
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'release.download':
+                downloaded.append(kwargs.get('data', {}).get('name'))
+                return True
+            return None
+
+        env = MagicMock()
+        env.setting.return_value = 1  # torrent.minimum_seeders
+
+        with patch('couchpotato.core.plugins.release.main.fireEvent', side_effect = fake_fire_event), \
+                patch('couchpotato.core.plugins.release.main.Env', env):
+            plugin.tryDownloadResult(results, {'_id': 'movie-1'}, {'minimum_score': minimum_score, 'index': 0})
+
+        return downloaded
+
+    def test_a_torrent_is_downloaded_when_no_nzb_was_found(self, plugin):
+        """Preference nzb, but the search returned torrents only."""
+        results = [
+            {'name': 'only.torrent', 'protocol': 'torrent', 'score': 100, 'size': 4000, 'seeders': 20, 'age': 5},
+        ]
+        assert self._try(plugin, results) == ['only.torrent']
+
+    def test_a_torrent_is_downloaded_when_the_preferred_nzb_fails_the_filters(self, plugin):
+        """The real fallback path: an nzb ranked first but rejected on score.
+
+        The list arrives nzb-first (the preference already applied); the nzb is
+        filtered out for scoring below `minimum_score`, and the torrent behind
+        it is taken.
+        """
+        results = [
+            {'name': 'weak.nzb', 'protocol': 'nzb', 'score': 2, 'size': 4000, 'age': 5},
+            {'name': 'fine.torrent', 'protocol': 'torrent', 'score': 800, 'size': 4000, 'seeders': 20, 'age': 5},
+        ]
+        assert self._try(plugin, results, minimum_score = 500) == ['fine.torrent']
+
+    def test_the_preferred_release_still_wins_when_it_passes(self, plugin):
+        """The complement — fallback must not fire when it should not."""
+        results = [
+            {'name': 'good.nzb', 'protocol': 'nzb', 'score': 800, 'size': 4000, 'age': 5},
+            {'name': 'big.torrent', 'protocol': 'torrent', 'score': 5000, 'size': 4000, 'seeders': 900, 'age': 5},
+        ]
+        assert self._try(plugin, results) == ['good.nzb']

--- a/tests/unit/test_protocol_preference.py
+++ b/tests/unit/test_protocol_preference.py
@@ -81,12 +81,29 @@ class TestSortByProtocolPreference:
         result = sort_by_protocol_preference(items, 'torrent', _get)
         assert _protocols(result) == ['torrent', 'nzb', 'mystery']
 
+    @pytest.mark.parametrize('preference, expected', [('nzb', 'nzb'), ('torrent', 'torrent')])
     @pytest.mark.parametrize('bad', [None, '', '   ', 'ftp'])
-    def test_missing_or_unrecognised_protocols_are_treated_as_unknown(self, bad):
-        """A6: absent data must not outrank real data."""
-        items = _items(bad, 'nzb')
-        result = sort_by_protocol_preference(items, 'nzb', _get)
-        assert _protocols(result) == ['nzb', bad]
+    def test_missing_or_unrecognised_protocols_are_treated_as_unknown(self, bad, preference, expected):
+        """A6: absent data must not outrank real data, in EITHER direction.
+
+        Parametrised over both preferences because A6 claims unknown sorts
+        last under 'nzb' *and* 'torrent' -- running it only one way would
+        leave half the claim untested.
+        """
+        items = _items(bad, expected)
+        result = sort_by_protocol_preference(items, preference, _get)
+        assert _protocols(result) == [expected, bad]
+
+    def test_score_order_is_preserved_within_the_group_under_a_torrent_preference(self):
+        """A4 claims stability for all three preference values.
+
+        The nzb direction is covered above; this pins the torrent direction
+        so the claim is true as written rather than true by inference from
+        `sorted` being unconditionally stable.
+        """
+        items = _items('nzb', 'torrent', 'nzb', 'torrent', 'torrent')
+        result = sort_by_protocol_preference(items, 'torrent', _get)
+        assert [i['pos'] for i in result] == [1, 3, 4, 0, 2]
 
     def test_a_non_string_protocol_does_not_crash_and_ranks_as_unknown(self):
         """A corrupt document can carry a non-None non-string 'protocol'
@@ -198,12 +215,13 @@ class TestSearcherSearchOrdering:
         """A7: no second hand-rolled copy of this logic may survive.
 
         Asserting only `helper.called` would pass even if the preference or
-        the getter were wired up wrong (e.g. reading the wrong config key,
-        or handing over a getter that reaches into the wrong shape of
-        item). Pin the actual contract: the preference read from config is
-        passed through unchanged, and the getter extracts the protocol from
-        `rel['protocol']` -- the shape search() results have, as opposed to
-        forMedia()'s `rel['info']['protocol']`.
+        the getter were wired up wrong (reading the wrong config key, or
+        handing over a getter that reaches into the wrong shape of item).
+        Pin the actual contract: the option name and section actually read
+        from config, the preference passed through unchanged, and a getter
+        that extracts the protocol from `rel['protocol']` -- the shape
+        search() results have, as opposed to forMedia()'s
+        `rel['info']['protocol']`.
         """
         from unittest.mock import patch
 
@@ -212,10 +230,15 @@ class TestSearcherSearchOrdering:
                    return_value = results) as helper, \
                 patch('couchpotato.core.media._base.searcher.main.fireEvent',
                       side_effect = lambda event, *a, **k: results if event.endswith('.nzb.movie') else []), \
-                patch.object(searcher, 'conf', return_value = 'nzb'):
+                patch.object(searcher, 'conf', return_value = 'nzb') as conf:
             searcher.search(['nzb'], {'type': 'movie'}, {'identifier': '1080p'})
 
         assert helper.called, 'Searcher.search must delegate to sort_by_protocol_preference'
+
+        # The config key literal is otherwise untested: `conf` is patched by
+        # every test here, so a typo in either the option name or the section
+        # would silently read a different (absent) setting in production.
+        conf.assert_called_once_with('preferred_method', section = 'searcher')
 
         args, kwargs = helper.call_args
         preference = args[1] if len(args) > 1 else kwargs['preference']
@@ -340,10 +363,14 @@ class TestReleaseForMediaOrdering:
         with patch('couchpotato.core.plugins.release.main.sort_by_protocol_preference',
                    return_value = docs) as helper, \
                 patch('couchpotato.core.plugins.release.main.get_db', return_value = db), \
-                patch.object(plugin, 'conf', return_value = 'nzb'):
+                patch.object(plugin, 'conf', return_value = 'nzb') as conf:
             plugin.forMedia('movie-1')
 
         assert helper.called, 'Release.forMedia must delegate to sort_by_protocol_preference'
+
+        # Both call sites must read the SAME option out of the SAME section,
+        # or the list the user sees and the list the picker walks diverge.
+        conf.assert_called_once_with('preferred_method', section = 'searcher')
 
         args, kwargs = helper.call_args
         preference = args[1] if len(args) > 1 else kwargs['preference']
@@ -584,6 +611,7 @@ class TestPreferredMethodRealSettingsPlumbing:
     """
 
     def test_preferred_method_is_read_through_the_real_settings_and_env_plumbing(self, tmp_path):
+        from couchpotato.core.media._base.searcher.main import Searcher
         from couchpotato.core.settings import Settings
         from couchpotato.environment import Env
 
@@ -597,6 +625,13 @@ class TestPreferredMethodRealSettingsPlumbing:
         Env._settings = settings
         try:
             assert Env.setting('preferred_method', section = 'searcher', default = 'both') == 'nzb'
+
+            # Go through Plugin.conf as the call sites actually do, rather
+            # than stopping at Env.setting -- that is the layer every other
+            # test in this file patches away, and the layer the option name
+            # and section literals are written against.
+            searcher = object.__new__(Searcher)
+            assert searcher.conf('preferred_method', section = 'searcher') == 'nzb'
         finally:
             Env._settings = original_settings
 

--- a/tests/unit/test_protocol_preference.py
+++ b/tests/unit/test_protocol_preference.py
@@ -246,9 +246,21 @@ class TestReleaseForMediaOrdering:
         assert [r['_id'] for r in self._for_media(plugin, 'nzb', docs)] == ['n1', 't1', 'unknown']
 
     def test_a_release_with_no_info_block_does_not_crash_the_list(self, plugin):
-        """Defensive: a partially-written document must not break the page."""
-        docs = [{'_id': 'broken'}, self._doc('n1', 'nzb', 100)]
-        assert [r['_id'] for r in self._for_media(plugin, 'nzb', docs)] == ['n1', 'broken']
+        """Defensive: a partially-written document must not break the page.
+
+        `k.get('info', {})` (the old, unguarded expression) already returns
+        `{}` for a MISSING 'info' key, so a doc that simply omits 'info'
+        does not exercise the `(k.get('info') or {})` hardening at all --
+        it would pass against either expression. The only case the `or {}`
+        guard changes is an explicit `'info': None`, which is what this test
+        must include to actually cover the hardening.
+        """
+        docs = [
+            {'_id': 'broken', 'info': None},
+            {'_id': 'missing_key'},
+            self._doc('n1', 'nzb', 100),
+        ]
+        assert [r['_id'] for r in self._for_media(plugin, 'nzb', docs)] == ['n1', 'broken', 'missing_key']
 
     def test_for_media_uses_the_shared_helper(self, plugin):
         """A7: the second copy of the logic must be gone."""

--- a/tests/unit/test_protocol_preference.py
+++ b/tests/unit/test_protocol_preference.py
@@ -295,15 +295,30 @@ class TestReleaseForMediaOrdering:
         'info': {'score': None} still has a truthy info dict, so `or {}`
         does not fire, and `.get('score', 0)` returns None (the key IS
         present) rather than the 0 default. Comparing None to an int during
-        sort raises TypeError. The score coercion must use `tryInt` (already
-        imported in release/main.py) so None/garbage sorts as 0, consistent
-        with the rest of the hardening.
+        sort raises TypeError. The score coercion must default None/garbage
+        to 0, consistent with the rest of the hardening.
         """
         docs = [
             {'_id': 'nullscore', 'info': {'protocol': 'nzb', 'score': None}},
             self._doc('t1', 'torrent', 500),
         ]
         assert [r['_id'] for r in self._for_media(plugin, 'both', docs)] == ['t1', 'nullscore']
+
+    def test_fractional_scores_are_not_truncated_into_ties(self, plugin):
+        """The coercion must not lose precision — `tryInt` would.
+
+        Torrent scores are floats: `score/main.py` adds `seeders * 100 / 15`,
+        and `/` is true division. Coercing with `tryInt` truncates, so 300.8
+        and 300.2 both become 300, the two releases tie, and their order falls
+        back to whatever the input order happened to be instead of the actual
+        score. `tryFloat` keeps the fraction and still defaults None/garbage
+        to 0.
+        """
+        docs = [
+            {'_id': 'lower', 'info': {'protocol': 'torrent', 'score': 300.2}},
+            {'_id': 'higher', 'info': {'protocol': 'torrent', 'score': 300.8}},
+        ]
+        assert [r['_id'] for r in self._for_media(plugin, 'both', docs)] == ['higher', 'lower']
 
     def test_for_media_uses_the_shared_helper(self, plugin):
         """A7: the second copy of the logic must be gone.

--- a/tests/unit/test_protocol_preference.py
+++ b/tests/unit/test_protocol_preference.py
@@ -117,3 +117,82 @@ class TestSortByProtocolPreference:
         items = _items('torrent', 'nzb')
         sort_by_protocol_preference(items, 'nzb', _get)
         assert _protocols(items) == ['torrent', 'nzb']
+
+
+class TestSearcherSearchOrdering:
+    """`Searcher.search()` — the order here decides what gets downloaded."""
+
+    @pytest.fixture
+    def searcher(self):
+        # __init__ registers events and API views; bypass it.
+        from couchpotato.core.media._base.searcher.main import Searcher
+        return object.__new__(Searcher)
+
+    def _search(self, searcher, preference, results):
+        """Drive search() with one provider event per protocol, as in production."""
+        from unittest.mock import patch
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'provider.search.nzb.movie':
+                return [r for r in results if r['protocol'] == 'nzb']
+            if event == 'provider.search.torrent.movie':
+                return [r for r in results if r['protocol'] != 'nzb']
+            return []
+
+        with patch('couchpotato.core.media._base.searcher.main.fireEvent',
+                   side_effect = fake_fire_event), \
+                patch.object(searcher, 'conf', return_value = preference):
+            return searcher.search(['nzb', 'torrent'], {'type': 'movie'}, {'identifier': '1080p'})
+
+    def test_nzb_preference_orders_nzb_first_regardless_of_score(self, searcher):
+        """A1: a 900-seeder torrent scoring 3400 still loses to a 210-score nzb."""
+        results = [
+            {'name': 'big.torrent', 'protocol': 'torrent', 'score': 3400},
+            {'name': 'good.nzb', 'protocol': 'nzb', 'score': 210},
+        ]
+        ordered = self._search(searcher, 'nzb', results)
+        assert [r['name'] for r in ordered] == ['good.nzb', 'big.torrent']
+
+    def test_torrent_preference_orders_torrents_first(self, searcher):
+        """A2."""
+        results = [
+            {'name': 'big.nzb', 'protocol': 'nzb', 'score': 3400},
+            {'name': 'ok.torrent', 'protocol': 'torrent', 'score': 210},
+        ]
+        ordered = self._search(searcher, 'torrent', results)
+        assert [r['name'] for r in ordered] == ['ok.torrent', 'big.nzb']
+
+    def test_both_preserves_pure_score_order(self, searcher):
+        """A3."""
+        results = [
+            {'name': 'mid.nzb', 'protocol': 'nzb', 'score': 500},
+            {'name': 'big.torrent', 'protocol': 'torrent', 'score': 3400},
+            {'name': 'small.torrent', 'protocol': 'torrent', 'score': 10},
+        ]
+        ordered = self._search(searcher, 'both', results)
+        assert [r['name'] for r in ordered] == ['big.torrent', 'mid.nzb', 'small.torrent']
+
+    def test_score_order_survives_inside_the_preferred_group(self, searcher):
+        """A4 at the call site, not just in the helper."""
+        results = [
+            {'name': 'best.nzb', 'protocol': 'nzb', 'score': 900},
+            {'name': 'worst.nzb', 'protocol': 'nzb', 'score': 5},
+            {'name': 'mid.nzb', 'protocol': 'nzb', 'score': 400},
+            {'name': 'a.torrent', 'protocol': 'torrent', 'score': 5000},
+        ]
+        ordered = self._search(searcher, 'nzb', results)
+        assert [r['name'] for r in ordered] == ['best.nzb', 'mid.nzb', 'worst.nzb', 'a.torrent']
+
+    def test_search_uses_the_shared_helper(self, searcher):
+        """A7: no second hand-rolled copy of this logic may survive."""
+        from unittest.mock import patch
+
+        results = [{'name': 'x.nzb', 'protocol': 'nzb', 'score': 1}]
+        with patch('couchpotato.core.media._base.searcher.main.sort_by_protocol_preference',
+                   return_value = results) as helper, \
+                patch('couchpotato.core.media._base.searcher.main.fireEvent',
+                      side_effect = lambda event, *a, **k: results if event.endswith('.nzb.movie') else []), \
+                patch.object(searcher, 'conf', return_value = 'nzb'):
+            searcher.search(['nzb'], {'type': 'movie'}, {'identifier': '1080p'})
+
+        assert helper.called, 'Searcher.search must delegate to sort_by_protocol_preference'

--- a/tests/unit/test_protocol_preference.py
+++ b/tests/unit/test_protocol_preference.py
@@ -502,3 +502,53 @@ class TestPreferredMethodConfigOption:
         assert stored == ['both', 'nzb', 'torrent']
         assert self._option()['default'] == 'both'
         assert self._option()['type'] == 'dropdown'
+
+
+class TestPreferredMethodRealSettingsPlumbing:
+    """Every call-site test above patches `self.conf` directly, so nothing
+    pins the real Settings -> Env.setting -> Plugin.conf path for this
+    option. This test writes a real settings.conf to a temp file, loads it
+    through the project's actual Settings class (the same class
+    tests/unit/test_settings.py exercises), points Env at that instance,
+    and asserts `preferred_method` is read back as 'nzb' -- with no mocks
+    on the settings machinery itself.
+    """
+
+    def test_preferred_method_is_read_through_the_real_settings_and_env_plumbing(self, tmp_path):
+        from couchpotato.core.settings import Settings
+        from couchpotato.environment import Env
+
+        config_path = tmp_path / 'settings.conf'
+        config_path.write_text('[searcher]\npreferred_method = nzb\n')
+
+        settings = Settings()
+        settings.setFile(str(config_path))
+
+        original_settings = Env._settings
+        Env._settings = settings
+        try:
+            assert Env.setting('preferred_method', section = 'searcher', default = 'both') == 'nzb'
+        finally:
+            Env._settings = original_settings
+
+    def test_an_absent_section_falls_back_to_the_documented_default(self, tmp_path):
+        """No [searcher] section at all -- the production instance's actual
+        state, per FEAT-007's Problem section ("has sat at the `both`
+        default since install"). Env.setting must return the default, not
+        raise.
+        """
+        from couchpotato.core.settings import Settings
+        from couchpotato.environment import Env
+
+        config_path = tmp_path / 'settings.conf'
+        config_path.write_text('[core]\ndebug = 0\n')
+
+        settings = Settings()
+        settings.setFile(str(config_path))
+
+        original_settings = Env._settings
+        Env._settings = settings
+        try:
+            assert Env.setting('preferred_method', section = 'searcher', default = 'both') == 'both'
+        finally:
+            Env._settings = original_settings

--- a/tests/unit/test_protocol_preference.py
+++ b/tests/unit/test_protocol_preference.py
@@ -1,0 +1,119 @@
+"""The download-source preference (`searcher.preferred_method`) ordering.
+
+FEAT-007 Part A. The preference is a HARD preference that FALLS BACK: every
+release of the preferred protocol outranks every release of the other one,
+but when the preferred protocol has nothing usable the other is still used.
+
+Before this change the ordering was hand-rolled twice — in `Searcher.search()`
+and in `Release.forMedia()` — using a `protocol[:3]` string trick against two
+different key paths, with no test coverage at all. The two copies disagreed on
+unknown protocols: sorting `''` ascending floated unknown-protocol releases
+ABOVE nzb when preferring usenet, and buried them when preferring torrents.
+"""
+
+import pytest
+
+from couchpotato.core.helpers.protocol import sort_by_protocol_preference
+
+
+def _items(*protocols):
+    """Items in descending-score order, as both call sites hand them over.
+
+    `pos` records the incoming order so stability can be asserted.
+    """
+    return [{'pos': i, 'protocol': p} for i, p in enumerate(protocols)]
+
+
+def _get(item):
+    return item.get('protocol')
+
+
+def _protocols(items):
+    return [item['protocol'] for item in items]
+
+
+class TestSortByProtocolPreference:
+
+    def test_nzb_preference_puts_every_nzb_before_every_torrent(self):
+        """A1: hard preference — even a last-place nzb beats a first-place torrent."""
+        items = _items('torrent', 'torrent', 'nzb', 'torrent')
+        result = sort_by_protocol_preference(items, 'nzb', _get)
+        assert _protocols(result) == ['nzb', 'torrent', 'torrent', 'torrent']
+
+    def test_torrent_preference_puts_every_torrent_before_every_nzb(self):
+        """A2: the mirror image."""
+        items = _items('nzb', 'nzb', 'torrent', 'nzb')
+        result = sort_by_protocol_preference(items, 'torrent', _get)
+        assert _protocols(result) == ['torrent', 'nzb', 'nzb', 'nzb']
+
+    def test_both_leaves_the_incoming_order_untouched(self):
+        """A3: 'both' means score order only — the caller already sorted by score."""
+        items = _items('torrent', 'nzb', 'torrent', 'nzb')
+        result = sort_by_protocol_preference(items, 'both', _get)
+        assert _protocols(result) == ['torrent', 'nzb', 'torrent', 'nzb']
+        assert [i['pos'] for i in result] == [0, 1, 2, 3]
+
+    def test_score_order_is_preserved_within_each_protocol_group(self):
+        """A4: the sort must be stable — callers sort by score first, then by protocol.
+
+        An unstable sort here would silently scramble score ranking within a
+        group, which is the whole basis for picking a release.
+        """
+        items = _items('torrent', 'nzb', 'torrent', 'nzb', 'torrent')
+        result = sort_by_protocol_preference(items, 'nzb', _get)
+        assert [i['pos'] for i in result] == [1, 3, 0, 2, 4]
+
+    def test_torrent_magnet_ranks_with_torrent(self):
+        """A5: a magnet link is a torrent as far as the preference is concerned."""
+        items = _items('torrent_magnet', 'nzb')
+        assert _protocols(sort_by_protocol_preference(items, 'nzb', _get)) == ['nzb', 'torrent_magnet']
+        assert _protocols(sort_by_protocol_preference(items, 'torrent', _get)) == ['torrent_magnet', 'nzb']
+
+    def test_unknown_protocol_sorts_last_when_preferring_nzb(self):
+        """A6: the bug being fixed — `''` used to sort BEFORE 'nzb' ascending."""
+        items = _items('mystery', 'torrent', 'nzb')
+        result = sort_by_protocol_preference(items, 'nzb', _get)
+        assert _protocols(result) == ['nzb', 'torrent', 'mystery']
+
+    def test_unknown_protocol_sorts_last_when_preferring_torrent_too(self):
+        """A6: unknown is last in BOTH directions, not direction-dependent."""
+        items = _items('mystery', 'torrent', 'nzb')
+        result = sort_by_protocol_preference(items, 'torrent', _get)
+        assert _protocols(result) == ['torrent', 'nzb', 'mystery']
+
+    @pytest.mark.parametrize('bad', [None, '', '   ', 'ftp'])
+    def test_missing_or_unrecognised_protocols_are_treated_as_unknown(self, bad):
+        """A6: absent data must not outrank real data."""
+        items = _items(bad, 'nzb')
+        result = sort_by_protocol_preference(items, 'nzb', _get)
+        assert _protocols(result) == ['nzb', bad]
+
+    def test_protocol_matching_is_case_and_whitespace_insensitive(self):
+        """Provider data is not guaranteed to be normalised."""
+        items = _items('torrent', ' NZB ')
+        result = sort_by_protocol_preference(items, 'nzb', _get)
+        assert _protocols(result) == [' NZB ', 'torrent']
+
+    @pytest.mark.parametrize('preference', ['both', 'nzb', 'torrent', None, '', 'nonsense'])
+    def test_empty_and_single_item_lists_are_safe(self, preference):
+        """A8: no crash on the degenerate cases, for any preference value."""
+        assert sort_by_protocol_preference([], preference, _get) == []
+        single = _items('nzb')
+        assert _protocols(sort_by_protocol_preference(single, preference, _get)) == ['nzb']
+
+    @pytest.mark.parametrize('preference', [None, '', 'nonsense'])
+    def test_an_unrecognised_preference_behaves_as_no_preference(self, preference):
+        """A config read can return None/'' before defaults are applied.
+
+        The safe reading of "I don't understand this setting" is "don't
+        reorder", never "reorder arbitrarily".
+        """
+        items = _items('torrent', 'nzb', 'torrent')
+        result = sort_by_protocol_preference(items, preference, _get)
+        assert _protocols(result) == ['torrent', 'nzb', 'torrent']
+
+    def test_the_input_list_is_not_mutated(self):
+        """Callers reuse their list; sorting must return a new one."""
+        items = _items('torrent', 'nzb')
+        sort_by_protocol_preference(items, 'nzb', _get)
+        assert _protocols(items) == ['torrent', 'nzb']

--- a/tests/unit/test_protocol_preference.py
+++ b/tests/unit/test_protocol_preference.py
@@ -262,6 +262,21 @@ class TestReleaseForMediaOrdering:
         ]
         assert [r['_id'] for r in self._for_media(plugin, 'nzb', docs)] == ['n1', 'broken', 'missing_key']
 
+    def test_a_score_of_none_does_not_crash_the_list(self, plugin):
+        """The `or {}` guard is only half a guard: a doc with an explicit
+        'info': {'score': None} still has a truthy info dict, so `or {}`
+        does not fire, and `.get('score', 0)` returns None (the key IS
+        present) rather than the 0 default. Comparing None to an int during
+        sort raises TypeError. The score coercion must use `tryInt` (already
+        imported in release/main.py) so None/garbage sorts as 0, consistent
+        with the rest of the hardening.
+        """
+        docs = [
+            {'_id': 'nullscore', 'info': {'protocol': 'nzb', 'score': None}},
+            self._doc('t1', 'torrent', 500),
+        ]
+        assert [r['_id'] for r in self._for_media(plugin, 'both', docs)] == ['t1', 'nullscore']
+
     def test_for_media_uses_the_shared_helper(self, plugin):
         """A7: the second copy of the logic must be gone."""
         from unittest.mock import MagicMock, patch

--- a/tests/unit/test_protocol_preference.py
+++ b/tests/unit/test_protocol_preference.py
@@ -330,3 +330,43 @@ class TestFallbackToTheOtherProtocol:
             {'name': 'big.torrent', 'protocol': 'torrent', 'score': 5000, 'size': 4000, 'seeders': 900, 'age': 5},
         ]
         assert self._try(plugin, results) == ['good.nzb']
+
+
+class TestPreferredMethodConfigOption:
+    """A9: named for what it does, without changing what it stores."""
+
+    @staticmethod
+    def _option():
+        from couchpotato.core.media._base.searcher import config
+        for section in config:
+            if section['name'] != 'searcher':
+                continue
+            for group in section['groups']:
+                for option in group['options']:
+                    if option['name'] == 'preferred_method':
+                        return option
+        raise AssertionError('preferred_method option not found in searcher config')
+
+    def test_the_label_says_what_the_setting_does(self):
+        option = self._option()
+        assert option['label'] == 'Preferred download source'
+
+    def test_the_description_explains_the_hard_preference_and_the_fallback(self):
+        description = self._option()['description'].lower()
+        assert 'prefer' in description
+        assert 'falls back' in description
+
+    def test_the_value_labels_are_plain_english(self):
+        labels = [label for label, _stored in self._option()['values']]
+        assert labels == ['No preference', 'Usenet (NZB)', 'Torrents']
+
+    def test_the_stored_values_are_unchanged(self):
+        """Backwards compatibility: existing settings.conf files must keep working.
+
+        Only the display strings change. `preferred_method = nzb` written by an
+        older build must still be read as 'nzb'.
+        """
+        stored = [value for _label, value in self._option()['values']]
+        assert stored == ['both', 'nzb', 'torrent']
+        assert self._option()['default'] == 'both'
+        assert self._option()['type'] == 'dropdown'

--- a/tests/unit/test_protocol_preference.py
+++ b/tests/unit/test_protocol_preference.py
@@ -310,10 +310,21 @@ class TestFallbackToTheOtherProtocol:
     """A10: the preference orders candidates; it never excludes them.
 
     `tryDownloadResult` walks the preference-ordered list and takes the first
-    release that passes the filters — so when the preferred protocol has
-    nothing usable, the other one is still downloaded. That is the designed
-    behaviour ("fall back to torrent"), and it is what makes the preference
-    safe to turn on.
+    release that passes the FILTERS (status / minimum_score / size / seeders)
+    -- so when the preferred protocol has nothing that passes those filters,
+    the other one is still downloaded. That is the designed behaviour
+    ("fall back to torrent"), and it is covered below.
+
+    That is NOT the same as "any failure of the preferred release falls
+    back". If the preferred release passes every filter but the DOWNLOAD
+    ITSELF then fails (downloader disabled/unreachable, provider error --
+    `release.download` returning something other than True or the sentinel
+    'try_next'), `tryDownloadResult` hits `break` and the non-preferred
+    release is never tried. This is pre-existing behaviour, not a
+    regression introduced here, and it is a known limitation, not something
+    this test suite claims is "safe" -- see
+    test_a_download_failure_does_not_fall_through_to_the_other_protocol
+    below, which pins it explicitly.
     """
 
     @pytest.fixture
@@ -340,6 +351,32 @@ class TestFallbackToTheOtherProtocol:
             plugin.tryDownloadResult(results, {'_id': 'movie-1'}, {'minimum_score': minimum_score, 'index': 0})
 
         return downloaded
+
+    def _try_with_download_outcomes(self, plugin, results, outcomes, minimum_score = 1):
+        """Like `_try`, but `release.download`'s return value is controlled
+        per release name via `outcomes` (defaulting to True), so a
+        download-failure scenario can be driven without touching the
+        filters.
+        """
+        from unittest.mock import MagicMock, patch
+
+        attempted = []
+
+        def fake_fire_event(event, *args, **kwargs):
+            if event == 'release.download':
+                name = kwargs.get('data', {}).get('name')
+                attempted.append(name)
+                return outcomes.get(name, True)
+            return None
+
+        env = MagicMock()
+        env.setting.return_value = 1  # torrent.minimum_seeders
+
+        with patch('couchpotato.core.plugins.release.main.fireEvent', side_effect = fake_fire_event), \
+                patch('couchpotato.core.plugins.release.main.Env', env):
+            plugin.tryDownloadResult(results, {'_id': 'movie-1'}, {'minimum_score': minimum_score, 'index': 0})
+
+        return attempted
 
     def test_a_torrent_is_downloaded_when_no_nzb_was_found(self, plugin):
         """Preference nzb, but the search returned torrents only."""
@@ -368,6 +405,30 @@ class TestFallbackToTheOtherProtocol:
             {'name': 'big.torrent', 'protocol': 'torrent', 'score': 5000, 'size': 4000, 'seeders': 900, 'age': 5},
         ]
         assert self._try(plugin, results) == ['good.nzb']
+
+    def test_a_download_failure_does_not_fall_through_to_the_other_protocol(self, plugin):
+        """KNOWN LIMITATION, pinned deliberately, not a regression.
+
+        The preferred nzb passes every filter (score, size, age) and is
+        tried first. `release.download` then returns False for it --
+        simulating a disabled/unreachable downloader or a provider error,
+        as opposed to a filter rejection. `tryDownloadResult` only advances
+        to the next candidate when a release is rejected by the filters or
+        when `release.download` returns the sentinel 'try_next'; any other
+        return value (including False) hits `break`, so the torrent behind
+        it is never attempted. This contradicts a plain reading of the
+        setting's "falls back" description for this one case -- the
+        description has been narrowed to say the fallback covers "no
+        acceptable release of this type is found", which this scenario
+        satisfies (an nzb was found and was acceptable) but which still
+        doesn't get downloaded.
+        """
+        results = [
+            {'name': 'good.nzb', 'protocol': 'nzb', 'score': 800, 'size': 4000, 'age': 5},
+            {'name': 'big.torrent', 'protocol': 'torrent', 'score': 5000, 'size': 4000, 'seeders': 900, 'age': 5},
+        ]
+        attempted = self._try_with_download_outcomes(plugin, results, outcomes = {'good.nzb': False})
+        assert attempted == ['good.nzb']
 
 
 class TestPreferredMethodConfigOption:

--- a/tests/unit/test_protocol_preference.py
+++ b/tests/unit/test_protocol_preference.py
@@ -339,6 +339,60 @@ class TestReleaseForMediaOrdering:
             "forMedia()'s getter must read the protocol from rel['info']['protocol']"
 
 
+class TestScannerCreatedReleasesRankAsUnknown:
+    """FIX 9: an undocumented behavioural change for library-scanned releases.
+
+    `Release.add()` (release/main.py, around lines 180-188) creates release
+    documents with NO `info` key at all -- these represent movies the
+    library scanner found, i.e. copies the user already owns. Under a
+    non-`both` `preferred_method` these now rank as unknown protocol and
+    sort LAST, where under the old direction-dependent `[:3]` sort they
+    sorted FIRST for an nzb preference (`''[:3]` == '' sorts before 'nzb'
+    ascending). This is an accepted, documented consequence of making
+    unknown-protocol handling direction-independent (see the "Unknown
+    protocol sorts last" decision in the FEAT-007 spec), not a new defect.
+
+    The knock-on: movie_detail.html's header picks completed_releases[0], so
+    for a movie with BOTH a scanner-created 'done' release and another
+    completed release carrying protocol info, which one the header shows
+    can flip. This test pins forMedia's output order for that scenario so
+    the behaviour is locked and visible rather than incidental.
+    """
+
+    @pytest.fixture
+    def plugin(self):
+        from couchpotato.core.plugins.release.main import Release
+        return object.__new__(Release)
+
+    def _for_media(self, plugin, preference, docs):
+        from unittest.mock import MagicMock, patch
+
+        db = MagicMock()
+        db.get_many.return_value = [{'_id': d['_id']} for d in docs]
+        db.get.side_effect = lambda _index, _id: next(d for d in docs if d['_id'] == _id)
+
+        with patch('couchpotato.core.plugins.release.main.get_db', return_value = db), \
+                patch.object(plugin, 'conf', return_value = preference):
+            return plugin.forMedia('movie-1')
+
+    def test_a_scanner_created_release_sorts_after_a_protocol_carrying_completed_release_under_nzb_preference(self, plugin):
+        """Both releases are 'completed' in movie_detail.html's sense (status
+        in ['done', 'seeding', 'downloaded']); the scanner-created one has no
+        'info' block at all, exactly as Release.add() leaves it. Under a
+        preference for nzb, the torrent-with-info release now sorts first
+        and the scanner-created release sorts last -- so
+        completed_releases[0] would flip from the scanner-created release
+        (its only candidate before this PR, when both docs are unknown/no
+        preference) to the protocol-carrying one.
+        """
+        docs = [
+            {'_id': 'scanned', 'status': 'done'},  # Release.add(): no 'info' key
+            {'_id': 'other', 'status': 'downloaded', 'info': {'protocol': 'torrent', 'score': 100}},
+        ]
+        result = self._for_media(plugin, 'nzb', docs)
+        assert [r['_id'] for r in result] == ['other', 'scanned']
+
+
 class TestFallbackToTheOtherProtocol:
     """A10: the preference orders candidates; it never excludes them.
 

--- a/tests/unit/test_protocol_preference.py
+++ b/tests/unit/test_protocol_preference.py
@@ -195,7 +195,16 @@ class TestSearcherSearchOrdering:
         assert [r['name'] for r in ordered] == ['best.nzb', 'mid.nzb', 'worst.nzb', 'a.torrent']
 
     def test_search_uses_the_shared_helper(self, searcher):
-        """A7: no second hand-rolled copy of this logic may survive."""
+        """A7: no second hand-rolled copy of this logic may survive.
+
+        Asserting only `helper.called` would pass even if the preference or
+        the getter were wired up wrong (e.g. reading the wrong config key,
+        or handing over a getter that reaches into the wrong shape of
+        item). Pin the actual contract: the preference read from config is
+        passed through unchanged, and the getter extracts the protocol from
+        `rel['protocol']` -- the shape search() results have, as opposed to
+        forMedia()'s `rel['info']['protocol']`.
+        """
         from unittest.mock import patch
 
         results = [{'name': 'x.nzb', 'protocol': 'nzb', 'score': 1}]
@@ -207,6 +216,14 @@ class TestSearcherSearchOrdering:
             searcher.search(['nzb'], {'type': 'movie'}, {'identifier': '1080p'})
 
         assert helper.called, 'Searcher.search must delegate to sort_by_protocol_preference'
+
+        args, kwargs = helper.call_args
+        preference = args[1] if len(args) > 1 else kwargs['preference']
+        get_protocol = args[2] if len(args) > 2 else kwargs['get_protocol']
+
+        assert preference == 'nzb', 'the preference read from conf() must be passed through unchanged'
+        assert get_protocol({'protocol': 'torrent'}) == 'torrent', \
+            "search()'s getter must read the protocol from rel['protocol']"
 
 
 class TestReleaseForMediaOrdering:
@@ -289,7 +306,15 @@ class TestReleaseForMediaOrdering:
         assert [r['_id'] for r in self._for_media(plugin, 'both', docs)] == ['t1', 'nullscore']
 
     def test_for_media_uses_the_shared_helper(self, plugin):
-        """A7: the second copy of the logic must be gone."""
+        """A7: the second copy of the logic must be gone.
+
+        Asserting only `helper.called` would pass even if the preference or
+        the getter were wired up wrong. Pin the actual contract: the
+        preference read from config is passed through unchanged, and the
+        getter extracts the protocol from `rel['info']['protocol']` -- the
+        shape release documents have, as opposed to search()'s
+        `rel['protocol']`.
+        """
         from unittest.mock import MagicMock, patch
 
         docs = [self._doc('n1', 'nzb', 100)]
@@ -304,6 +329,14 @@ class TestReleaseForMediaOrdering:
             plugin.forMedia('movie-1')
 
         assert helper.called, 'Release.forMedia must delegate to sort_by_protocol_preference'
+
+        args, kwargs = helper.call_args
+        preference = args[1] if len(args) > 1 else kwargs['preference']
+        get_protocol = args[2] if len(args) > 2 else kwargs['get_protocol']
+
+        assert preference == 'nzb', 'the preference read from conf() must be passed through unchanged'
+        assert get_protocol({'info': {'protocol': 'torrent'}}) == 'torrent', \
+            "forMedia()'s getter must read the protocol from rel['info']['protocol']"
 
 
 class TestFallbackToTheOtherProtocol:


### PR DESCRIPTION
Part A of `specs/FEAT-007-preferred-source-and-release-list-controls.md`. Part B (sort/filter controls on the release list) follows in its own PR.

## Why

"Most of my results are torrents and I prefer NZB." The tri-state setting for this already existed — but it was labelled **"First search"**, described as *"Which of the methods do you prefer"*, and had **zero test coverage**. Production has no `[searcher]` section at all, so it has sat at the `both` default since install.

Under `both`, torrents don't compete with NZBs on merit: `score/main.py:36-42` adds `seeders * 100/15 + leechers * 100/30`, so a 50-seeder torrent gains **+333** against a name/quality vocabulary that spans roughly -40 to +15. That bias is deliberately **out of scope** here (noted in the spec as follow-up work) — this PR makes the existing preference usable instead.

## What changed

- **Relabelled** to *Preferred download source* / *No preference · Usenet (NZB) · Torrents*, with a description that states the fallback accurately. **Stored values are unchanged** (`both`/`nzb`/`torrent`), so existing `settings.conf` files keep working.
- **One shared helper** (`couchpotato/core/helpers/protocol.py`) replaces the sort that was hand-rolled twice — in `Searcher.search()` (what gets downloaded) and `Release.forMedia()` (what the UI lists) — with a `protocol[:3]` string trick against two different key paths.
- **Bug fix:** unknown/missing protocols sorted `''`, which floated them **above** NZBs under a usenet preference and buried them under a torrent one. Ranking is now explicit and unknown sorts last in both directions.
- Hardening for partially-written release documents (`'info': None`, `'info': {'score': None}`, non-string protocol) — any of which took out the whole movie-detail page, since `forMedia`'s callers don't guard it.
- **+52 tests** where there were none.

## Behaviour

No change for `both`/unset users. The hard preference and its fallback are pre-existing behaviour, now documented and tested rather than incidental.

## Two things worth reviewer attention

1. **The fallback has a real limitation, now pinned rather than papered over.** `tryDownloadResult` advances to the next candidate when a release is rejected by the *filters* — not when the *download* fails. If the preferred NZB passes every filter and SABnzbd is down, it `break`s and the torrent behind it is never tried. Pre-existing; the setting's description was narrowed to match, and `test_a_download_failure_does_not_fall_through_to_the_other_protocol` keeps the gap visible.

2. **Scanner-created releases move.** `Release.add()` writes documents with no `info` key — the copies you already own. They now rank unknown and sort last. Knock-on: both `movie_detail.html:20-23` and `movie_cards.html:12-16` pick `completed_releases[0]` for the quality/status they display, so which one they show can flip. Accepted as a correct consequence of the fix, documented in the spec, pinned by a test.

## Verification

`make verify` green: ruff clean, **1517** Python unit tests, 194 UI unit, 133/135 E2E (the 2 failures are the known-flaky nav tests; both pass in isolation).

Three local review rounds. They caught, among other things, a test that passed against the unfixed code (found by mutation testing), and a regression introduced by a fix — `tryInt` coercion truncating float scores so 300.8 and 300.2 tied. Both are in the history rather than in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TscnMZYz1W2Hp3RNXGHfQX