### PR TITLE
FEAT-009B B3a: decide whether a replacement is allowed

### DIFF
--- a/couchpotato/core/plugins/renamer/api.py
+++ b/couchpotato/core/plugins/renamer/api.py
@@ -132,11 +132,38 @@ config = [{
                     'default': False,
                 },
                 {
+                    # DEAD. Declared 'default': True for the life of this fork
+                    # while being read by nothing, so `setDefault`
+                    # (core/settings.py:396, which writes only when the option
+                    # is ABSENT) has already persisted True into real config
+                    # files -- measured at .config/config.ini:151.
+                    #
+                    # Wiring THIS key up would therefore have begun deleting
+                    # library files on the first scan after upgrade, on every
+                    # existing install, with no action by the operator. That is
+                    # both withdrawn attempts' failure mode arriving through a
+                    # different door, so upgrade replacement got a NEW key
+                    # below instead. Owner decision, 2026-08-08 (spec D1).
+                    #
+                    # Left in place, and left declared, so an operator who set
+                    # it deliberately still sees it; `upgrade_replace` is what
+                    # the code reads.
                     'name': 'remove_lower_quality_copies',
                     'type': 'bool',
-                    'label': 'Delete Others',
-                    'description': 'Remove lower/equal quality copies of a release after downloading.',
+                    'label': 'Delete Others (unused)',
+                    'description': 'No longer read. Superseded by "Replace lower quality copies", which must be enabled deliberately.',
                     'default': True,
+                },
+                {
+                    # The key upgrade replacement actually reads. Defaults OFF
+                    # and cannot inherit the stale True above, because
+                    # setDefault only materialises a value for an ABSENT
+                    # option and this name has never existed in any config.
+                    'name': 'upgrade_replace',
+                    'type': 'bool',
+                    'label': 'Replace lower quality copies',
+                    'description': 'When a strictly better copy of a movie you already have is downloaded, DELETE the existing library file and put the new one in its place. The deleted file cannot be recovered. Off by default.',
+                    'default': False,
                 },
                 {
                     'advanced': True,

--- a/couchpotato/core/plugins/renamer/replacement.py
+++ b/couchpotato/core/plugins/renamer/replacement.py
@@ -1,0 +1,107 @@
+"""May the incoming copy replace the one already in the library?
+
+FEAT-009B B3a. A pure decision function: it takes the facts and returns an
+outcome. **It performs no filesystem or database operation whatsoever** — the
+atomic swap lands separately in B3b, so this layer can be proven exhaustively
+before anything acts on it.
+
+That ordering is the whole point. Two previous attempts at upgrade replacement
+were withdrawn, and both destroyed an irreplaceable file:
+
+  - the first compared nothing at all, so a 720p download overwrote a 2160p
+    remux (measured);
+  - the second compared with `quality.isHigher`, a SEARCH heuristic that
+    answers "should I keep looking under this profile" rather than "is this
+    file better". The default `Best` profile excludes 2160p, so it authorised
+    destroying a remux too -- while simultaneously being INERT, because the
+    releases it needed were never attached. Fixing the inertness would have
+    activated the destruction.
+
+So every "no" below is a named outcome, not a falsy return, and the caller
+must treat anything other than `REPLACE` as "leave the library file alone".
+
+The rules, and where each comes from:
+
+  * `upgrade_replace` off  -> refuse. A NEW settings key, defaulting off,
+    because the long-declared `remove_lower_quality_copies` is already
+    persisted True on every existing install (spec D1).
+  * more than one video file in the group -> refuse. If cd1's swap commits and
+    cd2's fails, cd1's bytes are gone, and a set-aside is forbidden by
+    AC-SIMP-11. Resolved by subtraction rather than rollback machinery (D7).
+  * the existing file's quality comes from its RELEASE DOCUMENT, never from
+    `quality.guess` -- the default template carries no quality token, so
+    guessing collapses to size and rates a 2160p remux as `brrip` (D2).
+  * anything unknown, ambiguous or unverifiable -> refuse. On this code path
+    "I am not sure" and "delete it" must never be the same branch.
+"""
+
+from couchpotato.core.plugins.renamer.owner import (
+    OWNER_RESOLVED,
+    resolve_owning_release,
+)
+
+# The one outcome that authorises deleting from the library.
+REPLACE = 'replace'
+
+DECLINED_SETTING_OFF = 'declined_setting_off'
+DECLINED_MULTI_FILE_GROUP = 'declined_multi_file_group'
+DECLINED_UNKNOWN_QUALITY = 'declined_unknown_quality'
+DECLINED_NOT_BETTER = 'declined_not_better'
+
+
+def decide_replacement(
+    destination,
+    incoming_quality,
+    releases,
+    size_on_disk,
+    video_file_count,
+    setting_enabled,
+    is_better,
+):
+    """Return `(outcome, existing_release)`.
+
+    `existing_release` is the release whose file would be deleted, and is only
+    non-None when the outcome is `REPLACE` — so a caller cannot reach for it
+    on a refusal.
+
+    `is_better(incoming_quality, existing_quality) -> bool` is injected rather
+    than imported so this stays pure and the caller supplies
+    `QualityPlugin.isBetterQuality`. `video_file_count` is the number of movie
+    files in the group, counted by the caller.
+    """
+    if not setting_enabled:
+        return DECLINED_SETTING_OFF, None
+
+    if video_file_count != 1:
+        # Not "> 1": a group with ZERO video files has nothing to reason about
+        # either, and treating it as replaceable would be a decision made on no
+        # evidence at all.
+        return DECLINED_MULTI_FILE_GROUP, None
+
+    existing, owner_outcome = resolve_owning_release(destination, releases, size_on_disk)
+    if owner_outcome != OWNER_RESOLVED:
+        # The resolver's own refusal is returned verbatim rather than
+        # flattened, so an operator learns WHY: no claimant, several, or a
+        # recorded size that disagrees with the bytes on disk.
+        return owner_outcome, None
+
+    existing_quality = {
+        'identifier': existing.get('quality'),
+        'is_3d': bool(existing.get('is_3d')),
+    }
+    if not existing_quality['identifier']:
+        return DECLINED_UNKNOWN_QUALITY, None
+
+    if not _has_identifier(incoming_quality):
+        # `quality.guess` returns None at quality/main.py:362 and :373, so this
+        # is reachable rather than defensive.
+        return DECLINED_UNKNOWN_QUALITY, None
+
+    if not is_better(incoming_quality, existing_quality):
+        return DECLINED_NOT_BETTER, None
+
+    return REPLACE, existing
+
+
+def _has_identifier(quality):
+    return bool(isinstance(quality, dict) and quality.get('identifier'))

--- a/couchpotato/core/plugins/renamer/replacement.py
+++ b/couchpotato/core/plugins/renamer/replacement.py
@@ -57,7 +57,7 @@ def decide_replacement(
     video_file_count,
     setting_enabled,
     is_better,
-    rank=None,
+    rank,
 ):
     """Return `(outcome, existing_release)`.
 
@@ -106,18 +106,27 @@ def decide_replacement(
         'is_3d': existing['is_3d'],
     }
 
-    if not _has_identifier(incoming_quality):
-        # `quality.guess` returns None at quality/main.py:362 and :373, so this
-        # is reachable rather than defensive.
+    # Symmetric with the existing side above: identifier AND is_3d must both
+    # be present. `_has_identifier` alone accepted a dict carrying only an
+    # identifier, which the real `isBetterQuality` then refuses for a missing
+    # is_3d -- reporting `declined_not_better`, i.e. "the copy on disk is
+    # fine", when the truth is "we could not read the incoming quality".
+    # `quality.guess` returns None at quality/main.py:362 and :373, so the
+    # unknown case is reachable rather than defensive.
+    if not _is_complete_quality(incoming_quality):
         return DECLINED_UNKNOWN_QUALITY, None
 
     # An identifier the ranking does not recognise is UNKNOWN, not "not
     # better". Both refuse, but they send an operator to different places: one
     # says the copy on disk is fine, the other says we could not read the
     # quality at all.
-    if rank is not None:
-        if rank(incoming_quality) is None or rank(existing_quality) is None:
-            return DECLINED_UNKNOWN_QUALITY, None
+    #
+    # `rank` is a REQUIRED argument, not an optional one defaulting to None.
+    # As an optional it was a safety check that a caller could silently omit,
+    # which is the fail-OPEN shape this whole task exists to avoid -- and the
+    # wiring step is exactly where it would have been forgotten.
+    if rank(incoming_quality) is None or rank(existing_quality) is None:
+        return DECLINED_UNKNOWN_QUALITY, None
 
     if not is_better(incoming_quality, existing_quality):
         return DECLINED_NOT_BETTER, None
@@ -125,5 +134,12 @@ def decide_replacement(
     return REPLACE, existing
 
 
-def _has_identifier(quality):
-    return bool(isinstance(quality, dict) and quality.get('identifier'))
+def _is_complete_quality(quality):
+    """Both fields present. `is_3d` is checked for PRESENCE, not truth: absent
+    is not False, and a 3D copy is not comparable with a 2D one at the same
+    rung."""
+    return bool(
+        isinstance(quality, dict)
+        and quality.get('identifier')
+        and 'is_3d' in quality
+    )

--- a/couchpotato/core/plugins/renamer/replacement.py
+++ b/couchpotato/core/plugins/renamer/replacement.py
@@ -57,6 +57,7 @@ def decide_replacement(
     video_file_count,
     setting_enabled,
     is_better,
+    rank=None,
 ):
     """Return `(outcome, existing_release)`.
 
@@ -85,17 +86,38 @@ def decide_replacement(
         # recorded size that disagrees with the bytes on disk.
         return owner_outcome, None
 
-    existing_quality = {
-        'identifier': existing.get('quality'),
-        'is_3d': bool(existing.get('is_3d')),
-    }
-    if not existing_quality['identifier']:
+    if not existing.get('quality'):
         return DECLINED_UNKNOWN_QUALITY, None
+
+    # `is_3d` must be PRESENT on the release document, not defaulted here.
+    #
+    # B1 deliberately refuses a quality dict whose `is_3d` is absent, because
+    # absent is not the same as False -- a 3D copy and a 2D one at the same
+    # rung are not comparable, and guessing "not 3D" authorises replacing one
+    # with the other. Building the dict with `bool(existing.get('is_3d'))`
+    # fabricated the key and handed B1 something that LOOKED complete,
+    # defeating that protection entirely from one layer up. Measured: a
+    # release recorded without the field returned `replace`.
+    if 'is_3d' not in existing:
+        return DECLINED_UNKNOWN_QUALITY, None
+
+    existing_quality = {
+        'identifier': existing['quality'],
+        'is_3d': existing['is_3d'],
+    }
 
     if not _has_identifier(incoming_quality):
         # `quality.guess` returns None at quality/main.py:362 and :373, so this
         # is reachable rather than defensive.
         return DECLINED_UNKNOWN_QUALITY, None
+
+    # An identifier the ranking does not recognise is UNKNOWN, not "not
+    # better". Both refuse, but they send an operator to different places: one
+    # says the copy on disk is fine, the other says we could not read the
+    # quality at all.
+    if rank is not None:
+        if rank(incoming_quality) is None or rank(existing_quality) is None:
+            return DECLINED_UNKNOWN_QUALITY, None
 
     if not is_better(incoming_quality, existing_quality):
         return DECLINED_NOT_BETTER, None

--- a/couchpotato/core/plugins/renamer/swap.py
+++ b/couchpotato/core/plugins/renamer/swap.py
@@ -74,10 +74,20 @@ def replace_atomically(source, destination, move, remove=os.remove):
         # would turn a bug into a file operation.
         return False, REFUSED_DESTINATION_MISSING
 
-    if os.path.samefile(source, destination):
-        # The shipping default `file_action = link` hardlinks the download into
-        # the library, so source and destination can be the same inode. Moving
-        # a file onto itself destroys it.
+    # The shipping default `file_action = link` hardlinks the download into
+    # the library, so source and destination can be the same inode. Moving a
+    # file onto itself destroys it.
+    #
+    # Wrapped, because `samefile` stats BOTH paths and raises OSError if
+    # either has gone -- and both were checked moments ago, so this is a real
+    # time-of-check/time-of-use window, not a hypothetical. An escaping
+    # exception would break this function's own `(ok, reason)` contract and
+    # reach the renamer as an untyped failure. If we cannot tell whether they
+    # are the same file, we refuse.
+    try:
+        if os.path.samefile(source, destination):
+            return False, REFUSED_SAME_FILE
+    except OSError:
         return False, REFUSED_SAME_FILE
 
     expected_size = os.path.getsize(source)

--- a/couchpotato/core/plugins/renamer/swap.py
+++ b/couchpotato/core/plugins/renamer/swap.py
@@ -38,6 +38,11 @@ REFUSED_NO_SOURCE = 'refused_no_source'
 REFUSED_DESTINATION_MISSING = 'refused_destination_missing'
 REFUSED_DESTINATION_IS_SYMLINK = 'refused_destination_is_symlink'
 REFUSED_SAME_FILE = 'refused_same_file'
+# Distinct from the above: we could not determine whether they are the same
+# file. Both refuse, but 'they are the same inode' and 'a stat failed' send
+# an operator to different places, and guessing the reassuring one is the
+# habit this module exists to avoid.
+REFUSED_IDENTITY_UNVERIFIABLE = 'refused_identity_unverifiable'
 
 # Failures after work began. The library file is intact in every one of them.
 FAILED_STAGING = 'failed_staging'
@@ -88,7 +93,7 @@ def replace_atomically(source, destination, move, remove=os.remove):
         if os.path.samefile(source, destination):
             return False, REFUSED_SAME_FILE
     except OSError:
-        return False, REFUSED_SAME_FILE
+        return False, REFUSED_IDENTITY_UNVERIFIABLE
 
     # Guarded for the same time-of-check/time-of-use reason as `samefile`
     # above: several stat calls on the destination happen between the source's

--- a/couchpotato/core/plugins/renamer/swap.py
+++ b/couchpotato/core/plugins/renamer/swap.py
@@ -1,0 +1,152 @@
+"""Put a better copy in place of the one already in the library, atomically.
+
+FEAT-009B B3b. This is the only function in the project that destroys an
+irreplaceable file, so it is written to make the destructive step the LAST
+thing that can happen and the only thing that is not reversible.
+
+The shape, and why each step is where it is:
+
+  1. refuse anything doubtful BEFORE touching the filesystem;
+  2. stage the incoming copy into the DESTINATION DIRECTORY under a unique
+     temporary name -- not the source directory. `os.replace` is atomic only
+     within a filesystem, and on this project's target deployment the library
+     and the download folder are routinely different mounts;
+  3. verify the staged bytes are the size we expected;
+  4. `os.replace(staging, destination)` -- one atomic operation. The old file
+     ceases to exist at the same instant the new one appears. There is no
+     window in which the library has neither.
+
+`os.remove` followed by a move is never acceptable here: it opens exactly that
+window, and a crash inside it loses the movie.
+
+The cleanup rule is the subtle one. On failure the staged file is removed
+**only when a complete copy still exists elsewhere**. `moveFile` may have
+consumed the source (a real move) or left it (copy/link), so after a failure
+the staged file is sometimes the ONLY complete copy in existence -- and
+deleting it to tidy up would destroy the download the operator just made. When
+that happens the function leaves it and says so.
+
+Callers get `(ok, reason)`. Every reason is a value, not a log string, so the
+decision can be asserted rather than parsed.
+"""
+
+import os
+import uuid
+
+# Refusals taken before anything is touched.
+REFUSED_NO_SOURCE = 'refused_no_source'
+REFUSED_DESTINATION_MISSING = 'refused_destination_missing'
+REFUSED_DESTINATION_IS_SYMLINK = 'refused_destination_is_symlink'
+REFUSED_SAME_FILE = 'refused_same_file'
+
+# Failures after work began. The library file is intact in every one of them.
+FAILED_STAGING = 'failed_staging'
+FAILED_SIZE_MISMATCH = 'failed_size_mismatch'
+FAILED_SWAP = 'failed_swap'
+
+REPLACED = 'replaced'
+
+
+def replace_atomically(source, destination, move, remove=os.remove):
+    """Replace `destination` with `source`. Returns `(ok, reason)`.
+
+    `move(src, dst)` is injected -- the renamer passes `moveFile`, which owns
+    the copy/link/symlink modes and permission handling. `remove` is injected
+    only so tests can force a cleanup failure.
+
+    The library file at `destination` survives every path through this
+    function except the successful one.
+    """
+    # --- refuse before touching anything -------------------------------
+    if not os.path.exists(source):
+        return False, REFUSED_NO_SOURCE
+
+    # `lexists`, not `exists`: a BROKEN symlink must be refused too. `exists`
+    # follows the link and reports False, which would send us down the
+    # "nothing there to replace" path and quietly write through a link whose
+    # target is outside the library.
+    if os.path.islink(destination):
+        return False, REFUSED_DESTINATION_IS_SYMLINK
+
+    if not os.path.exists(destination):
+        # This function replaces; it does not install. A caller that reaches
+        # here with no destination has mistaken the situation, and guessing
+        # would turn a bug into a file operation.
+        return False, REFUSED_DESTINATION_MISSING
+
+    if os.path.samefile(source, destination):
+        # The shipping default `file_action = link` hardlinks the download into
+        # the library, so source and destination can be the same inode. Moving
+        # a file onto itself destroys it.
+        return False, REFUSED_SAME_FILE
+
+    expected_size = os.path.getsize(source)
+
+    # --- stage beside the destination ----------------------------------
+    # Unique per attempt: two concurrent scans, or a previous crashed run,
+    # must not collide on this name. The renamer lock (B0) makes concurrency
+    # unlikely, not impossible -- a second CouchPotato process shares neither
+    # its memory nor its lock.
+    staging = os.path.join(
+        os.path.dirname(destination),
+        '.cp-upgrade-%s.part' % uuid.uuid4().hex,
+    )
+
+    try:
+        move(source, staging)
+    except Exception:
+        _discard_staging_if_safe(staging, source, expected_size, remove)
+        return False, FAILED_STAGING
+
+    # --- verify before the irreversible step ---------------------------
+    try:
+        staged_size = os.path.getsize(staging)
+    except OSError:
+        return False, FAILED_STAGING
+
+    if staged_size != expected_size:
+        _discard_staging_if_safe(staging, source, expected_size, remove)
+        return False, FAILED_SIZE_MISMATCH
+
+    # --- the one destructive operation ---------------------------------
+    try:
+        os.replace(staging, destination)
+    except OSError:
+        # The destination is untouched: os.replace either happened or did not.
+        _discard_staging_if_safe(staging, source, expected_size, remove)
+        return False, FAILED_SWAP
+
+    return True, REPLACED
+
+
+def _discard_staging_if_safe(staging, source, expected_size, remove):
+    """Remove the staged file ONLY if a complete copy survives elsewhere.
+
+    `move` may have consumed the source (a real move) or left it in place
+    (copy/link). After a failure the staged file is therefore sometimes the
+    only complete copy of the download in existence, and tidying it away would
+    destroy what the operator just spent hours fetching -- turning a
+    recoverable failure into a loss.
+
+    So: only discard when the source is still there AND still whole. Anything
+    else is left on disk for a human, which is untidy and recoverable, rather
+    than clean and gone.
+    """
+    if not os.path.exists(staging):
+        return
+    try:
+        source_intact = (
+            os.path.exists(source) and os.path.getsize(source) == expected_size
+        )
+    except OSError:
+        source_intact = False
+
+    if not source_intact:
+        return
+
+    try:
+        remove(staging)
+    except OSError:
+        # Leaving it is the safe failure. The destination is still intact and
+        # the source is still intact; the only cost is a stray .part file.
+        pass

--- a/couchpotato/core/plugins/renamer/swap.py
+++ b/couchpotato/core/plugins/renamer/swap.py
@@ -90,7 +90,15 @@ def replace_atomically(source, destination, move, remove=os.remove):
     except OSError:
         return False, REFUSED_SAME_FILE
 
-    expected_size = os.path.getsize(source)
+    # Guarded for the same time-of-check/time-of-use reason as `samefile`
+    # above: several stat calls on the destination happen between the source's
+    # existence check and this one, and an operator or another process can
+    # remove it in that window. An escaping OSError would break the
+    # `(ok, reason)` contract.
+    try:
+        expected_size = os.path.getsize(source)
+    except OSError:
+        return False, REFUSED_NO_SOURCE
 
     # --- stage beside the destination ----------------------------------
     # Unique per attempt: two concurrent scans, or a previous crashed run,
@@ -112,6 +120,10 @@ def replace_atomically(source, destination, move, remove=os.remove):
     try:
         staged_size = os.path.getsize(staging)
     except OSError:
+        # Cleanup attempted here too, for consistency with every other failure
+        # branch. The helper still refuses to discard the staged file when it
+        # is the only complete copy, so consistency costs no safety.
+        _discard_staging_if_safe(staging, source, expected_size, remove)
         return False, FAILED_STAGING
 
     if staged_size != expected_size:

--- a/specs/FEAT-009B-UPGRADE-REPLACEMENT.md
+++ b/specs/FEAT-009B-UPGRADE-REPLACEMENT.md
@@ -231,8 +231,12 @@ arriving through a different door.
 
 **Decision: a new option key that defaults to off.** The stale `True` can then
 never activate anything, because the new code does not read that key. The old
-key is ignored, and its presence logged once so an operator who set it
-deliberately learns it no longer does anything.
+key is ignored. Its presence should be logged once so an operator who set it
+deliberately learns it no longer does anything — **and that clause is NOT yet
+implemented.** It belongs where the new key is read, which is the wiring step
+(B4), not in the pure decision layer. Review caught the gap between this
+paragraph and the code, so it is recorded here rather than left to be
+discovered: B4 does not ship without it.
 
 ### D2 — the on-disk quality comes from the RELEASE DOC, never `quality.guess`
 

--- a/tests/unit/test_atomic_swap.py
+++ b/tests/unit/test_atomic_swap.py
@@ -32,6 +32,7 @@ from couchpotato.core.plugins.renamer.swap import (
     FAILED_SWAP,
     REFUSED_DESTINATION_IS_SYMLINK,
     REFUSED_DESTINATION_MISSING,
+    REFUSED_IDENTITY_UNVERIFIABLE,
     REFUSED_NO_SOURCE,
     REFUSED_SAME_FILE,
     REPLACED,
@@ -136,6 +137,21 @@ class TestRefusalsTakenBeforeAnythingIsTouched:
         assert (ok, reason) == (False, REFUSED_SAME_FILE)
         assert os.path.exists(library['src'])
         assert os.path.exists(hard)
+
+
+class TestAFailedIdentityCheckSaysSoRatherThanGuessing:
+    def test_a_raising_samefile_is_its_own_refusal(self, library, monkeypatch):
+        """`samefile` stats both paths and can raise. Reporting
+        `refused_same_file` for that would assert something we do not know --
+        "they are the same inode" and "a stat failed" send an operator to
+        different places, and the first is the reassuring one."""
+        monkeypatch.setattr(
+            'couchpotato.core.plugins.renamer.swap.os.path.samefile',
+            lambda a, b: (_ for _ in ()).throw(OSError('gone')),
+        )
+        ok, reason = replace_atomically(library['src'], library['dst'], _real_move)
+        assert (ok, reason) == (False, REFUSED_IDENTITY_UNVERIFIABLE)
+        assert _sha(library['dst']) == library['old_sha']
 
 
 class TestFailuresLeaveTheLibraryIntactAndTheDownloadRecoverable:

--- a/tests/unit/test_atomic_swap.py
+++ b/tests/unit/test_atomic_swap.py
@@ -10,7 +10,15 @@ mocks, and every failure case asserts the same two things:
 Asserting only "the call returned False" would pass for a function that had
 already deleted the movie and then errored.
 
-AC-SEC-6, AC-SEC-7, AC-DATA-3, and the T5.3 acceptance list.
+AC-SEC-6 (aliased paths: hardlink, symlink, broken symlink) and AC-SEC-7
+(the staging file: unique per attempt, never left behind while the source
+survives, never deleted when it is the only complete copy).
+
+Deliberately NOT claimed: AC-DATA-3, which is about releases belonging to
+the group's own media and needs a real SQLiteAdapter -- this file never
+touches the database. An earlier version of this docstring cited it, and
+an over-claimed citation is worse than none: it tells the next reader a
+criterion is covered when nothing here can cover it.
 """
 import hashlib
 import os
@@ -220,6 +228,55 @@ class TestTheStagedFileIsNeverTheOnlyCopyWeDelete:
         )
         replace_atomically(library['src'], library['dst'], _move_then_truncate_source)
         assert len(_no_stray_staging(library['dir'])) == 1
+        assert _sha(library['dst']) == library['old_sha']
+
+
+class TestTheTOCTOUGuardsActuallyGuard:
+    """Both `os.path.getsize` calls are wrapped because the paths were checked
+    moments earlier and can vanish in between.
+
+    Review pointed out that adding the guards is not the same as proving them,
+    which is CLAUDE.md rule 10 applied to my own fix -- so each one is forced
+    to raise here. Without these, an OSError escapes and breaks this
+    function's `(ok, reason)` contract, reaching the renamer as an untyped
+    failure instead of a named refusal.
+    """
+
+    def test_the_source_vanishing_after_its_existence_check_is_a_named_refusal(
+        self, library, monkeypatch
+    ):
+        real_getsize = os.path.getsize
+
+        def _vanishing(path):
+            if path == library['src']:
+                raise OSError('source removed between the check and the stat')
+            return real_getsize(path)
+
+        monkeypatch.setattr(
+            'couchpotato.core.plugins.renamer.swap.os.path.getsize', _vanishing
+        )
+        ok, reason = replace_atomically(library['src'], library['dst'], _real_move)
+        assert (ok, reason) == (False, REFUSED_NO_SOURCE)
+        assert _sha(library['dst']) == library['old_sha']
+
+    def test_an_unstattable_staged_file_is_a_named_failure(self, library, monkeypatch):
+        real_getsize = os.path.getsize
+        state = {'moved': False}
+
+        def _move_then_break(src, dst):
+            shutil.move(src, dst)
+            state['moved'] = dst
+
+        def _breaks_on_staging(path):
+            if state['moved'] and path == state['moved']:
+                raise OSError('staged file unreadable')
+            return real_getsize(path)
+
+        monkeypatch.setattr(
+            'couchpotato.core.plugins.renamer.swap.os.path.getsize', _breaks_on_staging
+        )
+        ok, reason = replace_atomically(library['src'], library['dst'], _move_then_break)
+        assert (ok, reason) == (False, FAILED_STAGING)
         assert _sha(library['dst']) == library['old_sha']
 
 

--- a/tests/unit/test_atomic_swap.py
+++ b/tests/unit/test_atomic_swap.py
@@ -1,0 +1,251 @@
+"""Atomic replacement of a library file (FEAT-009B B3b).
+
+This is the only function in the project that destroys an irreplaceable file,
+so every test here runs against a REAL filesystem (`tmp_path`) rather than
+mocks, and every failure case asserts the same two things:
+
+  * the library file is byte-identical to what it was, and
+  * a complete copy of the download still exists somewhere.
+
+Asserting only "the call returned False" would pass for a function that had
+already deleted the movie and then errored.
+
+AC-SEC-6, AC-SEC-7, AC-DATA-3, and the T5.3 acceptance list.
+"""
+import hashlib
+import os
+import shutil
+
+import pytest
+
+from couchpotato.core.plugins.renamer.swap import (
+    FAILED_SIZE_MISMATCH,
+    FAILED_STAGING,
+    FAILED_SWAP,
+    REFUSED_DESTINATION_IS_SYMLINK,
+    REFUSED_DESTINATION_MISSING,
+    REFUSED_NO_SOURCE,
+    REFUSED_SAME_FILE,
+    REPLACED,
+    replace_atomically,
+)
+
+OLD = b'the existing library copy, 720p' * 40
+NEW = b'the better incoming copy, 2160p' * 900
+
+
+def _sha(path):
+    return hashlib.sha256(open(path, 'rb').read()).hexdigest()
+
+
+@pytest.fixture
+def library(tmp_path):
+    """A real library file and a real download, on a real filesystem."""
+    lib = tmp_path / 'library' / 'The Thing (1982)'
+    lib.mkdir(parents=True)
+    dst = lib / 'The Thing.mkv'
+    dst.write_bytes(OLD)
+
+    dl = tmp_path / 'downloads' / 'The.Thing.1982.2160p'
+    dl.mkdir(parents=True)
+    src = dl / 'movie.mkv'
+    src.write_bytes(NEW)
+    return {'src': str(src), 'dst': str(dst), 'dir': lib, 'old_sha': _sha(dst)}
+
+
+def _real_move(src, dst):
+    shutil.move(src, dst)
+
+
+def _no_stray_staging(directory):
+    return [p.name for p in directory.iterdir() if p.name.startswith('.cp-upgrade-')]
+
+
+class TestTheSuccessfulPath:
+    def test_the_better_copy_takes_the_destination(self, library):
+        ok, reason = replace_atomically(library['src'], library['dst'], _real_move)
+        assert (ok, reason) == (True, REPLACED)
+        assert open(library['dst'], 'rb').read() == NEW
+        assert not os.path.exists(library['src']), 'a real move should consume the source'
+
+    def test_no_staging_file_is_left_behind(self, library):
+        replace_atomically(library['src'], library['dst'], _real_move)
+        assert _no_stray_staging(library['dir']) == []
+
+    def test_the_destination_keeps_its_exact_path(self, library):
+        """The library file must be replaced in place, not renamed alongside."""
+        before = sorted(p.name for p in library['dir'].iterdir())
+        replace_atomically(library['src'], library['dst'], _real_move)
+        assert sorted(p.name for p in library['dir'].iterdir()) == before
+
+
+class TestRefusalsTakenBeforeAnythingIsTouched:
+    def test_a_missing_source_refuses(self, library):
+        os.remove(library['src'])
+        ok, reason = replace_atomically(library['src'], library['dst'], _real_move)
+        assert (ok, reason) == (False, REFUSED_NO_SOURCE)
+        assert _sha(library['dst']) == library['old_sha']
+
+    def test_a_missing_destination_refuses_rather_than_installing(self, library):
+        """This function replaces; it does not install. Guessing would turn a
+        caller's bug into a file operation."""
+        os.remove(library['dst'])
+        ok, reason = replace_atomically(library['src'], library['dst'], _real_move)
+        assert (ok, reason) == (False, REFUSED_DESTINATION_MISSING)
+        assert os.path.exists(library['src']), 'the download must survive'
+
+    def test_a_symlinked_destination_refuses_and_its_target_survives(self, tmp_path, library):
+        """AC-SEC-6. Writing through the link would modify a file OUTSIDE the
+        library, which is not the file the library thinks it holds."""
+        outside = tmp_path / 'outside.mkv'
+        outside.write_bytes(b'not the librarys to touch')
+        outside_sha = _sha(outside)
+
+        link = library['dir'] / 'linked.mkv'
+        link.symlink_to(outside)
+
+        ok, reason = replace_atomically(library['src'], str(link), _real_move)
+        assert (ok, reason) == (False, REFUSED_DESTINATION_IS_SYMLINK)
+        assert _sha(outside) == outside_sha
+        assert os.path.exists(library['src'])
+
+    def test_a_BROKEN_symlink_destination_refuses(self, library):
+        """`os.path.exists` follows the link and reports False for a broken
+        one, so an `exists` check would have sent this down the
+        "nothing to replace" path. `islink` is checked first for that reason."""
+        broken = library['dir'] / 'broken.mkv'
+        broken.symlink_to(library['dir'] / 'does-not-exist.mkv')
+        ok, reason = replace_atomically(library['src'], str(broken), _real_move)
+        assert (ok, reason) == (False, REFUSED_DESTINATION_IS_SYMLINK)
+
+    def test_a_hardlink_of_the_source_refuses(self, library):
+        """AC-SEC-6. The shipping default `file_action = link` hardlinks the
+        download into the library, so source and destination can be the same
+        inode -- and moving a file onto itself destroys it."""
+        hard = library['dir'] / 'hardlinked.mkv'
+        os.link(library['src'], hard)
+        ok, reason = replace_atomically(library['src'], str(hard), _real_move)
+        assert (ok, reason) == (False, REFUSED_SAME_FILE)
+        assert os.path.exists(library['src'])
+        assert os.path.exists(hard)
+
+
+class TestFailuresLeaveTheLibraryIntactAndTheDownloadRecoverable:
+    """The whole point of the staging step. In each case the destination must
+    be byte-identical and a complete copy of the download must still exist."""
+
+    def test_a_failing_move_leaves_both_files(self, library):
+        def _boom(src, dst):
+            raise OSError('mount went away')
+
+        ok, reason = replace_atomically(library['src'], library['dst'], _boom)
+        assert (ok, reason) == (False, FAILED_STAGING)
+        assert _sha(library['dst']) == library['old_sha']
+        assert open(library['src'], 'rb').read() == NEW
+        assert _no_stray_staging(library['dir']) == []
+
+    def test_a_truncated_staging_file_is_caught_before_the_swap(self, library):
+        """The verify step exists for exactly this: a move that "succeeded"
+        but did not write everything."""
+        def _truncating_move(src, dst):
+            with open(dst, 'wb') as fh:
+                fh.write(open(src, 'rb').read()[:10])
+
+        ok, reason = replace_atomically(library['src'], library['dst'], _truncating_move)
+        assert (ok, reason) == (False, FAILED_SIZE_MISMATCH)
+        assert _sha(library['dst']) == library['old_sha']
+        assert open(library['src'], 'rb').read() == NEW
+        assert _no_stray_staging(library['dir']) == [], 'source intact, so tidy up'
+
+    def test_a_failing_swap_leaves_the_destination_untouched(self, library, monkeypatch):
+        monkeypatch.setattr(
+            'couchpotato.core.plugins.renamer.swap.os.replace',
+            lambda a, b: (_ for _ in ()).throw(OSError('cross-device')),
+        )
+        ok, reason = replace_atomically(library['src'], library['dst'], _real_move)
+        assert (ok, reason) == (False, FAILED_SWAP)
+        assert _sha(library['dst']) == library['old_sha']
+
+
+class TestTheStagedFileIsNeverTheOnlyCopyWeDelete:
+    """The subtle rule, and the one worth getting wrong slowly.
+
+    `move` may consume the source (a real move) or leave it (copy/link). After
+    a failure the staged file is therefore sometimes the ONLY complete copy of
+    the download, and tidying it away would destroy hours of fetching --
+    turning a recoverable failure into a loss.
+    """
+
+    def test_when_the_source_was_consumed_the_staged_copy_is_KEPT(self, library, monkeypatch):
+        monkeypatch.setattr(
+            'couchpotato.core.plugins.renamer.swap.os.replace',
+            lambda a, b: (_ for _ in ()).throw(OSError('boom')),
+        )
+        ok, reason = replace_atomically(library['src'], library['dst'], _real_move)
+
+        assert (ok, reason) == (False, FAILED_SWAP)
+        assert not os.path.exists(library['src']), 'precondition: the move consumed it'
+        stray = _no_stray_staging(library['dir'])
+        assert len(stray) == 1, 'the only complete copy of the download was deleted'
+        assert (library['dir'] / stray[0]).read_bytes() == NEW
+        assert _sha(library['dst']) == library['old_sha']
+
+    def test_when_the_source_survives_the_staged_copy_is_removed(self, library, monkeypatch):
+        """The control. Keeping every staged file regardless would fill the
+        library with .part files, so the rule has to discriminate."""
+        def _copying_move(src, dst):
+            shutil.copyfile(src, dst)      # leaves the source, as `copy` mode does
+
+        monkeypatch.setattr(
+            'couchpotato.core.plugins.renamer.swap.os.replace',
+            lambda a, b: (_ for _ in ()).throw(OSError('boom')),
+        )
+        ok, reason = replace_atomically(library['src'], library['dst'], _copying_move)
+
+        assert (ok, reason) == (False, FAILED_SWAP)
+        assert os.path.exists(library['src'])
+        assert _no_stray_staging(library['dir']) == []
+
+    def test_a_TRUNCATED_source_counts_as_not_intact_so_the_copy_is_kept(self, library, monkeypatch):
+        """"The source still exists" is not the same as "a complete copy still
+        exists". A half-written source is not a copy of anything."""
+        def _move_then_truncate_source(src, dst):
+            shutil.copyfile(src, dst)
+            with open(src, 'wb') as fh:
+                fh.write(b'partial')
+
+        monkeypatch.setattr(
+            'couchpotato.core.plugins.renamer.swap.os.replace',
+            lambda a, b: (_ for _ in ()).throw(OSError('boom')),
+        )
+        replace_atomically(library['src'], library['dst'], _move_then_truncate_source)
+        assert len(_no_stray_staging(library['dir'])) == 1
+        assert _sha(library['dst']) == library['old_sha']
+
+
+class TestStagingHappensInTheDestinationDirectory:
+    def test_the_staged_file_appears_beside_the_destination(self, library):
+        """`os.replace` is atomic only WITHIN a filesystem, and the library and
+        download folder are routinely different mounts on this project's target
+        deployment. Staging in the source directory would make the final step
+        a cross-device copy -- non-atomic, and the whole design would be
+        pointless."""
+        seen = {}
+
+        def _recording_move(src, dst):
+            seen['dst'] = dst
+            shutil.move(src, dst)
+
+        replace_atomically(library['src'], library['dst'], _recording_move)
+        assert os.path.dirname(seen['dst']) == os.path.dirname(library['dst'])
+
+    def test_the_staging_name_is_unique_per_attempt(self, library):
+        names = set()
+
+        def _recording_move(src, dst):
+            names.add(os.path.basename(dst))
+            raise OSError('stop here')
+
+        for _ in range(5):
+            replace_atomically(library['src'], library['dst'], _recording_move)
+        assert len(names) == 5, 'staging names collided: %s' % names

--- a/tests/unit/test_replacement_decision.py
+++ b/tests/unit/test_replacement_decision.py
@@ -152,6 +152,60 @@ class TestQualityMustBeKnownOnBothSides:
         assert _decide(incoming_quality=incoming)[0] == DECLINED_UNKNOWN_QUALITY
 
 
+class TestAbsentIs3dOnTheExistingReleaseRefuses:
+    """B1 refuses a quality dict whose `is_3d` is absent, because absent is not
+    the same as False: a 3D copy and a 2D one at the same rung are not
+    comparable, and guessing "not 3D" authorises replacing one with the other.
+
+    This layer defeated that protection by building the dict with
+    `bool(existing.get('is_3d'))`, fabricating the key and handing B1
+    something that LOOKED complete. Measured before the fix: a release
+    recorded without the field returned `replace`.
+
+    Worth keeping as a cautionary case -- the fix was one layer below, and
+    the caller undid it.
+    """
+
+    def test_a_release_document_with_no_is_3d_field_refuses(self):
+        no_3d = {k: v for k, v in _existing().items() if k != 'is_3d'}
+        assert 'is_3d' not in no_3d
+        assert _decide(releases=[no_3d])[0] == DECLINED_UNKNOWN_QUALITY
+
+    def test_an_explicit_false_is_fine(self):
+        """The control: refusing ABSENT must not refuse RECORDED-as-2D, or the
+        feature never fires for the overwhelmingly common case."""
+        assert _decide(releases=[_existing(is_3d=False)])[0] == REPLACE
+
+    def test_an_explicit_true_is_passed_through_not_flattened(self):
+        recorded_3d = _existing(is_3d=True)
+        seen = []
+
+        def _spy(incoming, existing):
+            seen.append(existing)
+            return False
+
+        _decide(releases=[recorded_3d], is_better=_spy)
+        assert seen == [{'identifier': '720p', 'is_3d': True}]
+
+
+class TestAnUnrecognisedIdentifierIsUnknownNotWorse:
+    """Both refuse, but they send an operator to different places: "the copy
+    on disk is fine" versus "we could not read its quality at all"."""
+
+    def test_an_existing_quality_the_ranking_does_not_know(self):
+        def _rank(q):
+            return None if q['identifier'] == 'laserdisc' else 0
+
+        odd = _existing(quality='laserdisc')
+        outcome, _ = _decide(releases=[odd], rank=_rank)
+        assert outcome == DECLINED_UNKNOWN_QUALITY
+
+    def test_a_known_pair_still_reaches_the_comparison(self):
+        """Control: the rank check must not swallow every decision."""
+        outcome, _ = _decide(rank=lambda q: 0)
+        assert outcome == REPLACE
+
+
 class TestOnlyAStrictlyBetterCopyReplaces:
     def test_a_worse_copy_refuses(self):
         assert _decide(incoming_quality=WORSE)[0] == DECLINED_NOT_BETTER

--- a/tests/unit/test_replacement_decision.py
+++ b/tests/unit/test_replacement_decision.py
@@ -1,0 +1,182 @@
+"""May the incoming copy replace the library file? (FEAT-009B B3a)
+
+This decision authorises deleting an irreplaceable file. Two previous attempts
+at it were withdrawn after destroying a 2160p remux, so the tests here are
+written the way the spec demands: every refusal is asserted as a NAMED outcome
+rather than inferred from a falsy value, and every "it refuses" case is paired
+with a control proving the decision is not simply inert.
+
+Inertness is not a lesser failure here. Withdrawn attempt #2 was simultaneously
+dangerous and inert, and the inertness is what hid the danger — the gate never
+fired in testing, so nobody saw what it would do when it did.
+
+AC-SEC-1, AC-SEC-2, AC-QA-11, AC-QA-13, D1, D2, D7.
+"""
+import pytest
+
+from couchpotato.core.plugins.renamer.owner import (
+    DECLINED_AMBIGUOUS_OWNER,
+    DECLINED_NO_OWNER,
+    DECLINED_UNVERIFIED_COPY,
+    copy_id_for_sizes,
+)
+from couchpotato.core.plugins.renamer.replacement import (
+    DECLINED_MULTI_FILE_GROUP,
+    DECLINED_NOT_BETTER,
+    DECLINED_SETTING_OFF,
+    DECLINED_UNKNOWN_QUALITY,
+    REPLACE,
+    decide_replacement,
+)
+
+DEST = '/library/Movies/The Thing (1982)/The Thing.mkv'
+SIZE = 40_000_000
+
+BETTER = {'identifier': '2160p', 'is_3d': False}
+WORSE = {'identifier': '720p', 'is_3d': False}
+
+
+def _existing(quality='720p', is_3d=False, size=SIZE, paths=(DEST,)):
+    return {
+        '_id': 'r-existing',
+        'files': {'movie': list(paths)},
+        'copy_id': copy_id_for_sizes([size]),
+        'quality': quality,
+        'is_3d': is_3d,
+    }
+
+
+def _rank_is_better(incoming, existing):
+    """Stand-in for QualityPlugin.isBetterQuality: 2160p beats 720p."""
+    order = ['2160p', 'bd50', '1080p', '720p']
+    try:
+        return order.index(incoming['identifier']) < order.index(existing['identifier'])
+    except (KeyError, ValueError, TypeError):
+        return False
+
+
+def _decide(**over):
+    kwargs = dict(
+        destination=DEST,
+        incoming_quality=BETTER,
+        releases=[_existing()],
+        size_on_disk=SIZE,
+        video_file_count=1,
+        setting_enabled=True,
+        is_better=_rank_is_better,
+    )
+    kwargs.update(over)
+    return decide_replacement(**kwargs)
+
+
+class TestTheHappyPathExistsAtAll:
+    """The control for every refusal test below. Without it, a decision
+    function that returned a refusal unconditionally would pass the entire
+    rest of this file — which is exactly the shape attempt #2 shipped."""
+
+    def test_a_strictly_better_copy_replaces(self):
+        outcome, existing = _decide()
+        assert outcome == REPLACE
+        assert existing['_id'] == 'r-existing'
+
+    def test_the_release_to_be_deleted_is_returned_only_on_replace(self):
+        """A caller must not be able to reach for the victim on a refusal."""
+        for over in ({'setting_enabled': False},
+                     {'video_file_count': 2},
+                     {'incoming_quality': WORSE}):
+            outcome, existing = _decide(**over)
+            assert outcome != REPLACE
+            assert existing is None, over
+
+
+class TestTheSettingIsTheFirstGate:
+    def test_off_refuses_even_when_everything_else_says_replace(self):
+        """AC-SEC-1/AC-SEC-2 and D1. `upgrade_replace` is a NEW key defaulting
+        off; the long-declared `remove_lower_quality_copies` is already
+        persisted True on every existing install and is no longer read."""
+        assert _decide(setting_enabled=False)[0] == DECLINED_SETTING_OFF
+
+    def test_it_is_checked_before_anything_else(self):
+        """With the setting off, a group that is ALSO multi-file and has an
+        unknown quality still reports the setting — so an operator who has not
+        opted in is told that, not something incidental."""
+        outcome, _ = _decide(
+            setting_enabled=False, video_file_count=3, incoming_quality=None
+        )
+        assert outcome == DECLINED_SETTING_OFF
+
+
+class TestMultiFileGroupsAreRefused:
+    """D7. If cd1's swap commits and cd2's fails, cd1's bytes are gone, and
+    AC-SIMP-11 forbids a set-aside — so the criteria were mutually
+    unsatisfiable. Resolved by subtraction: single-file groups only."""
+
+    @pytest.mark.parametrize('count', [2, 3, 7])
+    def test_more_than_one_video_file_refuses(self, count):
+        assert _decide(video_file_count=count)[0] == DECLINED_MULTI_FILE_GROUP
+
+    def test_zero_video_files_also_refuses(self):
+        """Not `> 1`. A group with no video file has nothing to reason about,
+        and calling it replaceable would be a decision made on no evidence."""
+        assert _decide(video_file_count=0)[0] == DECLINED_MULTI_FILE_GROUP
+
+
+class TestTheOwnersRefusalIsPassedThroughVerbatim:
+    """Flattening these into one outcome would tell an operator that something
+    went wrong without saying what, on the one path that deletes files."""
+
+    def test_no_release_claims_the_destination(self):
+        assert _decide(releases=[])[0] == DECLINED_NO_OWNER
+
+    def test_the_recorded_size_disagrees_with_the_bytes_on_disk(self):
+        assert _decide(size_on_disk=SIZE + 1)[0] == DECLINED_UNVERIFIED_COPY
+
+    def test_two_claimants_and_no_way_to_tell_them_apart(self):
+        a = _existing()
+        b = dict(_existing(), _id='r-other')
+        assert _decide(releases=[a, b], size_on_disk=SIZE)[0] == DECLINED_AMBIGUOUS_OWNER
+
+
+class TestQualityMustBeKnownOnBothSides:
+    def test_an_existing_release_with_no_recorded_quality_refuses(self):
+        """D2: the existing quality comes from the release document. A release
+        with none is not a licence to guess from the file — the default
+        template has no quality token, so guessing rates a remux as brrip."""
+        no_quality = dict(_existing(), quality=None)
+        assert _decide(releases=[no_quality])[0] == DECLINED_UNKNOWN_QUALITY
+
+    @pytest.mark.parametrize('incoming', [None, {}, {'is_3d': False}, 'not-a-dict'])
+    def test_an_unknown_incoming_quality_refuses(self, incoming):
+        """AC-QA-13: `quality.guess` returns None at quality/main.py:362 and
+        :373, so this is reachable, not defensive."""
+        assert _decide(incoming_quality=incoming)[0] == DECLINED_UNKNOWN_QUALITY
+
+
+class TestOnlyAStrictlyBetterCopyReplaces:
+    def test_a_worse_copy_refuses(self):
+        assert _decide(incoming_quality=WORSE)[0] == DECLINED_NOT_BETTER
+
+    def test_an_equal_copy_refuses(self):
+        equal = {'identifier': '720p', 'is_3d': False}
+        assert _decide(incoming_quality=equal)[0] == DECLINED_NOT_BETTER
+
+    def test_the_720p_versus_2160p_case_that_attempt_1_got_wrong(self):
+        """Measured failure of the first withdrawn attempt: a 720p download
+        overwrote a 2160p remux."""
+        existing_remux = _existing(quality='2160p')
+        outcome, _ = _decide(incoming_quality=WORSE, releases=[existing_remux])
+        assert outcome == DECLINED_NOT_BETTER
+
+    def test_the_comparison_is_delegated_not_reimplemented(self):
+        """The verdict must come from the injected comparator, so this cannot
+        drift from `QualityPlugin.isBetterQuality` — the single source that
+        knows 2160p beats bd50 and that a 3D mismatch is not comparable."""
+        calls = []
+
+        def _spy(incoming, existing):
+            calls.append((incoming, existing))
+            return False
+
+        outcome, _ = _decide(is_better=_spy)
+        assert outcome == DECLINED_NOT_BETTER
+        assert calls == [(BETTER, {'identifier': '720p', 'is_3d': False})]

--- a/tests/unit/test_replacement_decision.py
+++ b/tests/unit/test_replacement_decision.py
@@ -55,6 +55,15 @@ def _rank_is_better(incoming, existing):
         return False
 
 
+def _rank(quality):
+    """Stand-in for QualityPlugin.rankQuality: None for anything unknown."""
+    order = ['2160p', 'bd50', '1080p', '720p']
+    try:
+        return order.index(quality['identifier'])
+    except (KeyError, ValueError, TypeError):
+        return None
+
+
 def _decide(**over):
     kwargs = dict(
         destination=DEST,
@@ -64,6 +73,7 @@ def _decide(**over):
         video_file_count=1,
         setting_enabled=True,
         is_better=_rank_is_better,
+        rank=_rank,
     )
     kwargs.update(over)
     return decide_replacement(**kwargs)
@@ -186,6 +196,24 @@ class TestAbsentIs3dOnTheExistingReleaseRefuses:
 
         _decide(releases=[recorded_3d], is_better=_spy)
         assert seen == [{'identifier': '720p', 'is_3d': True}]
+
+
+class TestTheIncomingSideIsHeldToTheSameStandard:
+    """Symmetry matters here, not tidiness.
+
+    `identifier`-only was accepted on the incoming side while the existing side
+    required both fields. The real `isBetterQuality` then refuses for the
+    missing `is_3d` and the caller reports `declined_not_better` -- "the copy
+    on disk is fine" -- when the truth is "we could not read the incoming
+    quality". Same refusal, wrong diagnosis, and the wrong one is reassuring.
+    """
+
+    def test_an_incoming_quality_with_no_is_3d_is_unknown_not_not_better(self):
+        assert _decide(incoming_quality={'identifier': '2160p'})[0] == DECLINED_UNKNOWN_QUALITY
+
+    def test_a_complete_incoming_quality_still_replaces(self):
+        """Control: the stricter check must not refuse the ordinary case."""
+        assert _decide(incoming_quality={'identifier': '2160p', 'is_3d': False})[0] == REPLACE
 
 
 class TestAnUnrecognisedIdentifierIsUnknownNotWorse:


### PR DESCRIPTION
The decision layer for upgrade replacement, plus the new settings key it reads.

**Still nothing deletes.** This is a pure function — no filesystem, no database, no caller. The atomic swap is B3b.

## Why B3 is split

It is the highest-risk change in the plan. Two previous attempts were withdrawn, both having destroyed an irreplaceable file, and CLAUDE.md rule 11 says the third is reviewed as *new work* rather than as a correction. Splitting it keeps the dangerous part a small diff on top of a decision layer that can be proven exhaustively first.

## The new key (owner decision, D1)

`upgrade_replace` defaults **off** and is what the code reads.

`remove_lower_quality_copies` stays declared but is marked unused. It has carried `'default': True` for the life of this fork while being read by nothing, so `setDefault` (`settings.py:396`, which writes only for an *absent* option) has already persisted `True` into real config files — measured at `.config/config.ini:151`. Wiring **that** key up would have begun deleting library files on the first scan after upgrade, on every existing install, with no operator action. A name that has never existed in any config cannot inherit that.

## The gates

| condition | outcome |
|---|---|
| setting off | `declined_setting_off` — checked **first**, so an operator who hasn't opted in is told that, not something incidental |
| `video_file_count != 1` | `declined_multi_file_group` (D7) |
| owner unresolved | the resolver's own reason, **verbatim** |
| existing release has no quality | `declined_unknown_quality` (D2) |
| incoming quality unknown | `declined_unknown_quality` |
| not strictly better | `declined_not_better` |

Two details worth pausing on:

- **`!= 1`, not `> 1`.** Mutating it to `> 1` turns a test red: a group with *zero* video files would otherwise pass as replaceable, which is a decision made on no evidence at all.
- **The owner's refusal passes through unflattened.** "No claimant", "several claimants" and "recorded size disagrees with the bytes on disk" send an operator to different places.

## The comparison is injected, not reimplemented

A spy test asserts the verdict comes from the injected comparator rather than from local logic, so it cannot drift from `QualityPlugin.isBetterQuality` — the single place that knows 2160p beats bd50 and that a 3D mismatch is not comparable. Reimplementing that inline is close to how attempt #2 went wrong.

## Evidence

Seven mutations, each red, file byte-identical after restore:

| mutation | tests red |
|---|---|
| setting gate removed (ships ON) | 3 |
| multi-file gate removed | 5 |
| `!= 1` → `> 1` (zero-file group slips past) | 1 |
| owner refusal ignored | 3 |
| existing quality unknown → proceed | 1 |
| incoming quality unknown → proceed | 4 |
| not-better → better-or-equal | 5 |

**Every refusal test is paired with a control** proving the decision is not simply inert. That is not defensive padding: attempt #2 was dangerous *and* inert, and the inertness is what hid the danger — the gate never fired in testing, so nobody saw what it did when it fired.

`make verify` green (`GATE_RC=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc