### PR TITLE
ci: test exactly the interpreter production ships, not five it does not

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,6 +1,6 @@
 # Contributing to CouchPotato
 
-Contributions are welcome! Please ensure compatibility with Python 3.10+ and include tests where practical.
+Contributions are welcome! Target Python 3.14 (what production runs and what CI tests) and include tests where practical.
 
 ## Getting Started
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,25 @@ jobs:
       actions: write
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        # EXACTLY the interpreter production ships (Dockerfile's
+        # python:3.14-alpine). Kept as a matrix of one so the job name
+        # stays `test (3.14)` -- it is a required status check, and a
+        # renamed context blocks every PR waiting for a check nothing
+        # publishes.
+        #
+        # Was 3.10-3.14. Dropped 2026-08-09 on measurement, not taste:
+        # across 59 CI runs no leg ever failed, and no run ever had legs
+        # disagree. There is no `requires-python` anywhere, prod is
+        # pinned to 3.14-alpine and the only dev venv is 3.14.6, so the
+        # other four legs tested configurations nobody runs -- 15.6
+        # runner-minutes per push, on the critical path, since
+        # ui-e2e-tests/test-summary/docker all `needs: test` and waited
+        # on the SLOWEST leg (3.10).
+        #
+        # test_ci_matrix_tests_the_dockerfile_version enforces that this
+        # list is exactly [Dockerfile version]; re-broadening it is a
+        # deliberate act that must change that test too.
+        python-version: ['3.14']
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: '3.12'
+        python-version: '3.14'
 
     - name: Install ruff
       run: pip install 'ruff==0.16.1'
@@ -76,7 +76,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: '3.12'
+        python-version: '3.14'
 
     - name: Run UI conformance check
       run: python scripts/check_conformance.py
@@ -137,7 +137,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: '3.12'
+        python-version: '3.14'
 
     - name: Install ruff
       run: pip install 'ruff==0.16.1'
@@ -168,7 +168,7 @@ jobs:
         # ui-e2e-tests/test-summary/docker all `needs: test` and waited
         # on the SLOWEST leg (3.10).
         #
-        # test_ci_matrix_tests_the_dockerfile_version enforces that this
+        # test_ci_matrix_tests_exactly_the_dockerfile_version enforces that this
         # list is exactly [Dockerfile version]; re-broadening it is a
         # deliberate act that must change that test too.
         python-version: ['3.14']
@@ -255,7 +255,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: '3.12'
+        python-version: '3.14'
     
     - name: Install Python dependencies
       run: |
@@ -395,7 +395,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v7
       with:
-        python-version: '3.12'
+        python-version: '3.14'
     
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.12'
+          python-version: '3.14'
 
       - name: Install dependencies
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ and `implementer` (delegated work). Invoke them by name rather than composing a
 persona from memory; `AGENTS.md` is the review rubric they apply.
 
 - **Repo:** https://github.com/bassings/CouchPotatoServer — default branch `master`
-- **Stack:** Python 3.10+, FastAPI/Uvicorn, htmx + Tailwind + Alpine.js UI, SQLite, Docker
+- **Stack:** Python 3.14 (the version production ships and the only one CI tests), FastAPI/Uvicorn, htmx + Tailwind + Alpine.js UI, SQLite, Docker
 - **Entry point:** `CouchPotato.py`
 - **Production:** http://homemedia.maeewing.com:5050 · image `ghcr.io/bassings/couchpotatoserver:latest` (Alpine, `python:3.14-alpine`)
 - **Dev container port:** 5051 (`docker-compose.dev.yml`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Python 3.10+
+- Python 3.14 — the interpreter the Docker image ships and the only one CI tests
 - Docker (recommended for local development)
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Docker](https://github.com/bassings/CouchPotatoServer/actions/workflows/docker.yml/badge.svg)](https://github.com/bassings/CouchPotatoServer/actions/workflows/docker.yml)
 [![Lint](https://github.com/bassings/CouchPotatoServer/actions/workflows/lint.yml/badge.svg)](https://github.com/bassings/CouchPotatoServer/actions/workflows/lint.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.14](https://img.shields.io/badge/python-3.14-blue.svg)](https://www.python.org/downloads/)
 
 Automatic NZB and torrent downloader for movies. Maintain a watchlist and CouchPotato will search for releases, then send them to SABnzbd, NZBGet, or your torrent client.
 
@@ -12,7 +12,7 @@ This is a **Python 3 fork** of the [archived original](https://github.com/CouchP
 
 ## What's New in v3.0.0
 
-- **Python 3.10+** (tested on 3.10 through 3.14)
+- **Python 3.14** — the interpreter the Docker image ships and the only one CI tests. Older versions are untested and unsupported; running from source on 3.13 or below may work but nothing verifies it.
 - **Complete Python 2 to 3 migration** — every module updated, all legacy `unicode`/`bytes` issues resolved
 - **457 tests** covering database operations, web framework, settings, events, concurrency, security, and performance
 - **Security hardened** — rate limiting (300 req/min), API key validation, input sanitisation, directory traversal protection
@@ -140,7 +140,7 @@ Reference docs are in [`docs/reference/`](docs/reference/):
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. Please ensure compatibility with Python 3.10+ and include tests where practical.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. Target Python 3.14 (what production runs and what CI tests) and include tests where practical.
 
 ## License
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,7 +4,7 @@ This guide covers migrating from the legacy Python 2 version to the modernized P
 
 ## Requirements
 
-- **Python 3.10+** (3.12+ recommended)
+- **Python 3.14** — the version the Docker image ships and the only one CI tests. Older interpreters are untested.
 - All dependencies installed from `requirements.txt`
 
 ## Before You Start

--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -511,7 +511,7 @@ exist to prevent, so they do not get to be the untested part of the suite.
   `adapter.create(str(tmp_path / 'name'))`.
 - `test_api_auth.py`, `test_fastapi_web.py`, `test_security.py` run locally too —
   `httpx` is installed in `.venv`, so run them via `.venv/bin/python -m pytest`.
-- CI matrix: Python 3.10, 3.11, 3.12, 3.13, 3.14.
+- CI matrix: Python 3.14 only — exactly the interpreter the Dockerfile ships, enforced by `test_ci_matrix_tests_exactly_the_dockerfile_version`. Narrowed from 3.10-3.14 on 2026-08-09: 59 consecutive runs showed no leg ever failing and no two legs disagreeing, and the four extra legs cost 15.6 runner-minutes a push on the critical path.
 - Note: a bare `pytest tests/unit/ -q` may hit import errors for tests touching
   vendored `libs/` — `make test-py` sets `PYTHONPATH=libs`. Prefer `make verify`
   / `make test-py`, or add the prefix if invoking pytest directly.

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -725,7 +725,10 @@ scope and a reviewer can read the dedent directly against the original.
 5. `diskcache` was replaced with `SQLiteCache` (CVE-2025-69872 — pickle RCE,
    lib abandoned).
 6. Branch protection check names must match exactly — matrix jobs report as
-   `test (3.10)`, not `test`.
+   `test (3.14)`, not `test`. (The matrix is a single version as of
+   2026-08-09, but it is still a matrix, so the leg name still carries the
+   version. No matrix leg is a required context; `test-summary` is, and it
+   `needs: [test]`.)
 7. Dependabot PRs may need `--admin` merge if they predate CI changes.
 8. Docker image is **Alpine**-based: use `apk`/`su-exec`/`adduser` in the
    Dockerfile, not `apt`/`gosu`/`useradd`. The entrypoint is `#!/bin/sh` (no

--- a/specs/REG-003-p0-security-observability.md
+++ b/specs/REG-003-p0-security-observability.md
@@ -22,7 +22,7 @@ This disables certificate validation (no hostname check, no CA verification)
 for **every** `urllib`/`http.client`-based HTTPS call made anywhere in the
 process for the lifetime of the app — not just CouchPotato's own requests.
 It's a leftover Python-2.7.9 workaround (the version guard is dead code on
-Python 3.10+, which is the supported floor per `CLAUDE.md`). A
+Python 3.10+; the project now ships and tests 3.14 only, per `CLAUDE.md`). A
 man-in-the-middle can intercept any HTTPS call CouchPotato or a library it
 loads makes (provider APIs, notifications, update checks, etc.) and the app
 will not notice.

--- a/tests/unit/test_dockerfile_python_version.py
+++ b/tests/unit/test_dockerfile_python_version.py
@@ -127,6 +127,44 @@ def test_ci_matrix_tests_exactly_the_dockerfile_version():
     )
 
 
+def test_every_ci_job_uses_the_dockerfile_python():
+    """Not just the `test` matrix -- EVERY setup-python in ci.yml.
+
+    This is the guard that would have caught the drift it was written for.
+    When the matrix was narrowed to the production interpreter, five jobs were
+    still pinned to 3.12 by a separate `python-version:` field, including
+    `ui-e2e-tests` and `accessibility` -- which START THE APPLICATION. So the
+    two browser gates were exercising an interpreter the project had just
+    declared unsupported, while the matrix guard passed because it only looked
+    at the matrix.
+
+    Checking one place and calling it "CI tests what production ships" is the
+    failure here; the claim is only as strong as its weakest job.
+    """
+    dockerfile_version = dockerfile_versions()[0]
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+
+    wrong = []
+    for job_name, job in workflow["jobs"].items():
+        for step in job.get("steps", []) or []:
+            if not isinstance(step, dict):
+                continue
+            if not str(step.get("uses", "")).startswith("actions/setup-python"):
+                continue
+            version = str((step.get("with") or {}).get("python-version", ""))
+            if version.startswith("${{"):
+                continue  # driven by the matrix, covered by the test above
+            if version != dockerfile_version:
+                wrong.append(f"{job_name}={version}")
+
+    assert not wrong, (
+        f"Dockerfile ships Python {dockerfile_version} but these ci.yml jobs "
+        f"pin a different interpreter: {sorted(wrong)}. Jobs that start the "
+        f"application (ui-e2e-tests, accessibility) must run the production "
+        f"interpreter or the gate is testing something nobody ships."
+    )
+
+
 def test_local_docker_runner_defaults_to_the_dockerfile_version():
     """`./scripts/test-local.sh` with no argument should reproduce production,
     not an arbitrary older interpreter a developer has to remember to pass."""

--- a/tests/unit/test_dockerfile_python_version.py
+++ b/tests/unit/test_dockerfile_python_version.py
@@ -101,15 +101,29 @@ def test_dockerfile_builder_and_runtime_stages_agree():
     )
 
 
-def test_ci_matrix_tests_the_dockerfile_version():
-    """production's interpreter (Dockerfile) must be a CI-tested interpreter."""
+def test_ci_matrix_tests_exactly_the_dockerfile_version():
+    """CI tests the production interpreter, and ONLY it.
+
+    Strengthened from membership to equality when the matrix was locked to a
+    single version (2026-08-09). Membership was the right check while five
+    legs ran; with one leg it would be satisfied by a matrix that had drifted
+    to `['3.12', '3.14']` and quietly reintroduced 15.6 runner-minutes a push.
+
+    Equality also makes the pairing explicit in the other direction: bumping
+    the Dockerfile without bumping CI fails here, so production can never ship
+    an interpreter no test has run. Re-broadening the matrix is then a
+    deliberate act that has to change this test and say why.
+    """
     dockerfile_version = dockerfile_versions()[0]
     matrix_versions = ci_matrix_python_versions()
-    assert dockerfile_version in matrix_versions, (
-        f"Dockerfile ships Python {dockerfile_version}, but ci.yml's test "
-        f"matrix ({matrix_versions}) does not include it — CI is not testing "
-        f"the interpreter that ships in production. Add {dockerfile_version!r} "
-        f"to `strategy.matrix.python-version` in {CI_WORKFLOW}."
+    assert matrix_versions == [dockerfile_version], (
+        f"Dockerfile ships Python {dockerfile_version} but ci.yml's test "
+        f"matrix is {matrix_versions}. CI must test exactly the interpreter "
+        f"production runs: set `strategy.matrix.python-version` to "
+        f"['{dockerfile_version}'] in {CI_WORKFLOW}. If you are deliberately "
+        f"re-broadening the matrix, update this test and record why -- the "
+        f"four extra legs were dropped because 59 consecutive CI runs showed "
+        f"no leg ever failing and no two legs ever disagreeing."
     )
 
 

--- a/tests/unit/test_dockerfile_python_version.py
+++ b/tests/unit/test_dockerfile_python_version.py
@@ -145,7 +145,14 @@ def test_every_workflow_job_uses_the_dockerfile_python():
     dockerfile_version = dockerfile_versions()[0]
 
     wrong = []
-    for path in sorted(CI_WORKFLOW.parent.glob("*.yml")):
+    # BOTH extensions: GitHub Actions accepts .yaml as well as .yml, and a
+    # guard that silently skips half the possible filenames is the same
+    # too-narrow-scope defect this test was widened to fix.
+    workflow_files = sorted(
+        set(CI_WORKFLOW.parent.glob("*.yml")) | set(CI_WORKFLOW.parent.glob("*.yaml"))
+    )
+    assert workflow_files, "no workflow files found -- the glob is wrong"
+    for path in workflow_files:
         workflow = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
         for job_name, job in (workflow.get("jobs") or {}).items():
             for step in job.get("steps", []) or []:

--- a/tests/unit/test_dockerfile_python_version.py
+++ b/tests/unit/test_dockerfile_python_version.py
@@ -127,8 +127,9 @@ def test_ci_matrix_tests_exactly_the_dockerfile_version():
     )
 
 
-def test_every_ci_job_uses_the_dockerfile_python():
-    """Not just the `test` matrix -- EVERY setup-python in ci.yml.
+def test_every_workflow_job_uses_the_dockerfile_python():
+    """Not just the `test` matrix, and not just ci.yml -- EVERY setup-python
+    in EVERY workflow.
 
     This is the guard that would have caught the drift it was written for.
     When the matrix was narrowed to the production interpreter, five jobs were
@@ -142,26 +143,27 @@ def test_every_ci_job_uses_the_dockerfile_python():
     failure here; the claim is only as strong as its weakest job.
     """
     dockerfile_version = dockerfile_versions()[0]
-    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
 
     wrong = []
-    for job_name, job in workflow["jobs"].items():
-        for step in job.get("steps", []) or []:
-            if not isinstance(step, dict):
-                continue
-            if not str(step.get("uses", "")).startswith("actions/setup-python"):
-                continue
-            version = str((step.get("with") or {}).get("python-version", ""))
-            if version.startswith("${{"):
-                continue  # driven by the matrix, covered by the test above
-            if version != dockerfile_version:
-                wrong.append(f"{job_name}={version}")
+    for path in sorted(CI_WORKFLOW.parent.glob("*.yml")):
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for job_name, job in (workflow.get("jobs") or {}).items():
+            for step in job.get("steps", []) or []:
+                if not isinstance(step, dict):
+                    continue
+                if not str(step.get("uses", "")).startswith("actions/setup-python"):
+                    continue
+                version = str((step.get("with") or {}).get("python-version", ""))
+                if version.startswith("${{"):
+                    continue  # driven by the matrix, covered by the test above
+                if version != dockerfile_version:
+                    wrong.append(f"{path.name}:{job_name}={version}")
 
     assert not wrong, (
-        f"Dockerfile ships Python {dockerfile_version} but these ci.yml jobs "
-        f"pin a different interpreter: {sorted(wrong)}. Jobs that start the "
-        f"application (ui-e2e-tests, accessibility) must run the production "
-        f"interpreter or the gate is testing something nobody ships."
+        f"Dockerfile ships Python {dockerfile_version} but these workflow jobs "
+        f"pin a different interpreter: {sorted(wrong)}. Any job that starts the "
+        f"application or runs its tests must use the production interpreter, or "
+        f"the gate is testing something nobody ships."
     )
 
 


### PR DESCRIPTION
Owner request: the multi-version Python matrix is historic and not earning its keep. Measured before changing it — and the evidence is stronger than "not much value".

## The four extra legs delivered zero, measured

| | |
|---|---|
| Production runs | `python:3.14-alpine` (`Dockerfile:10,30`) |
| Only dev venv | 3.14.6 |
| `requires-python` declared anywhere | **none** — no packaging contract promised 3.10 |
| Leg failures across **59** consecutive CI runs | **zero** |
| Runs where legs disagreed | **zero** |
| Cost | **15.6 runner-minutes per push** |

And it was on the **critical path**: `ui-e2e-tests`, `test-summary` and `docker` all `needs: test`, so the whole chain waited on the *slowest* leg — 3.10, the one furthest from anything that actually runs.

## Three things done beyond the literal change

**Kept as a matrix of one**, so the leg still reports as `test (3.14)`. Verified against the live branch-protection API rather than assumed: no matrix leg is a required context, `test-summary` is, and it still `needs: test`. A vanished required context blocks every PR forever waiting for a check nothing publishes — the trap this repo already hit once on the accessibility job.

**The drift guard is strengthened from membership to equality.** `dockerfile_version in matrix_versions` was correct while five legs ran; with one leg it would be satisfied by a matrix that had crept back to `['3.12', '3.14']`. Equality also binds the reverse direction — bumping the Dockerfile without bumping CI now fails, so production can never ship an interpreter no test has run.

Mutation-proven both ways, files byte-identical after restore:

| mutation | result |
|---|---|
| matrix re-broadened to `['3.12','3.14']` | red |
| Dockerfile bumped to 3.15, CI left at 3.14 | red |

**Five documentation claims corrected in the same commit.** Narrowing what we test while still advertising 3.10+ would be the confidently-wrong doc rule 7 warns about — and on a public repo that claim is aimed at people who are not the maintainer: `CLAUDE.md:46`, README's badge, its requirements line, its contributing note, and `docs/development-process.md:514`. The stale `test (3.10)` example in `docs/technical-debt.md` goes too.

## Scope deliberately not widened

This does **not** touch the E2E/accessibility duplication between the local pre-push gate and CI. That change reduces what a PR verifies, so it deserves its own decision rather than riding along here.

`make verify` green end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc