### PR TITLE
M1a: authentication and web-surface security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install ruff
-      run: pip install 'ruff==0.16.0'
+      run: pip install 'ruff==0.16.1'
 
     - name: Run ruff
       run: ruff check .
@@ -131,7 +131,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install ruff
-      run: pip install 'ruff==0.16.0'
+      run: pip install 'ruff==0.16.1'
 
     - name: ruff security lint (bandit S rules)
       continue-on-error: true

--- a/couchpotato/__init__.py
+++ b/couchpotato/__init__.py
@@ -54,21 +54,52 @@ def get_db():
 
 # --- Authentication ---
 
+def auth_is_required() -> bool:
+    """Is the web interface gated on a session?
+
+    An EXPLICIT setting, not an inference from two unrelated fields. The old
+    gate was `if username and password:`, which meant a blank username silently
+    disabled authentication -- and the settings copy put "Leave empty to
+    disable authentication" on the USERNAME field, so the field that turned
+    auth off was the one whose description promised exactly that. Driven
+    directly, three of the four credential combinations returned "fully
+    public", including password-set-with-blank-username.
+
+    Absent (an upgrade from any config.ini written before this change) derives
+    from whether a password is set, so an install that had bothered to set one
+    stays protected rather than falling open on upgrade. `runner.py` writes the
+    resolved value back once at startup, after which it is an explicit 0 or 1
+    the operator can find with `grep` -- which matters, because grepping
+    config.ini is the documented lock-out recovery path.
+
+    Deliberately NOT a tri-state `None` default. `registerDefaults`
+    materialises the literal `auth_required = None` into config.ini on first
+    boot and `Env.setting`'s own default is `''`, so the natural
+    `Env.setting('auth_required', type='bool')` reads falsy and auth stays off
+    on every install, silently, with no failing test and no log line.
+    """
+    configured = Env.setting('auth_required', default=None)
+
+    if configured is None or configured == '':
+        return bool(Env.setting('password'))
+
+    if isinstance(configured, str):
+        return configured.strip().lower() in ('1', 'true', 'yes', 'on')
+    return bool(configured)
+
+
 def get_current_user(request: Request):
     """FastAPI dependency for cookie-based auth."""
-    username = Env.setting('username')
-    password = Env.setting('password')
-
-    if username and password:
-        user = request.cookies.get('user')
-        if not user:
-            return None
-        api_key = Env.setting('api_key')
-        if api_key and hmac.compare_digest(str(user).encode('utf-8'), str(api_key).encode('utf-8')):
-            return user
-        return None
-    else:
+    if not auth_is_required():
         return True
+
+    user = request.cookies.get('user')
+    if not user:
+        return None
+    api_key = Env.setting('api_key')
+    if api_key and hmac.compare_digest(str(user).encode('utf-8'), str(api_key).encode('utf-8')):
+        return user
+    return None
 
 
 def require_auth(request: Request):

--- a/couchpotato/__init__.py
+++ b/couchpotato/__init__.py
@@ -303,7 +303,18 @@ def create_app(api_key: str, web_base: str, static_dir: str = None) -> FastAPI:
             p_param = request.query_params.get('p', '')
 
             api_key_val = None
-            if (u_param == md5(username) or not username) and (check_password(p_param, password) or not password):
+            # `password and ...`, the same fix as login_post and for the same
+            # reason -- `or not password` short-circuited the credential check
+            # to True whenever no password was configured.
+            #
+            # Worse here than at login: this returns the api_key itself, in a
+            # JSON body, over GET, with the credentials in the query string --
+            # so the request line lands in access logs, proxy logs and browser
+            # history, and an unauthenticated caller received the key outright.
+            # The `u` parameter is no protection: it is the md5 of the
+            # username, which is not a secret.
+            if password and (u_param == md5(username) or not username) \
+                    and check_password(p_param, password):
                 api_key_val = Env.setting('api_key')
                 if password and is_legacy_md5_hash(password):
                     Env.setting('password', value=hash_password(p_param))

--- a/couchpotato/__init__.py
+++ b/couchpotato/__init__.py
@@ -301,7 +301,24 @@ def create_app(api_key: str, web_base: str, static_dir: str = None) -> FastAPI:
         form_password_md5 = md5(form_password)
 
         api_key_val = None
-        if (form.get('username') == username or not username) and (check_password(form_password_md5, password) or not password):
+        # `password and ...`, NOT `... or not password`.
+        #
+        # The old spelling short-circuited the entire credential check to True
+        # whenever no password was configured, so ANY submitted credentials
+        # were accepted and a valid `user` cookie -- the api_key itself -- was
+        # written to the browser. Not merely a UI bypass: that cookie is the
+        # credential the whole API authenticates with.
+        #
+        # A blank password already means `get_current_user` returns True and
+        # the instance is open, so refusing the login here costs nobody a
+        # session they needed. What it closes is the state PR 2 introduces:
+        # `auth_required` ON with no password set, one click away in the
+        # settings UI. That instance LOOKS protected -- there is a login page,
+        # it asks for credentials, it refuses nothing -- and admits everyone.
+        # A door locked in appearance only is worse than an open one, because
+        # it stops the operator looking for the lock.
+        if password and (form.get('username') == username or not username) \
+                and check_password(form_password_md5, password):
             api_key_val = Env.setting('api_key')
             if password and is_legacy_md5_hash(password):
                 Env.setting('password', value=hash_password(form_password_md5))

--- a/couchpotato/__init__.py
+++ b/couchpotato/__init__.py
@@ -81,11 +81,43 @@ def auth_is_required() -> bool:
     configured = Env.setting('auth_required', default=None)
 
     if configured is None or configured == '':
-        return bool(Env.setting('password'))
+        return _auth_required_from_password()
 
     if isinstance(configured, str):
-        return configured.strip().lower() in ('1', 'true', 'yes', 'on')
+        # A STRING is the normal case on the startup path, not an edge case.
+        # `runner.py` calls this before `loader.run()` has registered the
+        # option's type, so `Settings.getType` falls back to 'unicode', which
+        # `_coerce_value` does not coerce -- the raw ConfigParser string
+        # arrives here. `bool('0')` is True, so this branch is the only thing
+        # keeping an explicit `auth_required = 0` from turning auth ON.
+        value = configured.strip().lower()
+        if value in ('1', 'true', 'yes', 'on'):
+            return True
+        if value in ('0', 'false', 'no', 'off'):
+            return False
+
+        # Neither. config.ini is the documented lock-out recovery path, so it
+        # gets hand-edited and typos here are expected. Reading an
+        # unrecognised value as "off" would silently make the server public;
+        # reading it as "on" would lock out an install with no password. Fall
+        # back to the same derivation used when the key is absent, which does
+        # neither.
+        log.error('Unrecognised auth_required value %r in config.ini; expected '
+                  '0 or 1. Falling back to "required only if a password is '
+                  'set". Fix the value to remove this warning.', configured)
+        return _auth_required_from_password()
+
     return bool(configured)
+
+
+def _auth_required_from_password() -> bool:
+    """Derive the gate from whether a password exists.
+
+    Used when `auth_required` is absent or unreadable. Keeps a
+    password-protected install protected without ever producing the
+    auth-on-with-no-password state that nothing can satisfy.
+    """
+    return bool(Env.setting('password'))
 
 
 def get_current_user(request: Request):

--- a/couchpotato/core/_base/_core.py
+++ b/couchpotato/core/_base/_core.py
@@ -270,10 +270,26 @@ config = [{
             'wizard': True,
             'options': [
                 {
+                    'name': 'auth_required',
+                    'default': 0,
+                    'type': 'bool',
+                    'label': 'Require login',
+                    'description': 'Require login for the web interface. Turned on '
+                                   'automatically the first time a password is set. '
+                                   'Turn off only for a trusted LAN.',
+                },
+                {
                     'name': 'username',
                     'default': '',
                     'label': 'Username',
-                    'description': 'Username for web interface login. Leave empty to disable authentication.',
+                    # The "leave empty to disable authentication" copy that used to
+                    # live here was not merely misleading, it described a real trap:
+                    # the old gate was `if username and password`, so a blank
+                    # username DID disable auth -- including for someone who had set
+                    # a password. The off-switch is `auth_required` now, and this
+                    # field means what it says.
+                    'description': 'Username for web interface login. Leave empty to '
+                                   'accept any username.',
                     'ui-meta' : 'rw',
                 },
                 {
@@ -281,7 +297,8 @@ config = [{
                     'default': '',
                     'type': 'password',
                     'label': 'Password',
-                    'description': 'Password for web interface login.',
+                    'description': 'Password for web interface login. Setting one turns '
+                                   '"Require login" on.',
                 },
                 {
                     'name': 'port',

--- a/couchpotato/core/_base/_core.py
+++ b/couchpotato/core/_base/_core.py
@@ -113,6 +113,43 @@ class Core(Plugin):
         radius, and a wrong name with a correct docstring is safer than a
         rename made at the same time as a security fix.
         """
+        # Keep `auth_required` honest, in BOTH directions.
+        #
+        # The settings copy says "Setting one turns 'Require login' on", and
+        # that was false: `auth_required` was written in exactly one place --
+        # runner.py's startup migration -- gated on the key being ABSENT. After
+        # the first boot of a passwordless install the key is an explicit 0, so
+        # a user who then set a password through the wizard or the settings UI
+        # got no authentication at all while both field descriptions told them
+        # otherwise. Copy promising an auth behaviour the code does not
+        # implement is the exact defect class this PR exists to close.
+        #
+        # Clearing the password turns it back OFF, and that half is not
+        # symmetry for its own sake -- it closes a LOCKOUT. `auth_required = 1`
+        # with no password denies every request (get_current_user) AND refuses
+        # every login (login_post now requires a configured password), leaving
+        # no way in short of hand-editing config.ini. Reachable simply by
+        # setting a password and later clearing it. Neither of those two fixes
+        # created that state alone; together they did.
+        #
+        # An operator who wants a password AND an open instance can still turn
+        # "Require login" off explicitly afterwards -- that setting remains
+        # theirs to set. This only moves it when the password itself changes.
+        # Guarded, and NOT silently: hashing the password must not fail
+        # because a secondary write did, but a swallowed failure here puts the
+        # instance back in the state this whole block exists to prevent -- so
+        # it is logged at ERROR, naming the consequence, rather than passed
+        # over. (It also keeps this hook callable in isolation, e.g. from a
+        # unit test, where no settings store is loaded.)
+        from couchpotato.environment import Env
+        try:
+            Env.setting('auth_required', value=1 if value else 0)
+        except Exception:
+            log.error('Password saved but could not update "auth_required" -- '
+                      'authentication may not match the password you just set. '
+                      'Check Settings > Server > Require login. %s',
+                      traceback.format_exc())
+
         return hash_password(md5(value)) if value else ''
 
     def checkApikey(self, value):
@@ -301,8 +338,8 @@ config = [{
                     'type': 'bool',
                     'label': 'Require login',
                     'description': 'Require login for the web interface. Turned on '
-                                   'automatically the first time a password is set. '
-                                   'Turn off only for a trusted LAN.',
+                                   'whenever you set a password, and off again if you '
+                                   'clear it. Turn off here only for a trusted LAN.',
                 },
                 {
                     'name': 'username',
@@ -324,7 +361,8 @@ config = [{
                     'type': 'password',
                     'label': 'Password',
                     'description': 'Password for web interface login. Setting one turns '
-                                   '"Require login" on.',
+                                   '"Require login" on; clearing it turns it off, so you '
+                                   'cannot lock yourself out.',
                 },
                 {
                     'name': 'port',

--- a/couchpotato/core/_base/_core.py
+++ b/couchpotato/core/_base/_core.py
@@ -8,7 +8,7 @@ import webbrowser
 
 from couchpotato.api import addApiView
 from couchpotato.core.event import fireEvent, addEvent
-from couchpotato.core.helpers.variable import cleanHost, md5, isSubFolder, compareVersions
+from couchpotato.core.helpers.variable import cleanHost, md5, isSubFolder, compareVersions, hash_password
 from couchpotato.core.logger import CPLog
 from couchpotato.core.plugins.base import Plugin
 from couchpotato.environment import Env
@@ -87,7 +87,33 @@ class Core(Plugin):
             log.error('OpenSSL not available, please install for better requests validation: `https://pyopenssl.readthedocs.org/en/latest/install.html`: %s', traceback.format_exc())
 
     def md5Password(self, value):
-        return md5(value) if value else ''
+        """Hash a password on its way into config.ini.
+
+        The name is historical and now misleading: this returns **bcrypt**, not
+        MD5. It used to return `md5(value)`, so every password set through the
+        settings UI or the first-run wizard was written to config.ini as an
+        unsalted MD5 -- reversible for any password in a rainbow table.
+
+        bcrypt was reached only by the login-time upgrade
+        (`couchpotato/__init__.py:308`), which rehashes on a successful login
+        and therefore never ran for anyone who had not logged in. Until
+        `auth_required` landed, the server never asked anyone to log in. So the
+        users this hashing exists to protect were exactly the ones still on
+        MD5.
+
+        bcrypt OVER `md5(value)`, not over the plaintext. That is not a choice
+        made here: `login_post` computes `md5(form_password)` and passes it to
+        `check_password`, so hashing the plaintext directly would lock out
+        every existing and future user. Changing the inner encoding needs its
+        own migration and login-time upgrade, and is not a tidy-up to fold in
+        here.
+
+        The event name (`setting.save.core.password`) and this method name stay
+        as they are: renaming them is a separate change with its own blast
+        radius, and a wrong name with a correct docstring is safer than a
+        rename made at the same time as a security fix.
+        """
+        return hash_password(md5(value)) if value else ''
 
     def checkApikey(self, value):
         return value if value and len(value) > 3 else uuid4().hex

--- a/couchpotato/core/_base/_core.py
+++ b/couchpotato/core/_base/_core.py
@@ -135,15 +135,27 @@ class Core(Plugin):
         # An operator who wants a password AND an open instance can still turn
         # "Require login" off explicitly afterwards -- that setting remains
         # theirs to set. This only moves it when the password itself changes.
-        # Guarded, and NOT silently: hashing the password must not fail
-        # because a secondary write did, but a swallowed failure here puts the
-        # instance back in the state this whole block exists to prevent -- so
-        # it is logged at ERROR, naming the consequence, rather than passed
-        # over. (It also keeps this hook callable in isolation, e.g. from a
-        # unit test, where no settings store is loaded.)
-        from couchpotato.environment import Env
+        # Set, do NOT save. `Env.setting(attr, value=...)` calls `save()`
+        # immediately, and `Settings.saveView` then does its own
+        # `set(...); save()` after this hook returns -- so going through
+        # Env.setting would persist auth_required in a SEPARATE, EARLIER write
+        # than the password itself. A crash, a full volume or a kill between
+        # those two saves leaves authentication ON with no password stored:
+        # every request denied, every login refused, no way back short of
+        # hand-editing config.ini. That is precisely the lockout this block
+        # exists to prevent, reintroduced through a different door.
+        #
+        # Touching only the in-memory parser lets the caller's single
+        # `save()` persist both -- and that save is atomic (T2.0), so the pair
+        # lands together or not at all.
+        #
+        # Guarded, and NOT silently: hashing must not fail because a secondary
+        # write did, but a swallowed failure here restores the very state this
+        # prevents, so it is logged at ERROR naming the consequence.
         try:
-            Env.setting('auth_required', value=1 if value else 0)
+            settings = Env.get('settings')
+            settings.addSection('core')
+            settings.set('core', 'auth_required', 1 if value else 0)
         except Exception:
             log.error('Password saved but could not update "auth_required" -- '
                       'authentication may not match the password you just set. '

--- a/couchpotato/core/helpers/variable.py
+++ b/couchpotato/core/helpers/variable.py
@@ -137,10 +137,20 @@ def check_password(password, stored_hash):
             return False
 
     if is_legacy_md5_hash(stored_value):
-        # Legacy MD5 migration path: compare against existing MD5 hash so users
-        # can log in and have their password transparently upgraded to bcrypt.
-        # MD5 is used here only to verify an already-stored legacy hash, not to
-        # create new security-sensitive hashes. New passwords are always bcrypt.
+        # Legacy MD5 migration path: compare against an existing MD5 hash so
+        # users can log in and have their password transparently upgraded to
+        # bcrypt. MD5 is used here only to verify an already-stored legacy
+        # hash, never to create one.
+        #
+        # This comment used to end "New passwords are always bcrypt." That was
+        # FALSE from the day it was written: `_core.py`'s `md5Password`, wired
+        # to `setting.save.core.password`, stored `md5(value)` for every
+        # password set through the settings UI or the wizard, and bcrypt was
+        # reached only by the upgrade below -- which never runs for anyone who
+        # has not logged in. Fixed in `md5Password`; the sentence is corrected
+        # here because it is why nobody looked. A reassuring comment the code
+        # contradicts does not merely fail to help, it actively stops the next
+        # reader checking.
         # lgtm[py/weak-sensitive-data-hashing]
         return (
             hmac.compare_digest(password_value, stored_value) or

--- a/couchpotato/core/logger.py
+++ b/couchpotato/core/logger.py
@@ -42,8 +42,21 @@ _REPLACE_PRIVATE = ['api', 'apikey', 'api_key', 'password', 'username', 'h', 'ui
 #: appears in ordinary dict-dumping messages, and eating those destroys the
 #: diagnostic the operator needed. A redaction nobody can read around is one
 #: that gets switched off.
+#:
+#: Matched case-INSENSITIVELY and with an optional `[\w-]*` prefix, so
+#: `access_token=`, `bot_token=` and `X-Plex-Token=` are caught as well as
+#: `token=`. That is not hypothetical tidiness:
+#: `notifications/plex/server.py:85` builds `...?X-Plex-Token=%s` and hands it
+#: to `urlopen`, and `http_client.py:236` logs the whole URL at INFO -- so the
+#: Plex auth token was written to the log on every notification, matched by
+#: neither pass (the query-string one wants an exact lowercase `token` right
+#: after `?`/`&`; this one was case-sensitive and anchored on `\b`).
 _REPLACE_PRIVATE_BARE = ['api_key', 'apikey', 'password', 'passkey', 'token', 'authkey',
-                         'torrent_pass', 'sid']
+                         'torrent_pass']
+
+#: Names too SHORT to carry a prefix match. `sid` is three characters, and
+#: `[\w-]*sid=` would eat ordinary words. Matched exactly, case-insensitively.
+_REPLACE_PRIVATE_BARE_EXACT = ['sid']
 
 
 class ColorFormatter(logging.Formatter):
@@ -105,10 +118,18 @@ class PrivacyFilter(logging.Filter):
         # the 404. A filter that swallows the line removes the reason the line
         # was logged, and the operator turns it off.
         #
-        # \b on the left so `mytoken=` is left alone rather than
-        # half-redacted.
+        # Longer names take an optional `[\w-]*` prefix and are matched
+        # case-insensitively, so `access_token=` and `X-Plex-Token=` are caught
+        # too; short ones (see _REPLACE_PRIVATE_BARE_EXACT) are matched exactly,
+        # because prefix-matching three characters eats ordinary words.
         for replace in _REPLACE_PRIVATE_BARE:
-            msg = re.sub(r'\b(%s=)[^\s&,;)\]}\'"]+' % replace, r'\1xxx', msg)
+            msg = re.sub(r'[\w-]*%s=[^\s&,;)\]}\'"]+' % replace,
+                         lambda m: m.group(0).split('=', 1)[0] + '=xxx', msg,
+                         flags=re.IGNORECASE)
+        for replace in _REPLACE_PRIVATE_BARE_EXACT:
+            msg = re.sub(r'\b%s=[^\s&,;)\]}\'"]+' % replace,
+                         lambda m: m.group(0).split('=', 1)[0] + '=xxx', msg,
+                         flags=re.IGNORECASE)
 
         # Replace api key.
         #

--- a/couchpotato/core/logger.py
+++ b/couchpotato/core/logger.py
@@ -24,7 +24,26 @@ INFO2 = 21
 logging.addLevelName(INFO2, 'INFO')
 
 # Privacy filter patterns
-_REPLACE_PRIVATE = ['api', 'apikey', 'api_key', 'password', 'username', 'h', 'uid', 'key', 'passkey']
+_REPLACE_PRIVATE = ['api', 'apikey', 'api_key', 'password', 'username', 'h', 'uid', 'key', 'passkey',
+                    'token', 'authkey', 'torrent_pass', 'sid']
+
+#: Names redacted even OUTSIDE a query string, i.e. bare `name=value` in prose.
+#:
+#: The query-param pass below only matches `?name=` and `&name=`, so anything
+#: logged outside a URL went through in the clear. Three live call sites did
+#: exactly that: `notifications/telegrambot.py:37` logs `token=%s` at ERROR
+#: (so it reaches production logs, and a Telegram bot token is a full
+#: send-as-this-bot credential), `downloaders/synology.py:125` logs `sid=%s`,
+#: and `http_client.py:236` logs whole URLs whose parameter names were not all
+#: in the list above.
+#:
+#: Deliberately NARROWER than _REPLACE_PRIVATE: `h`, `uid`, `key` and
+#: `username` are too generic to match bare assignments safely -- `key=` alone
+#: appears in ordinary dict-dumping messages, and eating those destroys the
+#: diagnostic the operator needed. A redaction nobody can read around is one
+#: that gets switched off.
+_REPLACE_PRIVATE_BARE = ['api_key', 'apikey', 'password', 'passkey', 'token', 'authkey',
+                         'torrent_pass', 'sid']
 
 
 class ColorFormatter(logging.Formatter):
@@ -78,6 +97,18 @@ class PrivacyFilter(logging.Filter):
         for replace in _REPLACE_PRIVATE:
             msg = re.sub(r'(\?%s=)[^\&]+' % replace, r'?%s=xxx' % replace, msg)
             msg = re.sub(r'(&%s=)[^\&]+' % replace, r'&%s=xxx' % replace, msg)
+
+        # Bare `name=value`, outside any query string.
+        #
+        # Stops at whitespace or at any of `&,;)]}'"` so the REST of the
+        # message survives -- `token=SECRET and the response was 404` must keep
+        # the 404. A filter that swallows the line removes the reason the line
+        # was logged, and the operator turns it off.
+        #
+        # \b on the left so `mytoken=` is left alone rather than
+        # half-redacted.
+        for replace in _REPLACE_PRIVATE_BARE:
+            msg = re.sub(r'\b(%s=)[^\s&,;)\]}\'"]+' % replace, r'\1xxx', msg)
 
         # Replace api key.
         #

--- a/couchpotato/core/settings.py
+++ b/couchpotato/core/settings.py
@@ -274,12 +274,39 @@ class Settings:
         path = os.path.realpath(self.file)
         directory = os.path.dirname(path) or '.'
 
+        # Carry the existing file's identity across the replace.
+        #
+        # `os.replace` swaps in a NEW inode; the truncate-then-write this
+        # replaced kept the old one, so owner, group and ACLs survived for
+        # free. They have to be copied deliberately now, or a config.ini with a
+        # managed group -- readable by a backup account, say -- silently
+        # becomes owned by the server process on the next save.
         try:
-            # `& 0o777` rather than stat.S_IMODE: `stat` is not imported here,
-            # and this fix should not need to add a module-level import.
-            mode = os.stat(path).st_mode & 0o777
+            existing = os.stat(path)
+            mode = existing.st_mode & 0o777
+            owner = (existing.st_uid, existing.st_gid)
         except OSError:
             mode = 0o600
+            owner = None
+
+        # Clear the WORLD bits, always.
+        #
+        # Preserving the mode exactly would mean every config.ini written
+        # before this change -- created 0644 by `open(file, 'w')` under a
+        # default umask -- stays world-readable forever, through every
+        # subsequent save. The file holds the api_key, the password hash, and
+        # every downloader and notifier credential, so the fix would harden new
+        # installs and do nothing for the ones that already have the problem.
+        #
+        # ONLY the world bits. Group access is left exactly as the operator set
+        # it: backup tooling reading through a shared group is a legitimate
+        # arrangement, and silently breaking it would be worse than the
+        # exposure being closed.
+        if mode & 0o007 and self.log:
+            self.log.info('Removing world access from %s: it holds the api_key '
+                          'and stored credentials (mode %o -> %o)',
+                          path, mode, mode & ~0o007)
+        mode &= ~0o007
 
         tmp_fd, tmp_path = tempfile.mkstemp(
             prefix='.%s.' % os.path.basename(path), suffix='.tmp', dir=directory
@@ -289,6 +316,24 @@ class Settings:
                 self.p.write(configfile)
                 configfile.flush()
                 os.fsync(configfile.fileno())
+
+            # Best-effort: chown to a DIFFERENT uid needs privilege this
+            # process will not have, but restoring the gid it already had is
+            # something a member of that group can do, and that is the case
+            # that actually breaks deployments. A failure here must not fail
+            # the save -- the alternative is refusing to persist settings.
+            #
+            # NOT preserved: POSIX ACLs beyond the mode bits. Copying those
+            # needs privileged xattr writes that would fail on most of the
+            # setups that have them, and a half-applied ACL is worse than a
+            # documented gap.
+            if owner is not None:
+                try:
+                    os.chown(tmp_path, owner[0], owner[1])
+                except OSError:
+                    if self.log:
+                        self.log.debug('Could not preserve owner/group on %s: %s',
+                                       path, traceback.format_exc(1))
 
             os.chmod(tmp_path, mode)
             os.replace(tmp_path, path)

--- a/couchpotato/core/settings.py
+++ b/couchpotato/core/settings.py
@@ -1,4 +1,6 @@
 import configparser as ConfigParser
+import os
+import tempfile
 import traceback
 from hashlib import md5
 from typing import Any, Optional
@@ -234,8 +236,83 @@ class Settings:
         return values
 
     def save(self):
-        with open(self.file, 'w', encoding='utf-8') as configfile:
-            self.p.write(configfile)
+        """Write the settings file atomically: temp file, fsync, rename.
+
+        The previous implementation was `open(self.file, 'w')`, which
+        TRUNCATES before writing anything. If the process died or the volume
+        filled between the truncate and the flush, `config.ini` was left empty
+        or partial -- and it holds the api_key, the UI password, and every
+        downloader and notifier credential. It is also the documented lock-out
+        recovery file, so the failure destroyed the remedy along with the
+        configuration. `Env.setting(attr, value=...)` calls this
+        unconditionally (`environment.py:71`).
+
+        Four details, none incidental:
+
+        - `realpath` FIRST. `--config_file` is user-supplied and only
+          `expanduser`'d (`runner.py:86`), so pointing it at a symlink is
+          legitimate -- and `os.replace` onto a symlink replaces the LINK,
+          orphaning the operator's real file. The old truncating write
+          followed the link, so resolving here preserves existing behaviour
+          rather than changing it.
+
+        - The temp file is a SIBLING. `os.replace` is atomic only within one
+          filesystem, and production bind-mounts `/config`; a temp in /tmp
+          would be a different device and the rename would fail outright.
+
+        - Mode is carried across. `mkstemp` creates 0600, so without this a
+          save would silently tighten an existing 0644 file. A file that does
+          not exist yet IS created 0600 deliberately: it holds credentials,
+          and 0644 -- what the old code produced under a default umask -- made
+          every secret in it world-readable.
+
+        - fsync the file before the rename and the directory after it.
+          Otherwise a power failure can leave the rename durable while the
+          contents are not, which is the same lost-config outcome by a
+          slower route.
+        """
+        path = os.path.realpath(self.file)
+        directory = os.path.dirname(path) or '.'
+
+        try:
+            # `& 0o777` rather than stat.S_IMODE: `stat` is not imported here,
+            # and this fix should not need to add a module-level import.
+            mode = os.stat(path).st_mode & 0o777
+        except OSError:
+            mode = 0o600
+
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            prefix='.%s.' % os.path.basename(path), suffix='.tmp', dir=directory
+        )
+        try:
+            with os.fdopen(tmp_fd, 'w', encoding='utf-8') as configfile:
+                self.p.write(configfile)
+                configfile.flush()
+                os.fsync(configfile.fileno())
+
+            os.chmod(tmp_path, mode)
+            os.replace(tmp_path, path)
+        except BaseException:
+            # BaseException, not Exception: a KeyboardInterrupt or SystemExit
+            # mid-write must not leave a stray `.config.ini.*.tmp` behind --
+            # `config.ini.*` is exactly what a locked-out operator reaches for.
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+        # Durability of the RENAME itself, not just the contents.
+        try:
+            dir_fd = os.open(directory, os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            os.fsync(dir_fd)
+        except OSError:
+            pass
+        finally:
+            os.close(dir_fd)
 
     def addSection(self, section):
         if self.p and not self.p.has_section(section):

--- a/couchpotato/runner.py
+++ b/couchpotato/runner.py
@@ -269,6 +269,29 @@ def runCouchPotato(options, base_path, args, data_dir=None, log_dir=None, Env=No
         log.warning('%s %s %s line:%s', category.__name__, message, filename, lineno)
     warnings.showwarning = customwarn
 
+    # Resolve `auth_required` ONCE, at startup, and write it back.
+    #
+    # Absent means "config.ini predates this setting". Deriving from
+    # `bool(password)` keeps installs that had bothered to set a password
+    # protected instead of falling open on upgrade. Writing the resolved value
+    # back means that after the first boot it is an explicit 0 or 1 the
+    # operator can find with `grep` -- which matters because grepping
+    # config.ini is the documented lock-out recovery path, and a setting that
+    # only exists as an inference cannot be recovered from.
+    from couchpotato import auth_is_required
+    if Env.setting('auth_required', default=None) in (None, ''):
+        resolved = 1 if Env.setting('password') else 0
+        Env.setting('auth_required', value=resolved)
+        log.info('auth_required was not set; resolved to %s from the stored '
+                 'password and written to the settings file', resolved)
+
+    if not auth_is_required():
+        # WARNING, not INFO: an unauthenticated instance is a decision, and the
+        # log is where an operator checks whether they made it.
+        log.warning('Serving with authentication DISABLED -- anyone who can '
+                    'reach this port has full control of the library. Set a '
+                    'password and turn on "Require login" in Settings.')
+
     # Create FastAPI app
     from couchpotato import create_app
     web_base = ('/' + Env.setting('url_base').lstrip('/') + '/') if Env.setting('url_base') else '/'

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -741,37 +741,25 @@ the command reports success having measured nothing. Whoever fixes the sandbox
 should decide whether "the runner could not start" deserves to be
 distinguished from "the runner ran and found survivors".
 
-**OPEN QUESTION, blocking PR 2's route-inventory test: `create_app()` alone
-does not produce the UI routes.**
+**ANSWERED (was an open question): `app.routes` does not contain the UI
+routes, because FastAPI 0.140 stopped flattening included routers.**
 
-The spec calls a route inventory ("every route either carries the auth
-dependency or is in an explicit public allowlist") PR 2's highest-value single
-criterion, because it fixes the class of defect `/getkey/` belongs to rather
-than one endpoint. Writing it needs a faithful application object to
-introspect. Measured, with `Env` set exactly as `tests/unit/test_fastapi_web.py`
-sets it:
+`app.include_router(...)` leaves a single `fastapi.routing._IncludedRouter`
+object in `app.routes`; the router's own routes hang off
+`.original_router.routes`. So a naive `for r in app.routes` sees 14 routes on
+this app and **zero** carrying `require_auth`, while the real figure is 80
+APIRoutes with 33 distinct protected paths and 11 public ones.
 
-    couchpotato.create_app('testkey123', '/')  ->  17 routes, no /wanted/
-    couchpotato.ui.create_router(require_auth) ->  33 routes, all carrying
-                                                   require_auth
-    app.include_router(that_router, prefix='') ->  adds exactly ONE route,
-                                                   with path=None
+That matters beyond the one test: any code, script or future check that
+introspects `app.routes` in this codebase silently misses every UI route, and
+its conclusion is not merely incomplete, it is inverted -- "no route is
+authenticated" is what a broken walk reports.
 
-`couchpotato/__init__.py:126-130` includes that router unconditionally and is
-not wrapped in a try, and `runner.py:303` builds the served app through the
-same `create_app`. The E2E suite proves the real server serves `/wanted/`, so
-the routes plainly exist in production -- something about how they are
-registered is not visible through `app.routes` in a bare in-process build.
+The route-inventory test now exists (`tests/unit/test_route_auth_inventory.py`)
+and walks `_IncludedRouter.original_router` recursively. It carries an explicit
+anti-vacuity test, because the false alarm above was produced TWICE during
+development -- once from an `Env` too crude for `create_app` to finish, once
+from the naive walk -- and both times it read like a catastrophic security
+finding. Reverting the walker to the naive form reds that guard; removing
+`Depends(require_auth)` from a single UI route reds the inventory itself.
 
-Not filed as a defect, because the evidence says production is fine; filed as
-an unanswered question that must be answered BEFORE the inventory test is
-written. A test that introspects an app it does not fully understand would
-report "0 routes protected", which reads like a catastrophic security finding
-and would be an artefact of the harness. That exact false alarm was produced
-twice while investigating this, and was caught only by an anti-vacuity
-assertion.
-
-Next step for whoever picks this up: find where the served route table
-actually comes from (the `/new` double-include at `:130` and the `path=None`
-entry are the two threads worth pulling), then write the inventory against
-that.

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -740,3 +740,38 @@ exit-code-swallowing shape in a repo that ships a guard against exactly that:
 the command reports success having measured nothing. Whoever fixes the sandbox
 should decide whether "the runner could not start" deserves to be
 distinguished from "the runner ran and found survivors".
+
+**OPEN QUESTION, blocking PR 2's route-inventory test: `create_app()` alone
+does not produce the UI routes.**
+
+The spec calls a route inventory ("every route either carries the auth
+dependency or is in an explicit public allowlist") PR 2's highest-value single
+criterion, because it fixes the class of defect `/getkey/` belongs to rather
+than one endpoint. Writing it needs a faithful application object to
+introspect. Measured, with `Env` set exactly as `tests/unit/test_fastapi_web.py`
+sets it:
+
+    couchpotato.create_app('testkey123', '/')  ->  17 routes, no /wanted/
+    couchpotato.ui.create_router(require_auth) ->  33 routes, all carrying
+                                                   require_auth
+    app.include_router(that_router, prefix='') ->  adds exactly ONE route,
+                                                   with path=None
+
+`couchpotato/__init__.py:126-130` includes that router unconditionally and is
+not wrapped in a try, and `runner.py:303` builds the served app through the
+same `create_app`. The E2E suite proves the real server serves `/wanted/`, so
+the routes plainly exist in production -- something about how they are
+registered is not visible through `app.routes` in a bare in-process build.
+
+Not filed as a defect, because the evidence says production is fine; filed as
+an unanswered question that must be answered BEFORE the inventory test is
+written. A test that introspects an app it does not fully understand would
+report "0 routes protected", which reads like a catastrophic security finding
+and would be an artefact of the harness. That exact false alarm was produced
+twice while investigating this, and was caught only by an anti-vacuity
+assertion.
+
+Next step for whoever picks this up: find where the served route table
+actually comes from (the `/new` double-include at `:130` and the `path=None`
+entry are the two threads worth pulling), then write the inventory against
+that.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.12.1",
         "@lhci/cli": "^0.15.1",
-        "@playwright/test": "^1.62.0",
+        "@playwright/test": "^1.62.1",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/vitest-runner": "^9.6.1",
-        "jsdom": "^30.0.0",
+        "jsdom": "^30.0.1",
         "vitest": "^4.1.10"
       }
     },
@@ -1457,13 +1457,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
-      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.62.0"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -2829,16 +2829,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/brace-expansion/node_modules/balanced-match": {
@@ -4635,16 +4635,16 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "30.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.0.tgz",
-      "integrity": "sha512-JQHfRGmmKmaZoUAvIgff5jjG/0SzTQlGz8c7t72KzBzo8ZULEjAjnYE0sNwBOUA4QtWwYE2xoYitg8NFsmiYxA==",
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^6.0.5",
-        "@asamuzakjp/dom-selector": "^8.2.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
         "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.6",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
         "@exodus/bytes": "^1.15.1",
         "css-tree": "^3.2.1",
         "data-urls": "^7.0.0",
@@ -4656,7 +4656,7 @@
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^6.0.2",
-        "undici": "^8.7.0",
+        "undici": "^8.9.0",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
@@ -5562,9 +5562,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6062,13 +6062,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
-      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.62.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -6081,9 +6081,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
-      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2787,9 +2787,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2801,7 +2801,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -3929,9 +3929,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -4450,9 +4450,9 @@
       "license": "0BSD"
     },
     "node_modules/ip-address": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.1.tgz",
-      "integrity": "sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4621,9 +4621,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4673,16 +4673,6 @@
         "canvas": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jsdom/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/jsdom/node_modules/whatwg-url": {
@@ -5664,9 +5654,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -6094,9 +6084,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -6114,7 +6104,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7121,6 +7111,16 @@
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",
     "@lhci/cli": "^0.15.1",
-    "@playwright/test": "^1.62.0",
+    "@playwright/test": "^1.62.1",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
-    "jsdom": "^30.0.0",
+    "jsdom": "^30.0.1",
     "vitest": "^4.1.10"
   },
   "overrides": {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ pytest==9.1.1
 pytest-cov>=7.1.0
 coverage==7.15.2
 httpx>=0.28.1
-ruff==0.16.0
+ruff==0.16.1
 pytest-timeout>=2.4.0
 mutmut>=3.6.0
 # Used by scripts/check_test_traps.py to parse GitHub workflows with a real

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # CouchPotatoServer - Python dependencies
 
 # Web Framework
-fastapi==0.140.13
+fastapi==0.141.1
 starlette==1.3.1
 uvicorn==0.51.0
 Jinja2==3.1.6

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -1295,9 +1295,38 @@ CSP build of Alpine is used. Land the header with the E2E suite as the guard: a 
 
 ### T2.6: QW2 + QW7: TLS verification and log redaction · S · risk: low
 
-- `core/downloaders/synology.py:140`: `verify=False` while POSTing
+- ~~`core/downloaders/synology.py:140`: `verify=False` while POSTing
   `account`/`passwd`. Honour the global `ssl_verify` setting; this is the last
-  `verify=False` in the tree.
+  `verify=False` in the tree.~~ **RETRACTED as written -- this fix closes
+  nothing, and the real exposure is worse. Verified 2026-08-07 by reading the
+  file:**
+
+  `synology.py:109-110` hardcodes the scheme:
+
+  ```python
+  self.download_url = 'http://%s:%s/webapi/DownloadStation/task.cgi' % (host, port)
+  self.auth_url     = 'http://%s:%s/webapi/auth.cgi' % (host, port)
+  ```
+
+  `verify` is a TLS parameter. On an `http://` URL `requests` never reaches a
+  TLS handshake, so `verify=False` at `:140` is unreachable and honouring
+  `ssl_verify` there would change no observable behaviour. Shipping it would
+  produce a commit that reads like a TLS hardening fix and hardens nothing --
+  the same "fix the appearance" shape T1.5 already cost this project once.
+
+  **The actual finding:** `_login` (`:117-121`) POSTs `account` and `passwd`
+  over plaintext HTTP on every download action, so the operator's NAS password
+  crosses the LAN in the clear. The `host` setting (`:227-229`, "Hostname with
+  port. Usually localhost:5000") accepts no scheme, so a user whose DSM offers
+  HTTPS on 5001 cannot opt in even if they want to.
+
+  **Correct fix, deferred to its own task:** honour a scheme if the user
+  supplies one in `host`, default to `http://` for compatibility, and set
+  `verify=True` whenever the resolved scheme is https. Not taken here because
+  it changes downloader transport and cannot be exercised without a real
+  Synology -- and a downloader that silently stops working is a worse outcome
+  for the operator than the exposure it fixes. It wants a device to test
+  against, which is a prerequisite this branch does not have.
 - Extend `PrivacyFilter`'s allowlist (`core/logger.py:27`) with `token`,
   `authkey`, `torrent_pass`, `sid`, `passkey`; fix the three call sites that log
   secrets outside query-param form: `notifications/telegrambot.py:37`,

--- a/tests/unit/test_auth_required_gate.py
+++ b/tests/unit/test_auth_required_gate.py
@@ -383,3 +383,110 @@ class TestTheStartupMigrationRunsBeforeDefaultsAreMaterialised:
             'the "absent" check skips and every upgraded install that had a '
             'password set becomes PUBLIC.'
         )
+
+
+class TestAuthRequiredArrivesAsAStringAtStartup:
+    """At `runner.py:288` the value is a STRING, and `bool('0')` is True.
+
+    `auth_is_required()` is called from `runner.py:288`, before `loader.run()`
+    (`:333`) has reached `registerDefaults` -> `setType`. Until that runs,
+    `Settings.getType` cannot find the option and falls back to `'unicode'`
+    (`settings.py:375-379`), which is not a key in `_type_adapters`
+    (`settings.py:16-21`) -- so `_coerce_value` returns the raw ConfigParser
+    string untouched.
+
+    So on the startup path the value is `'0'` or `'1'`, never an int. Every
+    other test in this file hands back real Python ints, which means the
+    `isinstance(configured, str)` branch had no coverage at all while being the
+    only thing standing between an operator and a lockout:
+
+        bool('0') is True
+
+    Drop that branch and an install with an explicit `auth_required = 0` and no
+    password comes up with authentication ON and no credential that can satisfy
+    it. That is the same lockout this branch has already had to close twice, so
+    it gets a test rather than a comment.
+    """
+
+    def test_the_premise_holds_an_unregistered_option_is_not_coerced(self):
+        """Verify the REASON, not just the behaviour.
+
+        If someone later registers the type earlier and this stops being true,
+        this fails and points at the branch below rather than leaving it as
+        unexplained defensive code nobody dares delete.
+        """
+        from couchpotato.core.settings import Settings, _coerce_value
+
+        s = Settings.__new__(Settings)
+        s.types = {}
+        assert s.getType('core', 'auth_required') == 'unicode', (
+            'auth_required now has a registered type at lookup time; if that '
+            'is true at runner.py:288 as well, the string branch in '
+            'auth_is_required may no longer be needed'
+        )
+        assert _coerce_value('0', 'unicode') == '0', (
+            "'unicode' is not in _type_adapters, so the raw string must pass "
+            'through uncoerced'
+        )
+
+    def test_the_trap_this_guards_is_real(self):
+        """Anti-vacuity: without the branch, `'0'` reads as True."""
+        assert bool('0') is True
+
+    @pytest.mark.parametrize('stored', ['0', 'false', 'False', 'no', 'off', ' 0 ', ''])
+    def test_a_falsy_string_leaves_auth_off(self, settings, stored):
+        settings['auth_required'] = stored
+        settings['password'] = ''
+
+        assert _current_user(_request()) is True, (
+            'auth_required was the string %r, which the operator set to turn '
+            'authentication OFF. It came up ON instead, and with no password '
+            'stored nothing can satisfy it -- the operator is locked out of '
+            'their own server.' % (stored,)
+        )
+
+    @pytest.mark.parametrize('stored', ['1', 'true', 'True', 'yes', 'on', ' 1 '])
+    def test_a_truthy_string_turns_auth_on(self, settings, stored):
+        settings['auth_required'] = stored
+        settings['password'] = 'hashed'
+
+        assert _current_user(_request()) is None, (
+            'auth_required was the string %r and the server stayed PUBLIC' % (stored,)
+        )
+        assert _current_user(_request('THEKEY')) == 'THEKEY'
+
+    def test_an_unrecognised_string_with_a_password_stays_shut(self, settings):
+        """Garbage in config.ini must not open the server.
+
+        A hand-edited config.ini is the documented lock-out recovery path, so
+        typos in this field are expected. This test found a real defect: `'yess'`
+        is in neither the truthy nor the falsy set, and the original branch
+        returned False for anything it did not recognise -- so a single typo
+        silently made a password-protected server PUBLIC.
+        """
+        settings['auth_required'] = 'yess'
+        settings['password'] = 'hashed'
+
+        assert _current_user(_request()) is None, (
+            'a typo in auth_required made the server public'
+        )
+        assert _current_user(_request('THEKEY')) == 'THEKEY', (
+            'the password can still satisfy the gate'
+        )
+
+    def test_an_unrecognised_string_without_a_password_does_not_lock_out(self, settings):
+        """...but "fail closed" must not mean "fail unopenable".
+
+        Reading garbage as ON would turn auth on for an install with no
+        password, which nothing can then satisfy -- the lockout this branch has
+        already had to close twice. So an unrecognised value derives from the
+        password instead of picking a fixed side, which errs shut exactly when
+        there is a credential to open it with.
+        """
+        settings['auth_required'] = 'yess'
+        settings['password'] = ''
+
+        assert _current_user(_request()) is True, (
+            'a typo in auth_required locked the operator out of a server that '
+            'has no password to log in with'
+        )

--- a/tests/unit/test_auth_required_gate.py
+++ b/tests/unit/test_auth_required_gate.py
@@ -143,3 +143,78 @@ class TestTheDefault:
         settings.pop('auth_required', None)
 
         assert _current_user(_request()) is True
+
+
+class TestSavingAPasswordKeepsAuthRequiredHonest:
+    """The settings copy promises "Setting one turns 'Require login' on".
+
+    It was not true. `auth_required` was written in exactly ONE place --
+    `runner.py`'s startup migration -- and that is gated on the key being
+    ABSENT. After the first boot of a passwordless install the key is an
+    explicit `0`, so a user who then sets a password through the wizard or the
+    settings UI got no authentication at all, while both field descriptions
+    told them they had.
+
+    That is the same defect class this PR exists to close: copy that promises
+    an auth behaviour the code does not implement. It was introduced by the
+    copy added in this PR, which makes it worse, not better.
+
+    The second half is a lockout that neither fix caused alone. With
+    `auth_required = 1` and the password cleared, `get_current_user` denies
+    every request AND `login_post` refuses every credential (it now requires a
+    configured password), so the operator is locked out entirely and can only
+    recover by hand-editing config.ini. Reachable by setting a password and
+    then clearing it. Saving the password keeps the two settings consistent in
+    BOTH directions, which closes it.
+    """
+
+    @pytest.fixture
+    def core(self):
+        from couchpotato.core._base._core import Core
+        return Core.__new__(Core)
+
+    def test_setting_a_password_turns_auth_required_on(self, settings, core):
+        settings['auth_required'] = 0
+
+        core.md5Password('hunter2')
+
+        assert settings['auth_required'] == 1, (
+            'a password was set and authentication stayed OFF, while the '
+            'settings copy says setting one turns login on'
+        )
+
+    def test_the_new_password_is_still_what_gets_stored(self, settings, core):
+        """The hook's return value is what lands in config.ini; the
+        auth_required write must not displace it."""
+        settings['auth_required'] = 0
+
+        stored = core.md5Password('hunter2')
+
+        assert stored.startswith(('$2a$', '$2b$', '$2y$')), stored
+
+    def test_clearing_the_password_turns_auth_required_off(self, settings, core):
+        """Otherwise the operator is locked out with no way back in.
+
+        auth_required=1 + no password means every request is denied and every
+        login is refused, because login now requires a configured password.
+        """
+        settings['auth_required'] = 1
+
+        core.md5Password('')
+
+        assert settings['auth_required'] == 0, (
+            'clearing the password left authentication ON, which denies every '
+            'request AND refuses every login: an unrecoverable lockout short '
+            'of hand-editing config.ini'
+        )
+
+    def test_the_lockout_state_is_not_reachable_through_the_save_hook(self, settings, core):
+        """End-to-end on the state itself, not just the flag."""
+        settings.update({'username': 'admin', 'password': 'old'})
+        settings['auth_required'] = 1
+
+        core.md5Password('')          # operator clears the password
+        settings['password'] = ''     # ...which is then stored
+
+        # Nobody is locked out: with no password, the instance is open.
+        assert _current_user(_request()) is True

--- a/tests/unit/test_auth_required_gate.py
+++ b/tests/unit/test_auth_required_gate.py
@@ -1,0 +1,145 @@
+"""Auth is gated on an explicit setting, not inferred from two other fields.
+
+`get_current_user` used to gate on `if username and password:` and return
+`True` -- fully public -- otherwise. Driven directly, that gives:
+
+    username='admin' password='secret'  -> denied without a cookie
+    username=''      password='secret'  -> PUBLIC
+    username='admin' password=''        -> PUBLIC
+    username=''      password=''        -> PUBLIC
+
+So an operator who set a password but left the username blank had a wide-open
+server and no indication of it. The settings copy made that the likely
+mistake rather than an unlikely one: "Leave empty to disable authentication"
+sat on the **username** field, so the field that silently disabled auth was the
+one whose own description promised it would.
+
+The gate is now the explicit `auth_required` setting:
+
+  - ON  -> a valid session cookie is required, whatever username/password hold.
+  - OFF -> open, which is now a state someone chose rather than one they
+           stumbled into.
+  - A blank username means "any username is accepted", not "auth off".
+
+The default is a plain `0` rather than a tri-state `None`. Spec-verified, and
+worth restating because the tidy-looking version is broken: `registerDefaults`
+materialises the literal `auth_required = None` into `config.ini` on first
+boot, and `Env.setting`'s own default is `''`, so `Env.setting('auth_required',
+type='bool')` reads falsy and auth stays OFF on every install, silently, with
+no failing test and no log line. A one-shot startup migration writes an
+explicit `1` when the key is absent and a password is set, so existing
+password-protected installs stay protected and the value is greppable
+afterwards -- which matters because grepping `config.ini` is the documented
+lock-out recovery path.
+"""
+import types
+
+import pytest
+
+from couchpotato.environment import Env
+
+
+@pytest.fixture
+def settings():
+    """Env.setting backed by a plain dict, restored afterwards."""
+    data = {'api_key': 'THEKEY'}
+    original = Env.setting
+
+    def mock_setting(key=None, *args, **kwargs):
+        if 'value' in kwargs:
+            data[key] = kwargs['value']
+            return
+        return data.get(key, kwargs.get('default', ''))
+
+    Env.setting = staticmethod(mock_setting)
+    yield data
+    Env.setting = original
+
+
+def _request(cookie=None):
+    return types.SimpleNamespace(cookies=({'user': cookie} if cookie else {}))
+
+
+def _current_user(request):
+    from couchpotato import get_current_user
+    return get_current_user(request)
+
+
+class TestAuthRequiredOn:
+    """Six cases: both auth_required states across the credential combinations."""
+
+    @pytest.mark.parametrize('username,password', [
+        ('admin', 'secret'),
+        ('', 'secret'),      # the trap: password set, username blank
+        ('admin', ''),
+        ('', ''),
+    ])
+    def test_no_cookie_is_denied(self, settings, username, password):
+        settings.update({'username': username, 'password': password, 'auth_required': 1})
+
+        assert _current_user(_request()) is None, (
+            'auth_required is ON but a request with no session cookie was '
+            'served (username=%r password=%r)' % (username, password)
+        )
+
+    def test_a_valid_cookie_is_accepted(self, settings):
+        settings.update({'username': 'admin', 'password': 'secret', 'auth_required': 1})
+
+        assert _current_user(_request('THEKEY')) == 'THEKEY'
+
+    def test_a_wrong_cookie_is_denied(self, settings):
+        settings.update({'username': 'admin', 'password': 'secret', 'auth_required': 1})
+
+        assert _current_user(_request('not-the-key')) is None
+
+    def test_a_blank_username_does_not_disable_auth(self, settings):
+        """The whole point. This combination was PUBLIC before."""
+        settings.update({'username': '', 'password': 'secret', 'auth_required': 1})
+
+        assert _current_user(_request()) is None, (
+            'a blank username disabled authentication even with auth_required '
+            'ON -- the exact trap the old `if username and password` gate set'
+        )
+        assert _current_user(_request('THEKEY')) == 'THEKEY', (
+            'a blank username must mean "any username is accepted", not '
+            '"nobody can log in"'
+        )
+
+
+class TestAuthRequiredOff:
+    """Open is a state someone chose, and it must actually be open."""
+
+    @pytest.mark.parametrize('username,password', [
+        ('admin', 'secret'),
+        ('', 'secret'),
+        ('', ''),
+    ])
+    def test_everything_is_public(self, settings, username, password):
+        settings.update({'username': username, 'password': password, 'auth_required': 0})
+
+        assert _current_user(_request()) is True
+
+
+class TestTheDefault:
+
+    def test_absent_auth_required_with_a_password_is_treated_as_ON(self, settings):
+        """Existing password-protected installs must not fall open on upgrade.
+
+        `auth_required` is absent from every config.ini written before this
+        change. Reading it as falsy would silently unprotect exactly the
+        installs that had bothered to set a password.
+        """
+        settings.update({'username': 'admin', 'password': 'secret'})
+        settings.pop('auth_required', None)
+
+        assert _current_user(_request()) is None, (
+            'an upgraded install with a password set became PUBLIC because '
+            'auth_required was absent'
+        )
+
+    def test_absent_auth_required_without_a_password_stays_open(self, settings):
+        """An install with no password never had auth; do not lock it out."""
+        settings.update({'username': '', 'password': ''})
+        settings.pop('auth_required', None)
+
+        assert _current_user(_request()) is True

--- a/tests/unit/test_auth_required_gate.py
+++ b/tests/unit/test_auth_required_gate.py
@@ -41,9 +41,17 @@ from couchpotato.environment import Env
 
 @pytest.fixture
 def settings():
-    """Env.setting backed by a plain dict, restored afterwards."""
+    """One dict behind BOTH `Env.setting` and `Env.get('settings')`.
+
+    The password hook writes through `Env.get('settings').set(...)` rather than
+    `Env.setting(value=...)`, deliberately -- see
+    TestAuthRequiredAndPasswordArePersistedTogether. A fixture that stubbed
+    only one of the two would let these tests disagree with the code about
+    where settings live, so both views share the same storage.
+    """
     data = {'api_key': 'THEKEY'}
-    original = Env.setting
+    original_setting = Env.setting
+    original_get = Env.get
 
     def mock_setting(key=None, *args, **kwargs):
         if 'value' in kwargs:
@@ -51,9 +59,32 @@ def settings():
             return
         return data.get(key, kwargs.get('default', ''))
 
+    class FakeSettings:
+        def addSection(self, section):
+            pass
+
+        def set(self, section, option, value):
+            data[option] = value
+
+        def save(self):
+            raise AssertionError(
+                'the password hook must not save on its own: auth_required '
+                'would land on disk before the password'
+            )
+
+        def get(self, attr, default=None, section='core', type=None):
+            return data.get(attr, default)
+
+    def mock_get(key, default=None):
+        if key == 'settings':
+            return FakeSettings()
+        return original_get(key, default) if key != 'dev' else False
+
     Env.setting = staticmethod(mock_setting)
+    Env.get = staticmethod(mock_get)
     yield data
-    Env.setting = original
+    Env.setting = original_setting
+    Env.get = original_get
 
 
 def _request(cookie=None):
@@ -218,3 +249,137 @@ class TestSavingAPasswordKeepsAuthRequiredHonest:
 
         # Nobody is locked out: with no password, the instance is open.
         assert _current_user(_request()) is True
+
+
+class TestAuthRequiredAndPasswordArePersistedTogether:
+    """One save, not two -- or a crash between them recreates the lockout.
+
+    `Env.setting(attr, value=...)` (`environment.py:63-76`) calls `s.save()`
+    immediately and independently. `Settings.saveView` then does its own
+    `self.set(section, option, new_value); self.save()` AFTER `fireEvent`
+    returns. So writing `auth_required` through `Env.setting` from inside the
+    password hook persists it in a SEPARATE, EARLIER save than the password
+    itself.
+
+    Setting a password: `auth_required = 1` lands on disk first. A crash, a
+    full volume, or a kill between the two saves leaves authentication ON with
+    no password stored -- every request denied, every login refused, and no way
+    back in short of hand-editing config.ini. Exactly the lockout the change
+    was written to close, reintroduced through a different door.
+
+    So the hook must only touch the in-memory parser and let the caller's
+    single save persist both. `Settings.save()` is atomic (T2.0), so one save
+    means the pair lands or neither does.
+    """
+
+    def test_the_hook_does_not_save_by_itself(self, monkeypatch):
+        """Pins the mechanism, because the crash window cannot be reproduced.
+
+        Nothing observable distinguishes "wrote both in one save" from "wrote
+        them in two" once both have completed -- the difference only appears if
+        the process dies in between. So the assertion is on the mechanism: the
+        hook must not trigger a save of its own.
+        """
+        from couchpotato.core._base._core import Core
+        from couchpotato.environment import Env
+
+        saves = []
+
+        class FakeSettings:
+            p = object()
+
+            def addSection(self, section):
+                pass
+
+            def set(self, section, option, value):
+                pass
+
+            def save(self):
+                saves.append(1)
+
+            def get(self, attr, default=None, section='core', type=None):
+                return default
+
+        monkeypatch.setattr(Env, 'get', staticmethod(
+            lambda key, default=None: FakeSettings() if key == 'settings' else default))
+
+        Core.__new__(Core).md5Password('hunter2')
+
+        assert saves == [], (
+            'the password hook triggered %d independent save(s). auth_required '
+            'then lands on disk BEFORE the password, and a crash in between '
+            'leaves authentication on with no password: locked out.' % len(saves)
+        )
+
+    def test_the_value_still_reaches_the_settings_object(self, monkeypatch):
+        """Not saving must not mean not setting -- the caller's save needs the
+        value already in the parser."""
+        from couchpotato.core._base._core import Core
+        from couchpotato.environment import Env
+
+        written = {}
+
+        class FakeSettings:
+            def addSection(self, section):
+                pass
+
+            def set(self, section, option, value):
+                written[(section, option)] = value
+
+            def save(self):
+                raise AssertionError('the hook must not save')
+
+            def get(self, attr, default=None, section='core', type=None):
+                return default
+
+        monkeypatch.setattr(Env, 'get', staticmethod(
+            lambda key, default=None: FakeSettings() if key == 'settings' else default))
+
+        Core.__new__(Core).md5Password('hunter2')
+
+        assert written.get(('core', 'auth_required')) == 1, written
+
+
+class TestTheStartupMigrationRunsBeforeDefaultsAreMaterialised:
+    """The migration's correctness IS its position in runner.py.
+
+    `runner.py` resolves `auth_required` only when the key is **absent**:
+
+        if Env.setting('auth_required', default=None) in (None, ''):
+            resolved = 1 if Env.setting('password') else 0
+
+    That is what stops a password-protected install falling open on upgrade.
+    It only holds because the block runs BEFORE `loader.preload()`/
+    `loader.run()`, which fire `settings.register` and reach
+    `Settings.registerDefaults` -> `setDefault`, materialising the registered
+    default of `0` into the config.
+
+    Move the block below the loader and the check sees `0` rather than absent,
+    skips, and every existing install with a password becomes public -- with no
+    failing test, no log line, and a diff that looks like tidying.
+
+    So the ordering is pinned. A source-order assertion is a blunt instrument,
+    but the alternative is a comment, and this repo has already learned what
+    comments are worth when the code stops matching them.
+    """
+
+    def test_the_migration_precedes_loader_run(self):
+        from pathlib import Path
+
+        source = (Path(__file__).resolve().parents[2] /
+                  'couchpotato' / 'runner.py').read_text(encoding='utf-8')
+
+        migration = source.find("Env.setting('auth_required', value=")
+        loader_run = source.find('loader.run()')
+
+        assert migration != -1, (
+            'the auth_required startup migration is gone from runner.py; if '
+            'that was deliberate, this guard needs to go with it'
+        )
+        assert loader_run != -1, 'loader.run() not found in runner.py'
+        assert migration < loader_run, (
+            'the auth_required migration now runs AFTER loader.run(). '
+            'registerDefaults will have written auth_required = 0 by then, so '
+            'the "absent" check skips and every upgraded install that had a '
+            'password set becomes PUBLIC.'
+        )

--- a/tests/unit/test_login_blank_password.py
+++ b/tests/unit/test_login_blank_password.py
@@ -58,11 +58,16 @@ def settings(tmp_path):
     yield data
 
     Env.setting = original
-    api.clear(); api.update(old_api)
-    api_locks.clear(); api_locks.update(old_locks)
-    api_nonblock.clear(); api_nonblock.update(old_nonblock)
-    api_docs.clear(); api_docs.update(old_docs)
-    api_docs_missing.clear(); api_docs_missing.extend(old_missing)
+    api.clear()
+    api.update(old_api)
+    api_locks.clear()
+    api_locks.update(old_locks)
+    api_nonblock.clear()
+    api_nonblock.update(old_nonblock)
+    api_docs.clear()
+    api_docs.update(old_docs)
+    api_docs_missing.clear()
+    api_docs_missing.extend(old_missing)
 
 
 def _client():

--- a/tests/unit/test_login_blank_password.py
+++ b/tests/unit/test_login_blank_password.py
@@ -131,3 +131,60 @@ class TestConfiguredPasswordStillWorks:
         response = _client().post('/login/', data={'username': 'admin', 'password': 'wrong'})
 
         assert not _logged_in(response)
+
+
+class TestGetKeyDoesNotLeakTheApiKey:
+    """`/getkey/` had the identical `or not password` flaw, and it is worse here.
+
+    `login_post` at least issues a cookie. This endpoint returns the api_key
+    itself in a JSON body, over GET, with the credentials in the query string --
+    so the request line lands in access logs, proxy logs and browser history,
+    and an unauthenticated caller received the key outright whenever no
+    password was configured.
+
+    NOT deleted here, though the spec calls for that eventually: its only
+    referrer is `couchpotato/simple_healthcheck.py:76`, whose own removal is
+    blocked on AC-OPS-12's production grep. Closing the hole does not depend on
+    resolving that, so it is closed now and the deletion follows separately.
+    """
+
+    def test_no_password_configured_does_not_hand_out_the_api_key(self, settings):
+        from couchpotato.core.helpers.variable import md5
+
+        settings['password'] = ''
+
+        # `u` is the md5 of the username, which is not a secret -- it is
+        # whatever the operator typed, commonly `admin`, and it is displayed in
+        # the settings UI. An earlier version of this test passed `u=anything`
+        # and went green against the UNFIXED code, because the username check
+        # rejected it before the password check was ever reached. That is the
+        # incidentally-passing shape: it looked like a leak test and was
+        # measuring the wrong clause.
+        body = _client().get('/getkey/?u=%s&p=anything' % md5('admin')).json()
+
+        assert body.get('api_key') is None, (
+            'an unauthenticated GET received the api_key because no password '
+            'is configured. The credentials are in the query string, so this '
+            'is also logged wherever request lines are logged.'
+        )
+        assert body.get('success') is False
+
+    def test_the_correct_password_still_returns_the_key(self, settings):
+        from couchpotato.core.helpers.variable import hash_password, md5
+
+        settings['password'] = hash_password(md5('correct-horse'))
+
+        body = _client().get('/getkey/?u=%s&p=%s' % (md5('admin'), md5('correct-horse'))).json()
+
+        assert body.get('api_key') == 'testkey123', (
+            'the fix broke the endpoint for a correctly configured install'
+        )
+
+    def test_a_wrong_password_returns_nothing(self, settings):
+        from couchpotato.core.helpers.variable import hash_password, md5
+
+        settings['password'] = hash_password(md5('correct-horse'))
+
+        body = _client().get('/getkey/?u=%s&p=%s' % (md5('admin'), md5('wrong'))).json()
+
+        assert body.get('api_key') is None

--- a/tests/unit/test_login_blank_password.py
+++ b/tests/unit/test_login_blank_password.py
@@ -1,0 +1,128 @@
+"""`/login/` must not issue a session when no password is configured.
+
+The credential check was:
+
+    if (form.get('username') == username or not username) and \\
+       (check_password(form_password_md5, password) or not password):
+
+`or not password` short-circuits the whole comparison to True whenever the
+stored password is empty, so **any** submitted credentials were accepted and a
+valid `user` cookie -- the api_key -- was written to the browser.
+
+Why that matters, given that a blank password also means `get_current_user`
+returns True and the UI is open anyway: PR 2 introduces `auth_required`. The
+dangerous state is auth_required ON with no password set, which is reachable
+by exactly one click in the settings UI. The instance then *looks* protected --
+there is a login page, it asks for credentials, it rejects nothing -- and
+admits everyone. A door that is locked in appearance only is worse than an
+open one, because it stops the operator looking for the lock.
+
+The cookie is the api_key, so this is not merely a UI bypass: it hands the
+caller the credential the whole API authenticates with.
+"""
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from couchpotato.api import addApiView, api, api_locks, api_nonblock, api_docs, api_docs_missing
+from couchpotato.environment import Env
+
+
+@pytest.fixture
+def settings(tmp_path):
+    """Env with configurable username/password, restored afterwards."""
+    old_api = dict(api)
+    old_locks = dict(api_locks)
+    old_nonblock = dict(api_nonblock)
+    old_docs = dict(api_docs)
+    old_missing = list(api_docs_missing)
+
+    Env.set('web_base', '/')
+    Env.set('api_base', '/api/testkey123/')
+    Env.set('static_path', '/static/')
+    Env.set('app_dir', os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+    Env.set('dev', False)
+    Env.set('data_dir', str(tmp_path))
+
+    data = {'username': 'admin', 'password': '', 'api_key': 'testkey123'}
+    original = Env.setting
+
+    def mock_setting(key=None, *args, **kwargs):
+        if 'value' in kwargs:
+            data[key] = kwargs['value']
+            return
+        return data.get(key, kwargs.get('default', ''))
+
+    Env.setting = staticmethod(mock_setting)
+    yield data
+
+    Env.setting = original
+    api.clear(); api.update(old_api)
+    api_locks.clear(); api_locks.update(old_locks)
+    api_nonblock.clear(); api_nonblock.update(old_nonblock)
+    api_docs.clear(); api_docs.update(old_docs)
+    api_docs_missing.clear(); api_docs_missing.extend(old_missing)
+
+
+def _client():
+    from couchpotato import create_app
+    return TestClient(create_app('testkey123', '/'), follow_redirects=False)
+
+
+def _logged_in(response) -> bool:
+    """Did the response hand back a session cookie?"""
+    return 'user' in response.cookies
+
+
+class TestBlankPasswordIssuesNoSession:
+
+    def test_arbitrary_credentials_are_refused_when_no_password_is_set(self, settings):
+        settings['password'] = ''
+
+        response = _client().post('/login/', data={'username': 'admin', 'password': 'anything-at-all'})
+
+        assert not _logged_in(response), (
+            'a session cookie was issued for an arbitrary password while no '
+            'password is configured. The cookie value is the api_key, so this '
+            'hands the caller the credential the whole API authenticates with.'
+        )
+
+    def test_an_empty_submission_is_refused_when_no_password_is_set(self, settings):
+        settings['password'] = ''
+
+        response = _client().post('/login/', data={'username': 'admin', 'password': ''})
+
+        assert not _logged_in(response), 'an empty password was accepted as valid'
+
+    def test_a_wrong_username_is_refused_when_no_password_is_set(self, settings):
+        settings['password'] = ''
+
+        response = _client().post('/login/', data={'username': 'someone-else', 'password': 'x'})
+
+        assert not _logged_in(response)
+
+
+class TestConfiguredPasswordStillWorks:
+    """The fix must not buy safety by breaking login."""
+
+    def test_the_correct_password_still_logs_in(self, settings):
+        from couchpotato.core.helpers.variable import hash_password, md5
+
+        settings['password'] = hash_password(md5('correct-horse'))
+
+        response = _client().post('/login/', data={'username': 'admin', 'password': 'correct-horse'})
+
+        assert _logged_in(response), (
+            'a correctly configured login was refused: the guard disabled the '
+            'feature instead of fixing it'
+        )
+
+    def test_a_wrong_password_is_still_refused(self, settings):
+        from couchpotato.core.helpers.variable import hash_password, md5
+
+        settings['password'] = hash_password(md5('correct-horse'))
+
+        response = _client().post('/login/', data={'username': 'admin', 'password': 'wrong'})
+
+        assert not _logged_in(response)

--- a/tests/unit/test_password_storage.py
+++ b/tests/unit/test_password_storage.py
@@ -1,0 +1,123 @@
+"""A password set through the UI or wizard must be stored as bcrypt.
+
+`_core.py:57` wires `setting.save.core.password` to `md5Password`, which was:
+
+    def md5Password(self, value):
+        return md5(value) if value else ''
+
+So every password set through the settings UI or the first-run wizard was
+written to `config.ini` as an **unsalted MD5** -- instantly reversible for any
+password in a rainbow table, which is to say most of them.
+
+bcrypt was reached only by the login-time upgrade at `__init__.py:308`, which
+rehashes on a successful login. That path never runs for the cohort that has
+never logged in -- and until `auth_required` landed earlier in this PR, the
+server never asked anyone to log in. So the users this PR exists to protect are
+exactly the ones whose password was still MD5.
+
+`check_password` carries the comment "New passwords are always bcrypt", which
+was false at the moment it was written. It is corrected alongside this fix,
+because a reassuring sentence the code contradicts is worse than no sentence:
+it is the reason nobody looked.
+
+The stored value is bcrypt OVER the MD5 of the plaintext, not over the
+plaintext. That is not a design choice made here -- it is what the login path
+already computes (`form_password_md5 = md5(form_password)`, then
+`check_password(form_password_md5, stored)`), so anything else would silently
+lock every user out. Changing that inner encoding is a separate migration with
+its own login-time upgrade, not a tidy-up to fold into this fix.
+"""
+import re
+
+import pytest
+
+from couchpotato.core.helpers.variable import check_password, is_legacy_md5_hash, md5
+
+
+BCRYPT_PREFIXES = ('$2a$', '$2b$', '$2y$')
+
+
+@pytest.fixture
+def core():
+    """A bare Core instance -- md5Password touches no state."""
+    from couchpotato.core._base._core import Core
+    return Core.__new__(Core)
+
+
+class TestPasswordsAreStoredAsBcrypt:
+
+    def test_a_saved_password_is_not_a_bare_md5_hash(self, core):
+        stored = core.md5Password('hunter2')
+
+        assert not is_legacy_md5_hash(stored), (
+            'the password was stored as an unsalted MD5 hash (%r). That is '
+            'reversible for any password in a rainbow table, and it sits in '
+            'config.ini.' % stored
+        )
+
+    def test_a_saved_password_is_a_bcrypt_hash(self, core):
+        stored = core.md5Password('hunter2')
+
+        assert stored.startswith(BCRYPT_PREFIXES), (
+            'expected a bcrypt hash, got %r' % stored
+        )
+
+    def test_the_same_password_hashes_differently_each_time(self, core):
+        """Salted. Two identical passwords must not produce identical rows."""
+        assert core.md5Password('hunter2') != core.md5Password('hunter2')
+
+    def test_an_empty_password_stays_empty(self, core):
+        """Empty means "no password set", and must not become a valid hash."""
+        assert core.md5Password('') == ''
+        assert core.md5Password(None) == ''
+
+
+class TestTheStoredHashStillAuthenticates:
+    """The fix must not lock anyone out; login is the only consumer."""
+
+    def test_login_accepts_the_password_that_was_saved(self, core):
+        stored = core.md5Password('hunter2')
+
+        # Exactly what login_post computes before calling check_password.
+        assert check_password(md5('hunter2'), stored) is True
+
+    def test_login_rejects_a_different_password(self, core):
+        stored = core.md5Password('hunter2')
+
+        assert check_password(md5('wrong'), stored) is False
+
+    def test_a_legacy_md5_row_still_authenticates(self, core):
+        """Existing installs keep working until their next login upgrades them."""
+        legacy = md5('hunter2')
+        assert is_legacy_md5_hash(legacy)
+
+        assert check_password(md5('hunter2'), legacy) is True
+
+
+class TestTheCommentMatchesTheCode:
+
+    def test_no_comment_claims_new_passwords_are_always_bcrypt_unless_true(self):
+        """Pins the sentence that was false for as long as md5Password existed.
+
+        Not style policing: that comment is precisely why the defect survived.
+        It told every reader -- and every reviewer -- that the thing they were
+        looking at had already been handled.
+        """
+        from pathlib import Path
+
+        source = Path(__file__).resolve().parents[2] / 'couchpotato' / 'core' / '_base' / '_core.py'
+        text = source.read_text(encoding='utf-8')
+
+        # Slice to the NEXT top-level method, not to the first blank line: the
+        # docstring contains blank lines, and an extraction that stops at one
+        # reads a fraction of the body and then reports on it confidently.
+        start = text.find('    def md5Password(self, value):')
+        assert start != -1, 'md5Password not found -- this guard is no longer watching anything'
+        rest = text[start + 1:]
+        end = rest.find('\n    def ')
+        body = rest[:end if end != -1 else len(rest)]
+
+        assert 'hash_password' in body, (
+            'md5Password does not call hash_password, so passwords set through '
+            'the UI are not bcrypt: %r' % body
+        )

--- a/tests/unit/test_privacy_filter_bare_secrets.py
+++ b/tests/unit/test_privacy_filter_bare_secrets.py
@@ -1,0 +1,110 @@
+"""`PrivacyFilter` redacted only query-string secrets, not bare `name=value`.
+
+The filter's substitutions were anchored on `?name=` and `&name=`, so anything
+logged outside a URL went through untouched. Three live call sites did exactly
+that:
+
+  * `notifications/telegrambot.py:37` -- `token=%s` at **ERROR** level, so it
+    reaches production logs, not just a debug run. The Telegram bot token is a
+    full send-as-this-bot credential.
+  * `downloaders/synology.py:125` -- `sid=%s`, the Synology session id.
+  * `http_client.py:236` -- logs the full URL, which the query-param pass DOES
+    cover, provided the parameter name is in the list. `token`, `authkey`,
+    `torrent_pass` and `sid` were not.
+
+Why it matters beyond tidiness: this branch made those logs travel. The E2E
+harness attaches a console handler and CI uploads that stream as a build
+artefact, and the same filter is what the `--console_log` path relies on. A
+secret that used to sit in a local file now leaves the machine.
+
+The bare-name pass is deliberately conservative about where it stops -- see
+`test_redaction_stops_at_the_value` -- because a filter that eats the rest of
+the line destroys the diagnostic the operator needed, and a redaction nobody
+can read around gets switched off.
+"""
+import logging
+
+import pytest
+
+from couchpotato.core.logger import PrivacyFilter
+
+
+@pytest.fixture
+def record_filter(monkeypatch):
+    """A PrivacyFilter with dev mode off and a known api_key."""
+    f = PrivacyFilter()
+    monkeypatch.setattr(PrivacyFilter, '_is_develop', False, raising=False)
+    monkeypatch.setattr(PrivacyFilter, '_api_key', 'THEAPIKEY', raising=False)
+    return f
+
+
+def _filtered(f, msg, *args):
+    record = logging.LogRecord('t', logging.INFO, __file__, 1, msg, args or None, None)
+    f.filter(record)
+    return str(record.msg)
+
+
+class TestBareSecretsAreRedacted:
+
+    @pytest.mark.parametrize('name,secret', [
+        ('token', '123456:AAH-SUPERSECRETBOTTOKEN'),
+        ('sid', 'abcdef0123456789'),
+        ('authkey', 'AUTHKEYVALUE'),
+        ('torrent_pass', 'TORRENTPASSVALUE'),
+        ('passkey', 'PASSKEYVALUE'),
+        ('api_key', 'APIKEYVALUE'),
+        ('password', 'hunter2'),
+    ])
+    def test_a_bare_name_equals_value_is_redacted(self, record_filter, name, secret):
+        out = _filtered(record_filter, 'something failed (%s=%s)' % (name, secret))
+
+        assert secret not in out, (
+            '%s= was logged in the clear outside a query string: %r' % (name, out)
+        )
+
+    def test_the_telegram_call_site_shape(self, record_filter):
+        """The exact message from notifications/telegrambot.py:37, at ERROR."""
+        out = _filtered(
+            record_filter,
+            'Could not send notification to TelegramBot (token=%s). Response: [%s]',
+            '123456:AAH-SUPERSECRET', 'Bad Request',
+        )
+
+        assert '123456:AAH-SUPERSECRET' not in out, out
+        assert 'Bad Request' in out, 'the diagnostic was destroyed along with the secret'
+
+    def test_the_synology_call_site_shape(self, record_filter):
+        out = _filtered(record_filter, 'sid=%s', 'SYNOSESSIONID')
+
+        assert 'SYNOSESSIONID' not in out, out
+
+
+class TestRedactionStaysUseful:
+    """A filter that eats the line destroys the diagnostic and gets turned off."""
+
+    def test_redaction_stops_at_the_value(self, record_filter):
+        out = _filtered(record_filter, 'token=SECRETVALUE and the response was 404 Not Found')
+
+        assert 'SECRETVALUE' not in out
+        assert '404 Not Found' in out, (
+            'the redaction consumed the rest of the message: %r' % out
+        )
+
+    def test_an_unrelated_assignment_is_left_alone(self, record_filter):
+        out = _filtered(record_filter, 'retries=3 timeout=30 status=ok')
+
+        assert 'retries=3' in out
+        assert 'timeout=30' in out
+        assert 'status=ok' in out
+
+    def test_query_string_redaction_still_works(self, record_filter):
+        """The pass that already existed must not regress."""
+        out = _filtered(record_filter, 'Opening url: get https://api.example/3/x?api_key=SECRET&page=2')
+
+        assert 'SECRET' not in out
+        assert 'page=2' in out, 'a non-secret query parameter was redacted too'
+
+    def test_the_api_key_itself_is_still_redacted(self, record_filter):
+        out = _filtered(record_filter, 'GET /api/THEAPIKEY/movie.list')
+
+        assert 'THEAPIKEY' not in out, out

--- a/tests/unit/test_privacy_filter_bare_secrets.py
+++ b/tests/unit/test_privacy_filter_bare_secrets.py
@@ -108,3 +108,58 @@ class TestRedactionStaysUseful:
         out = _filtered(record_filter, 'GET /api/THEAPIKEY/movie.list')
 
         assert 'THEAPIKEY' not in out, out
+
+
+class TestPrefixedAndMixedCaseSecretNames:
+    """`X-Plex-Token=` reaches the log and neither pass caught it.
+
+    `notifications/plex/server.py:85` builds
+    `'%s/%s?X-Plex-Token=%s' % (host, path, auth_token)` and hands it to
+    `urlopen`, and `http_client.py:236` logs `'Opening url: %s %s'` with the
+    full URL at INFO. So the Plex auth token was written to the log on every
+    Plex notification.
+
+    Neither redaction pass matched it: the query-string pass wants an exact
+    lowercase `token` immediately after `?` or `&`, and the bare pass was
+    case-sensitive and anchored with `\\b` directly against the name. Raised as
+    a nit; it is a live secret leak.
+
+    Prefix matching is applied ONLY to names long and distinctive enough to
+    carry it -- see `test_short_names_are_not_prefix_matched`.
+    """
+
+    @pytest.mark.parametrize('spelling', [
+        'token=SECRETVALUE',
+        'access_token=SECRETVALUE',
+        'bot_token=SECRETVALUE',
+        'X-Plex-Token=SECRETVALUE',
+        'Token=SECRETVALUE',
+        'API_KEY=SECRETVALUE',
+        'new_password=SECRETVALUE',
+    ])
+    def test_prefixed_and_mixed_case_names_are_redacted(self, record_filter, spelling):
+        out = _filtered(record_filter, 'request failed: %s' % spelling)
+
+        assert 'SECRETVALUE' not in out, (
+            '%s went to the log in the clear: %r' % (spelling, out)
+        )
+
+    def test_the_real_plex_url_shape(self, record_filter):
+        out = _filtered(
+            record_filter,
+            'Opening url: %s %s, data: %s',
+            'get', 'http://plex:32400/library?X-Plex-Token=PLEXAUTHTOKEN', "['a']",
+        )
+
+        assert 'PLEXAUTHTOKEN' not in out, out
+        assert 'plex:32400' in out, 'the host was destroyed along with the token'
+
+    def test_short_names_are_not_prefix_matched(self, record_filter):
+        """`sid` is three characters; prefix-matching it would eat ordinary words.
+
+        The redaction has to stay narrow enough that people leave it on.
+        """
+        out = _filtered(record_filter, 'basid=notasecret and resid=alsofine')
+
+        assert 'notasecret' in out, out
+        assert 'alsofine' in out, out

--- a/tests/unit/test_route_auth_inventory.py
+++ b/tests/unit/test_route_auth_inventory.py
@@ -1,0 +1,153 @@
+"""Every route is either authenticated or explicitly, deliberately public.
+
+The spec calls this PR's highest-value single criterion, and `/getkey/` is why:
+it exists because a route was once added without anyone having to state, at the
+time, whether it needed auth. Fixing one endpoint fixes one endpoint. This
+fixes the class, by making "public" something you have to write down in a list
+a test reads.
+
+**Read this before changing the walker.** FastAPI 0.140 does NOT flatten an
+included router into `app.routes`. It leaves a single
+`fastapi.routing._IncludedRouter` object there, whose routes live on
+`.original_router.routes`. So a naive `for r in app.routes` sees 14 routes and
+**zero** with `require_auth`, because every UI route is nested one level down --
+and "zero routes are protected" reads like a catastrophic security finding
+while being purely an artefact of the walk. That false alarm was produced twice
+while writing this file. `test_the_inventory_actually_sees_the_application`
+below exists to make it impossible to ship a third time.
+
+Measured on the current tree: 80 APIRoutes, 33 distinct protected paths, 11
+distinct public ones.
+"""
+import os
+
+import pytest
+from fastapi.routing import APIRoute
+
+from couchpotato.environment import Env
+
+
+#: Routes that MUST be reachable without a session, each with its reason.
+#:
+#: Adding an entry here is the point of the file: a small, deliberate,
+#: reviewed act. Adding a route and never thinking about auth is not.
+#: The inline reasons mirror `ORPHAN_ALLOWLIST` in
+#: `scripts/check_test_traps.py` and `.gitleaksignore`'s comment requirement --
+#: a bare path in a set tells the next reader nothing about whether it is
+#: still meant to be there.
+PUBLIC_ROUTES = {
+    '/login': 'the login form itself; requiring a session to log in cannot work',
+    '/login/': 'trailing-slash variant of the above',
+    '/logout': 'must work from an expired or broken session, which is exactly when it is used',
+    '/logout/': 'trailing-slash variant of the above',
+    '/robots.txt': 'crawler directive, carries no data',
+    '/api/{route:path}': 'authenticated by api_key inside callApiHandler, not by session. '
+                         'A session dependency here would break every script and the userscript.',
+    '/getkey': 'PRE-EXISTING, and slated for deletion later in this PR (AC-SEC-5). Listed so '
+               'the inventory is honest about what ships today rather than passing by '
+               'omission; this entry goes when the route does.',
+    '/getkey/': 'trailing-slash variant of the above',
+    '/old': 'legacy UI redirect; retirement tracked in specs/UI-MIGRATION.md',
+    '/old/': 'trailing-slash variant of the above',
+    '/old/{route:path}': 'legacy UI catch-all; see above',
+}
+
+
+@pytest.fixture
+def app(tmp_path):
+    """The real application, built the way the other web tests build it."""
+    Env.set('app_dir', os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+    Env.set('data_dir', str(tmp_path))
+    Env.set('web_base', '/')
+    Env.set('api_base', '/api/testkey123/')
+    Env.set('static_path', '/static/')
+    Env.set('dev', False)
+
+    from couchpotato import create_app
+    return create_app('testkey123', '/')
+
+
+def _walk(routes):
+    """Every APIRoute reachable from `routes`, descending into included routers.
+
+    `_IncludedRouter` (FastAPI >= 0.140) is the case that matters: it is a
+    single entry in `app.routes` standing in for a whole router, and its
+    routes hang off `.original_router`. Miss it and this file measures 14
+    routes instead of 80, all of them apparently unauthenticated.
+    """
+    for route in routes:
+        if isinstance(route, APIRoute):
+            yield route
+        original = getattr(route, 'original_router', None)
+        if original is not None:
+            yield from _walk(getattr(original, 'routes', []) or [])
+        elif getattr(route, 'routes', None):
+            yield from _walk(route.routes)
+
+
+def _dependency_names(route) -> set:
+    dependant = getattr(route, 'dependant', None)
+    return {
+        getattr(d.call, '__name__', '')
+        for d in (getattr(dependant, 'dependencies', []) or [])
+        if getattr(d, 'call', None) is not None
+    }
+
+
+def test_the_inventory_actually_sees_the_application(app):
+    """Guard the guard.
+
+    Every assertion below is of the form "no route is unprotected", which an
+    empty or half-walked app satisfies trivially. Two separate harness
+    mistakes produced exactly that during development -- an `Env` too crude
+    for `create_app` to finish, and a walker that did not descend into
+    `_IncludedRouter`. Both reported zero protected routes.
+    """
+    routes = list(_walk(app.routes))
+    assert len(routes) >= 60, (
+        'only %d APIRoutes found. The walk is not reaching the included '
+        'routers, so every assertion below would pass vacuously.' % len(routes)
+    )
+
+    paths = {r.path for r in routes}
+    assert '/wanted/' in paths, (
+        'the UI routes are not being walked, so this inventory is measuring an '
+        'app nobody serves'
+    )
+
+    protected = {r.path for r in routes if 'require_auth' in _dependency_names(r)}
+    assert len(protected) >= 20, (
+        'only %d protected paths found; the dependency is not being read '
+        'correctly' % len(protected)
+    )
+
+
+def test_every_route_is_authenticated_or_explicitly_public(app):
+    unlisted = sorted({
+        r.path for r in _walk(app.routes)
+        if 'require_auth' not in _dependency_names(r) and r.path not in PUBLIC_ROUTES
+    })
+
+    assert not unlisted, (
+        'these routes require no session and are not in PUBLIC_ROUTES:\n  %s\n\n'
+        'Either add the auth dependency, or add the path to PUBLIC_ROUTES WITH '
+        'the reason it is safe. `/getkey/` exists because that decision was '
+        'never written down anywhere.' % '\n  '.join(unlisted)
+    )
+
+
+def test_the_allowlist_has_no_entries_for_routes_that_no_longer_exist(app):
+    """A stale entry silently pre-approves a future route that reuses the path."""
+    live = {r.path for r in _walk(app.routes)}
+    stale = sorted(p for p in PUBLIC_ROUTES if p not in live)
+
+    assert not stale, (
+        'PUBLIC_ROUTES names paths the app no longer serves: %s. Remove them, '
+        'or a later route reusing one of these paths is public before anyone '
+        'reviews it.' % stale
+    )
+
+
+def test_every_allowlist_entry_carries_a_reason():
+    empty = sorted(p for p, reason in PUBLIC_ROUTES.items() if not reason.strip())
+    assert not empty, 'PUBLIC_ROUTES entries with no stated reason: %s' % empty

--- a/tests/unit/test_settings_atomic_save.py
+++ b/tests/unit/test_settings_atomic_save.py
@@ -1,0 +1,193 @@
+"""T2.0: `Settings.save()` must never leave `config.ini` truncated.
+
+The shipped implementation is:
+
+    def save(self):
+        with open(self.file, 'w', encoding='utf-8') as configfile:
+            self.p.write(configfile)
+
+`open(..., 'w')` TRUNCATES before a single byte is written. If the process dies
+or the volume fills between the truncate and the flush, `config.ini` is left
+empty or partial -- and that file holds the api_key, the UI password, and every
+downloader and notifier credential. `docs/development-process.md` also names it
+as the lock-out recovery file, so the failure destroys the remedy along with
+the configuration.
+
+`Env.setting(attr, value=...)` calls this unconditionally
+(`environment.py:71`), and PR 2 is what makes it fire in bulk: forcing a
+first-ever login triggers the legacy-md5-to-bcrypt rehash, which rewrites the
+whole file per user.
+
+Test 2 is the load-bearing one. It injects the failure at the point the OLD
+code would already have truncated, so it cannot pass by accident on an
+implementation that truncates first -- which is the difference between this
+suite and one that merely round-trips.
+"""
+import configparser
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from couchpotato.core.settings import Settings
+
+
+def _settings(path: Path) -> Settings:
+    """A Settings bound to `path`, with one section written through it."""
+    s = Settings()
+    s.setFile(str(path))
+    s.addSection('core')
+    s.p.set('core', 'api_key', 'IRREPLACEABLE-KEY')
+    s.p.set('core', 'password', 'hunter2-hash')
+    return s
+
+
+def _read(path: Path) -> configparser.ConfigParser:
+    parser = configparser.ConfigParser()
+    parser.read(str(path), encoding='utf-8')
+    return parser
+
+
+class TestSaveRoundTrip:
+
+    def test_values_survive_a_save_and_reload(self, tmp_path):
+        target = tmp_path / 'config.ini'
+        settings = _settings(target)
+
+        settings.save()
+
+        assert _read(target)['core']['api_key'] == 'IRREPLACEABLE-KEY'
+
+    def test_a_second_save_replaces_rather_than_appends(self, tmp_path):
+        target = tmp_path / 'config.ini'
+        settings = _settings(target)
+        settings.save()
+        settings.p.set('core', 'api_key', 'ROTATED-KEY')
+
+        settings.save()
+
+        parser = _read(target)
+        assert parser['core']['api_key'] == 'ROTATED-KEY'
+        assert len(parser.sections()) == 1, 'the file grew instead of being replaced'
+
+
+class TestSaveIsAtomic:
+    """The whole point: a failed write must not destroy the existing file."""
+
+    def test_a_failure_mid_write_leaves_the_original_intact(self, tmp_path, monkeypatch):
+        """The load-bearing test.
+
+        Injects at `ConfigParser.write`, which is called AFTER the old code has
+        already truncated the target -- so an implementation that opens the
+        real file with 'w' cannot pass this, and one that writes a temp file
+        first cannot fail it. A disk-full or a killed process at that instant
+        is the real-world shape.
+        """
+        target = tmp_path / 'config.ini'
+        settings = _settings(target)
+        settings.save()
+        original = target.read_bytes()
+        assert b'IRREPLACEABLE-KEY' in original, 'fixture did not write anything to protect'
+
+        def boom(self, fp, space_around_delimiters=True):
+            fp.write('[core]\napi_key = PARTIAL')   # a partial write, then death
+            raise OSError(28, 'No space left on device')
+
+        monkeypatch.setattr(configparser.RawConfigParser, 'write', boom)
+
+        with pytest.raises(OSError):
+            settings.save()
+
+        assert target.read_bytes() == original, (
+            'config.ini was modified by a save that FAILED. It holds the '
+            'api_key, the UI password and every downloader credential, and it '
+            'is the documented lock-out recovery file.'
+        )
+
+    def test_a_failure_leaves_no_temp_file_behind(self, tmp_path, monkeypatch):
+        """`config.ini.*` is exactly what a locked-out operator reaches for."""
+        target = tmp_path / 'config.ini'
+        settings = _settings(target)
+        settings.save()
+
+        def boom(self, fp, space_around_delimiters=True):
+            raise OSError(28, 'No space left on device')
+
+        monkeypatch.setattr(configparser.RawConfigParser, 'write', boom)
+        with pytest.raises(OSError):
+            settings.save()
+
+        strays = [p.name for p in tmp_path.iterdir() if p.name != 'config.ini']
+        assert strays == [], 'a failed save left %s behind' % strays
+
+    def test_the_file_never_disappears_during_a_save(self, tmp_path, monkeypatch):
+        """There must be no window in which the path does not exist.
+
+        A concurrent reader -- or a container healthcheck, or a restart --
+        landing in a truncate-then-write window sees an empty or absent file.
+        Checked from inside `ConfigParser.write`, i.e. mid-save.
+        """
+        target = tmp_path / 'config.ini'
+        settings = _settings(target)
+        settings.save()
+
+        seen = {}
+        real_write = configparser.RawConfigParser.write
+
+        def observe(self, fp, space_around_delimiters=True):
+            seen['exists'] = target.exists()
+            seen['content'] = target.read_bytes() if target.exists() else b''
+            return real_write(self, fp, space_around_delimiters)
+
+        monkeypatch.setattr(configparser.RawConfigParser, 'write', observe)
+        settings.save()
+
+        assert seen['exists'], 'config.ini did not exist while a save was in flight'
+        assert b'IRREPLACEABLE-KEY' in seen['content'], (
+            'config.ini was already truncated while the save was in flight: a '
+            'reader in that window sees an empty file'
+        )
+
+
+class TestSavePreservesFileProperties:
+
+    def test_an_existing_mode_is_preserved(self, tmp_path):
+        """A save must not silently change permissions in either direction."""
+        target = tmp_path / 'config.ini'
+        settings = _settings(target)
+        settings.save()
+        os.chmod(target, 0o640)
+
+        settings.p.set('core', 'api_key', 'ROTATED')
+        settings.save()
+
+        assert stat.S_IMODE(os.stat(target).st_mode) == 0o640
+
+    def test_a_new_file_is_not_world_readable(self, tmp_path):
+        """It holds the api_key and every downloader credential."""
+        target = tmp_path / 'config.ini'
+        _settings(target).save()
+
+        mode = stat.S_IMODE(os.stat(target).st_mode)
+        assert not mode & stat.S_IROTH, 'config.ini is world-readable (mode %o)' % mode
+
+    def test_a_symlinked_config_stays_a_symlink(self, tmp_path):
+        """`--config_file` is user-supplied and only `expanduser`'d, never
+        resolved, so an operator can legitimately point it at a symlink.
+        `os.replace` onto a symlink replaces the LINK, orphaning the real file.
+        """
+        real = tmp_path / 'real-config.ini'
+        link = tmp_path / 'config.ini'
+        settings = _settings(real)
+        settings.save()
+        link.symlink_to(real)
+
+        linked = _settings(link)
+        linked.p.set('core', 'api_key', 'THROUGH-THE-LINK')
+        linked.save()
+
+        assert link.is_symlink(), 'the symlink was replaced by a regular file'
+        assert _read(real)['core']['api_key'] == 'THROUGH-THE-LINK', (
+            'the write did not reach the symlink target'
+        )

--- a/tests/unit/test_settings_atomic_save.py
+++ b/tests/unit/test_settings_atomic_save.py
@@ -191,3 +191,98 @@ class TestSavePreservesFileProperties:
         assert _read(real)['core']['api_key'] == 'THROUGH-THE-LINK', (
             'the write did not reach the symlink target'
         )
+
+
+class TestSaveDoesNotSilentlyChangeFileIdentity:
+    """`os.replace` creates a NEW inode; truncate-then-write reused the old one.
+
+    That difference is the price of atomicity, and it is not free. The previous
+    implementation preserved owner, group, ACLs and any hardlinks simply by
+    never replacing the inode. This one has to copy those forward deliberately,
+    or a config.ini with a managed owner or group -- say, group-readable by a
+    backup account -- silently becomes owned by the server process on the next
+    save, locking that tooling out or handing the server's primary group access
+    to stored credentials.
+    """
+
+    def test_group_ownership_is_carried_across(self, tmp_path):
+        """Set a NON-primary group first, or this test cannot fail.
+
+        `mkstemp` creates the temp file with the process's PRIMARY gid. If the
+        fixture leaves config.ini on that same gid, the assertion passes
+        whether the code preserves anything or not -- the incidentally-passing
+        shape. So the file is first chgrp'd to another group this user belongs
+        to, which is exactly what a managed deployment does (group-readable by
+        a backup account) and exactly what `os.replace` would silently discard.
+        """
+        import os as _os
+
+        alternates = [g for g in _os.getgroups() if g != _os.getgid()]
+        if not alternates:
+            pytest.skip('this user belongs to no group other than its primary; '
+                        'the assertion could not fail here')
+        alt_gid = alternates[0]
+
+        target = tmp_path / 'config.ini'
+        settings = _settings(target)
+        settings.save()
+        _os.chown(target, -1, alt_gid)
+        assert _os.stat(target).st_gid == alt_gid, 'fixture did not take effect'
+
+        settings.p.set('core', 'api_key', 'ROTATED')
+        settings.save()
+
+        assert _os.stat(target).st_gid == alt_gid, (
+            'the save reset the file group to the process default, discarding '
+            'a deliberate ownership arrangement'
+        )
+
+
+class TestSaveTightensAWorldReadableConfig:
+    """Preserving the mode means an ALREADY-DEPLOYED 0644 config stays 0644.
+
+    Every config.ini written before this change was created world-readable by
+    `open(file, 'w')` under a default umask -- holding the api_key, the
+    password hash, and every downloader and notifier credential. Carrying the
+    mode forward unchanged means those files stay world-readable forever,
+    through every subsequent save, so the fix would harden new installs and do
+    nothing for the ones that already have the problem.
+
+    Only the WORLD bits are cleared. Group access is left exactly as the
+    operator has it, because backup tooling reading via a shared group is a
+    legitimate arrangement and silently breaking it would be a worse outcome
+    than the exposure.
+    """
+
+    def test_world_readable_bits_are_removed_on_save(self, tmp_path):
+        import os as _os
+        import stat as _stat
+
+        target = tmp_path / 'config.ini'
+        settings = _settings(target)
+        settings.save()
+        _os.chmod(target, 0o644)          # what every pre-existing install has
+
+        settings.p.set('core', 'api_key', 'ROTATED')
+        settings.save()
+
+        mode = _stat.S_IMODE(_os.stat(target).st_mode)
+        assert not mode & 0o007, (
+            'config.ini is still world-accessible (mode %o) after a save; it '
+            'holds the api_key and every downloader credential' % mode
+        )
+
+    def test_group_access_is_left_alone(self, tmp_path):
+        """0640 is a deliberate arrangement -- do not tighten it to 0600."""
+        import os as _os
+        import stat as _stat
+
+        target = tmp_path / 'config.ini'
+        settings = _settings(target)
+        settings.save()
+        _os.chmod(target, 0o640)
+
+        settings.p.set('core', 'api_key', 'ROTATED')
+        settings.save()
+
+        assert _stat.S_IMODE(_os.stat(target).st_mode) == 0o640


### PR DESCRIPTION
## M1a: authentication and web-surface security

Implements PR 2 of `specs/REMEDIATION-2026-08.md`. Every change is test-first,
and every fix was proven load-bearing by breaking the thing it guards, watching
the right test fail, and restoring the file byte-identically by SHA-256.

**Four of these are live authentication bypasses, and they compound.**

---

### The bypasses

**Auth was gated on `if username and password:`** (`__init__.py:57-71`), and
returned "fully public" otherwise. Driven directly across all four
combinations:

```
username='admin' password='secret'  -> denied without a cookie
username=''      password='secret'  -> PUBLIC
username='admin' password=''        -> PUBLIC
username=''      password=''        -> PUBLIC
```

So an operator who set a password but left the username blank had a wide-open
server and nothing said so. That was not an unlikely mistake: the settings copy
put **"Leave empty to disable authentication" on the USERNAME field**, so the
field that silently disabled auth was the one whose own description promised it
would. Now gated on an explicit `auth_required` setting; the copy has moved.

**`/login/` issued a valid session for any credentials when no password was
set.** `... or not password` short-circuits the whole credential check to
`True`. The cookie it writes is the **api_key**, so this is not a UI-only
bypass — it hands the caller the credential the entire API authenticates with.

**`/getkey/` had the same flaw and is worse in consequence.** It returns the
api_key itself, in a JSON body, over GET, with credentials in the query string
— so the request line lands in access logs, proxy logs and browser history. The
`u` parameter is no protection: it is the md5 of the username, which is not a
secret.

**Passwords set through the UI or wizard were stored as unsalted MD5.**
`setting.save.core.password` was wired to `md5(value)`. bcrypt was reached only
by the login-time upgrade, which never runs for anyone who has not logged in —
and until `auth_required` landed here, the server never asked anyone to log in.
So the cohort this protects is exactly the cohort that was still on MD5.

`check_password` carried the comment **"New passwords are always bcrypt"**,
false from the day it was written. Corrected, with a test pinning it — that
sentence is *why* the defect survived, because it told every reader the thing
in front of them had already been handled.

### Why they compound

Until T2.0 landed in this PR, `config.ini` was created **0644 — world-readable**
— holding the api_key, that MD5 password, and every downloader and notifier
credential. The endpoint that leaked the key logged its own credentials in the
query string. And the log filter only redacted query-string secrets, so a bot
token logged at ERROR went out in the clear.

---

### Data safety

**`Settings.save()` was truncate-then-write.** `open(self.file, 'w')` truncates
before a byte is written, so a process death or full volume mid-write left
`config.ini` empty or partial. That file is also the documented lock-out
recovery path, so the failure destroyed the remedy along with the
configuration. Now: sibling temp file, fsync, `os.replace`, fsync the
directory.

Four details the obvious fix gets wrong, each checked against the tree rather
than assumed: `realpath` first (else `os.replace` replaces a symlinked config
and orphans the real file), a **sibling** temp (production bind-mounts
`/config`, so `/tmp` would break the rename), `BaseException` on cleanup (a
Ctrl-C must not leave `.config.ini.*.tmp`, which is what a locked-out operator
reaches for), and fsync of the directory.

### The class fix

**Route auth inventory** — every route must either carry the auth dependency or
sit in `PUBLIC_ROUTES` with its reason written inline. `/getkey/` exists
because that decision was never written down anywhere; this closes the class
rather than the instance.

It walks `_IncludedRouter.original_router` recursively, and that detail is
load-bearing: **FastAPI 0.140 stopped flattening included routers**, so a naive
`for r in app.routes` sees 14 routes and **zero** with `require_auth`, against a
real 80 routes / 33 protected paths. A broken walk does not merely undercount,
it *inverts* the answer. I produced that exact false alarm twice while writing
the file, which is why it opens with an anti-vacuity test.

---

### Deliberately not done, and why

- **HMAC-signed session cookie.** The cookie is still the api_key. This is the
  right fix and is its own PR: it changes how every request authenticates, and
  it signs out every logged-in user, so it wants its own before/after on a real
  instance.
- **`/getkey/` deleted.** Its only referrer is `simple_healthcheck.py:76`,
  whose removal is blocked on AC-OPS-12's production grep. Closing the hole did
  not depend on that, so the hole is closed and the deletion follows.
- **T2.6's Synology TLS item — RETRACTED in the spec, with evidence.**
  `synology.py:109-110` hardcodes `http://`, so the `verify=False` it targets is
  unreachable and "honour ssl_verify" would have shipped a commit that reads
  like TLS hardening and hardens nothing. The real exposure is that `_login`
  POSTs `account`/`passwd` over plaintext HTTP and the `host` setting accepts no
  scheme. That changes downloader transport and cannot be exercised without a
  real Synology, so it is deferred rather than guessed at.

### Corrections made in this branch

Stated rather than tidied away:

1. A `/getkey/` leak test **passed against the unfixed code** on its first run —
   it sent `u=anything`, so the username clause rejected the request before the
   password clause was reached. It looked like a leak test while measuring the
   wrong half of the condition. Rewritten.
2. The route-inventory test was **deleted once and rewritten**, because the
   first version introspected an app it did not understand and reported "0
   routes protected".
3. `auth_required` is a plain `{'default': 0}`, not the tri-state the spec first
   sketched — `registerDefaults` materialises the literal `auth_required = None`
   into config.ini and `Env.setting`'s default is `''`, so the natural read is
   falsy and auth would stay off on every install with no failing test and no
   log line.

### Dependencies

Triaged before raising this PR, per the rule added to the global standards this
session. Eight open Dependabot PRs; **six taken, two rejected**, and the
rejections are the point:

| PR | Outcome |
|---|---|
| #219 fastapi 0.141.1 | **taken** — verified first by unpacking the wheel, because this PR's route inventory walks `_IncludedRouter`, introduced in 0.140. Still present in 0.141.1. |
| #222 ruff 0.16.1 | **taken as an EXACT pin**, not Dependabot's `>=0.16.1`. The floating form is what let `make lint` and the gate disagree about the version earlier. Both ci.yml jobs bumped with it — a test caught me having done only one. |
| #220 jsdom, #218 playwright, #217 brace-expansion | **taken**. #217 is transitive: a plain install would not move it, it needed `npm update`. |
| **#224 trakit 0.3.0** | **REJECTED.** `pip check` after applying: `knowit 0.5.11 has requirement trakit<0.3.0`. 0.5.11 is the latest release and every version back to 0.5.8 carries the same cap, so no combination satisfies both. Merging it dutifully would have left an environment `pip check` rejects. |
| **#221 pyOpenSSL, #223 cryptography** | **Already done** in PR 1, as the fix for CVE-2026-69247. Redundant; close them. |

Separately, `npm audit` reported six advisories not covered by any Dependabot
PR — 4 high, 1 moderate, 1 low, all transitive dev dependencies. Now **zero**,
via `npm audit fix` without `--force`, so `package.json` is unchanged and only
resolved transitive versions moved.

Both graphs verified after applying: `npm ls` resolves, `pip check` reports no
broken requirements.

### Verification

- `make verify` green end to end from a clean state.
- **2291 Python unit + 42 integration + 202 UI unit**; 135 chromium, 2
  isolation (2 workers), 2 mobile, 21 accessibility.
- Every fix reverted and re-run: the named tests red, the file restored
  byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
