### PR TITLE
T16: coverage follows the change surface, not the branch

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -19,8 +19,14 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 # It errs towards YES on any doubt (no base ref, unreadable diff). A slow gate
 # is an annoyance; a skipped gate that should have run is how a UI regression
 # reaches master.
+#
+# The base is the branch this work MERGES INTO, resolved by
+# scripts/push_base_ref.sh. It is deliberately not `@{upstream}`: after the
+# first push that is the branch's own remote ref, which would narrow the
+# question to "what changed since my last push" and let a UI change in commit
+# one be forgotten by commit two.
 VERIFY_ARGS=()
-BASE_REF="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || echo origin/master)"
+BASE_REF="$("$REPO_ROOT/scripts/push_base_ref.sh" 2>/dev/null || echo origin/master)"
 if ! "$REPO_ROOT/scripts/needs_e2e.sh" "$BASE_REF"; then
   VERIFY_ARGS+=(--no-e2e)
   echo "🔒 pre-push: running the FAST local gate (no browser-visible files changed)"

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,10 +10,27 @@ set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-echo "🔒 pre-push: running full local gate (scripts/verify.sh)…"
+# Coverage follows the CHANGE SURFACE, not the branch. A Python-only change
+# does not need five minutes of browser tests here, because CI runs them on
+# master and nightly regardless -- and `scripts/needs_e2e.sh` is the single
+# source of truth for that question, shared with the workflow so the two
+# cannot drift apart.
+#
+# It errs towards YES on any doubt (no base ref, unreadable diff). A slow gate
+# is an annoyance; a skipped gate that should have run is how a UI regression
+# reaches master.
+VERIFY_ARGS=()
+BASE_REF="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || echo origin/master)"
+if ! "$REPO_ROOT/scripts/needs_e2e.sh" "$BASE_REF"; then
+  VERIFY_ARGS+=(--no-e2e)
+  echo "🔒 pre-push: running the FAST local gate (no browser-visible files changed)"
+  echo "   E2E, accessibility and mobile are skipped here and still run in CI."
+else
+  echo "🔒 pre-push: running the FULL local gate (scripts/verify.sh)…"
+fi
 echo "   (bypass with 'git push --no-verify' — use sparingly)"
 
-if "$REPO_ROOT/scripts/verify.sh"; then
+if "$REPO_ROOT/scripts/verify.sh" "${VERIFY_ARGS[@]+"${VERIFY_ARGS[@]}"}"; then
   echo "✅ pre-push: gate passed — pushing."
   exit 0
 else

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -26,7 +26,15 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 # question to "what changed since my last push" and let a UI change in commit
 # one be forgotten by commit two.
 VERIFY_ARGS=()
-BASE_REF="$("$REPO_ROOT/scripts/push_base_ref.sh" 2>/dev/null || echo origin/master)"
+# No `|| echo origin/master` fallback, deliberately. push_base_ref.sh cannot
+# exit non-zero -- every git call that could fail is guarded and the last line
+# is a bare echo -- so that fallback only fired if the script were missing
+# entirely, and it would then have supplied a CONFIDENT wrong answer.
+#
+# An empty BASE_REF is better: needs_e2e.sh treats a missing base ref as
+# "assume YES" and runs the full gate. A guard that cannot fire is worse than
+# no guard, because it reads as protection.
+BASE_REF="$("$REPO_ROOT/scripts/push_base_ref.sh")"
 if ! "$REPO_ROOT/scripts/needs_e2e.sh" "$BASE_REF"; then
   VERIFY_ARGS+=(--no-e2e)
   echo "🔒 pre-push: running the FAST local gate (no browser-visible files changed)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,21 @@ jobs:
       with:
         fetch-depth: 0        # needs\_e2e.sh diffs against the base
     - id: decide
+      # Context values go through `env:`, never spliced into `run:`. Not
+      # exploitable today (the pull_request trigger is filtered to two literal
+      # branches), but it is the shape GitHub's hardening guide flags, and it
+      # is one careless widening of that filter away from being real.
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_REF: ${{ github.base_ref }}
       run: |
         set -euo pipefail
-        if [ "${{ github.event_name }}" != "pull_request" ]; then
-          echo "not a pull request (${{ github.event_name }}) -- browser suites always run"
+        if [ "$EVENT_NAME" != "pull_request" ]; then
+          echo "not a pull request ($EVENT_NAME) -- browser suites always run"
           echo "browser=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi
-        if ./scripts/needs_e2e.sh "origin/${{ github.base_ref }}"; then
+        if ./scripts/needs_e2e.sh "origin/$BASE_REF"; then
           echo "browser=true" >> "$GITHUB_OUTPUT"
         else
           echo "browser=false" >> "$GITHUB_OUTPUT"
@@ -285,7 +292,19 @@ jobs:
     # is the same GitHub behaviour that once let the accessibility verdict be
     # ABSENT rather than red on broken branches. It is acceptable only because
     # the skip is decided by the change surface and master/nightly always run.
-    if: needs.scope.outputs.browser == 'true'
+    #
+    # And it is why this condition FAILS CLOSED. Keying on `== 'true'` meant a
+    # scope job that died before writing its output -- failed checkout,
+    # classifier that would not run -- skipped both browser jobs and left the
+    # PR mergeable with no E2E and no accessibility coverage at all. Only an
+    # explicit 'false' is safe to skip on. `!cancelled()` is required because
+    # the implicit success() of `needs:` would otherwise skip this job before
+    # the condition is read.
+    if: >-
+      !cancelled()
+      && needs.test.result == 'success'
+      && needs.ui-unit-tests.result == 'success'
+      && needs.scope.outputs.browser != 'false'
     steps:
     - uses: actions/checkout@v7
     
@@ -420,7 +439,16 @@ jobs:
       contents: read
       actions: write
     needs: [scope]
-    if: needs.scope.outputs.browser == 'true'
+    # Fail CLOSED. A skipped job satisfies a required status check on GitHub,
+    # so keying on `== 'true'` meant that a scope job which died before writing
+    # its output -- failed checkout, classifier that would not run -- skipped
+    # both browser jobs and left the PR mergeable with no E2E and no
+    # accessibility coverage. Only an explicit 'false' is safe to skip on.
+    # `!cancelled()` is required because the implicit success() of `needs:`
+    # would otherwise skip this job before the condition is read at all.
+    if: >-
+      !cancelled()
+      && needs.scope.outputs.browser != 'false'
     # `needs: [scope]` ONLY -- scope is seconds, so this still starts almost
     # immediately and does not re-enter the serial chain CI-003 removed it
     # from. Was `needs: ui-e2e-tests`, added 2026-02-16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,18 @@ jobs:
         # The base copy is what master is already protected by, so it is the
         # only version with any authority over what merges into master.
         CLASSIFIER="$(mktemp)"
-        git show "origin/$BASE_REF:scripts/needs_e2e.sh" > "$CLASSIFIER"
+        if ! git show "origin/$BASE_REF:scripts/needs_e2e.sh" > "$CLASSIFIER" 2>/dev/null; then
+          # The base branch has no classifier. True for the PR that
+          # INTRODUCES it -- which is how this was found, by the job failing
+          # on its own PR -- and for any branch cut before it landed.
+          #
+          # Run the browser suites. There is no trusted answer available, and
+          # "no trusted answer" resolves the same way every other uncertainty
+          # in this gate does.
+          echo "no classifier on origin/$BASE_REF -- browser suites run"
+          echo "browser=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
         chmod +x "$CLASSIFIER"
 
         if "$CLASSIFIER" "origin/$BASE_REF"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
       with:
-        fetch-depth: 0        # needs\_e2e.sh diffs against the base
+        fetch-depth: 0        # needs_e2e.sh diffs against the base
     - id: decide
       # Context values go through `env:`, never spliced into `run:`. Not
       # exploitable today (the pull_request trigger is filtered to two literal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [ master, develop ]
   pull_request:
     branches: [ master, develop ]
+  # Nightly, so the browser suites run against master even in a week with no
+  # UI changes. Without this, "coverage follows the change surface" would mean
+  # a long run of Python-only work never exercises the UI at all.
+  schedule:
+    - cron: '0 15 * * *'   # 01:00 Australia/Sydney, off-peak for the owner
 
 permissions:
   contents: read
@@ -19,6 +24,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Answers "do the browser suites need to run?" ONCE, via the same script the
+  # pre-push hook calls. Sharing the script is the point: two copies of "what
+  # counts as a UI change" drift, and the quieter side then silently stops
+  # covering something.
+  #
+  # Always YES on master and on the nightly run -- the change-surface rule is a
+  # PR-time optimisation, not a reduction in what master is held to.
+  scope:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      browser: ${{ steps.decide.outputs.browser }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0        # needs\_e2e.sh diffs against the base
+    - id: decide
+      run: |
+        set -euo pipefail
+        if [ "${{ github.event_name }}" != "pull_request" ]; then
+          echo "not a pull request (${{ github.event_name }}) -- browser suites always run"
+          echo "browser=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        if ./scripts/needs_e2e.sh "origin/${{ github.base_ref }}"; then
+          echo "browser=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "browser=false" >> "$GITHUB_OUTPUT"
+        fi
+
   lint:
     runs-on: ubuntu-latest
     permissions:
@@ -242,7 +278,14 @@ jobs:
     permissions:
       contents: read
       actions: write
-    needs: [test, ui-unit-tests]
+    needs: [test, ui-unit-tests, scope]
+    # Skipped when nothing browser-visible changed. GitHub reports a skipped
+    # job as satisfying a required status check, which is what keeps such a PR
+    # mergeable -- and that is a deliberate reliance, recorded here because it
+    # is the same GitHub behaviour that once let the accessibility verdict be
+    # ABSENT rather than red on broken branches. It is acceptable only because
+    # the skip is decided by the change surface and master/nightly always run.
+    if: needs.scope.outputs.browser == 'true'
     steps:
     - uses: actions/checkout@v7
     
@@ -376,7 +419,11 @@ jobs:
     permissions:
       contents: read
       actions: write
-    # NO `needs:` -- deliberately. Was `needs: ui-e2e-tests`, added 2026-02-16
+    needs: [scope]
+    if: needs.scope.outputs.browser == 'true'
+    # `needs: [scope]` ONLY -- scope is seconds, so this still starts almost
+    # immediately and does not re-enter the serial chain CI-003 removed it
+    # from. Was `needs: ui-e2e-tests`, added 2026-02-16
     # in 40539241 with no stated reason and no data dependency: since T1.7 this
     # job starts, seeds and tears down its OWN server on its own runner, so
     # there was no shared state for the edge to sequence. It cost the whole

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,19 @@ permissions:
 # deliberately false in docker.yml / release-to-prod.yml, where a cancelled run
 # would leave a half-published image.
 concurrency:
-  group: ci-${{ github.ref }}
+  # `github.event_name` is part of the key, and that is the whole point.
+  #
+  # A `schedule` run against the default branch has `github.ref` of
+  # refs/heads/master -- the SAME ref a `push` to master has. Keyed on ref
+  # alone, the nightly and a master push shared one group with
+  # cancel-in-progress, so a merge landing near 15:00 UTC killed one or the
+  # other. Silently: a cancelled run is not a red run, so nothing pages and
+  # the nightly simply stops happening on the weeks anything gets merged.
+  #
+  # That defeats the reason the nightly exists -- a quiet week of Python-only
+  # work still has to exercise the UI against master, and "quiet" is exactly
+  # when nobody would notice it had not.
+  group: ci-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,11 @@ on:
   # UI changes. Without this, "coverage follows the change surface" would mean
   # a long run of Python-only work never exercises the UI at all.
   schedule:
-    - cron: '0 15 * * *'   # 01:00 Australia/Sydney, off-peak for the owner
+    # 15:00 UTC. Australia/Sydney is UTC+10 in winter and UTC+11 under
+    # daylight saving, so this lands at 01:00 or 02:00 local depending on the
+    # season. Off-peak either way, and GitHub cron has no timezone, so the
+    # drift is accepted rather than worked around.
+    - cron: '0 15 * * *'
 
 permissions:
   contents: read
@@ -56,7 +60,27 @@ jobs:
           echo "browser=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi
-        if ./scripts/needs_e2e.sh "origin/$BASE_REF"; then
+        # The classifier is taken from the BASE branch, never from the PR.
+        #
+        # `actions/checkout` gives us the PR's own merge ref, so running
+        # ./scripts/needs_e2e.sh from the working tree would let a PR that
+        # edits the classifier decide whether the classifier's own change
+        # needs browser tests. An author could make it `exit 1`
+        # unconditionally, both required browser jobs would skip, and a
+        # skipped job SATISFIES a required check -- so the change that
+        # disabled the gate would merge without ever running it.
+        #
+        # Having `scripts/needs_e2e.sh` inside UI_PATTERNS does not fix that:
+        # the entry only forces a full run while it is still there, and the
+        # PR being defended against is the one that removes it.
+        #
+        # The base copy is what master is already protected by, so it is the
+        # only version with any authority over what merges into master.
+        CLASSIFIER="$(mktemp)"
+        git show "origin/$BASE_REF:scripts/needs_e2e.sh" > "$CLASSIFIER"
+        chmod +x "$CLASSIFIER"
+
+        if "$CLASSIFIER" "origin/$BASE_REF"; then
           echo "browser=true" >> "$GITHUB_OUTPUT"
         else
           echo "browser=false" >> "$GITHUB_OUTPUT"

--- a/scripts/needs_e2e.sh
+++ b/scripts/needs_e2e.sh
@@ -5,16 +5,16 @@
 # THE SINGLE SOURCE OF TRUTH for that question. The pre-push hook and the CI
 # workflow both call this, and that is the whole point: two copies of "what
 # counts as a UI change" drift, and when they drift the quieter side silently
-# stops covering something. `tests/unit/test_needs_e2e.sh_contract.py` fails if
-# either caller stops using it.
+# stops covering something. `tests/unit/test_hybrid_gate.py`
+# (TestBothCallersUseTheSharedScript) fails if either caller stops using it.
 #
 # Exit 0  = run the browser suites.
 # Exit 1  = they can be skipped for this change.
 #
 # Usage:  scripts/needs_e2e.sh <base-ref>
 #
-# Erring: when in ANY doubt -- no base ref, an unreadable diff, an unrecognised
-# path -- this exits 0. A slow gate is an annoyance; a skipped gate that should
+# Erring: when in ANY doubt -- no base ref, an unreadable diff, a pattern the
+# classifier itself cannot apply -- this exits 0. A slow gate is an annoyance; a skipped gate that should
 # have run is how a UI regression reaches master.
 set -euo pipefail
 
@@ -50,7 +50,7 @@ fi
 # `couchpotato/templates/` is the other live Jinja render root (the login
 # page). The Playwright config and fixtures decide what runs at all, and
 # package-lock pins the browser itself.
-UI_PATTERNS='^(couchpotato/ui/|couchpotato/static/|couchpotato/templates/|tests/e2e/|playwright\.config\.ts$|package\.json$|package-lock\.json$|scripts/verify\.sh$|scripts/needs_e2e\.sh$|\.github/workflows/)'
+UI_PATTERNS='^(couchpotato/ui/|couchpotato/static/|couchpotato/templates/|tests/e2e/|playwright\.config\.ts$|package\.json$|package-lock\.json$|scripts/verify\.sh$|scripts/needs_e2e\.sh$|scripts/push_base_ref\.sh$|\.github/workflows/)'
 
 # A here-string, NOT a pipe, and deliberately so. `echo ... | grep -q` made
 # grep exit at the first match; with enough remaining output to fill the pipe
@@ -58,7 +58,19 @@ UI_PATTERNS='^(couchpotato/ui/|couchpotato/static/|couchpotato/templates/|tests/
 # and the `if` took the FALSE branch. The failure scaled the wrong way: the
 # more files a change touched, the more likely it was to SKIP the browser
 # suites. Measured on this machine: correct at 1,000 paths, wrong at 4,000.
-MATCHED="$(grep -E "$UI_PATTERNS" <<< "$CHANGED" || true)"
+# `|| true` would swallow ANY grep failure, including a malformed pattern
+# (exit 2), and fall through to "nothing browser-visible changed" -- the one
+# fail-OPEN in a script that errs towards YES everywhere else. So exit 1 (no
+# match) and exit >=2 (the classifier itself broke) are kept apart.
+set +e
+MATCHED="$(grep -E "$UI_PATTERNS" <<< "$CHANGED")"
+GREP_RC=$?
+set -e
+
+if [[ "$GREP_RC" -gt 1 ]]; then
+  echo "needs_e2e: the classifier itself failed (grep exit $GREP_RC), assuming YES" >&2
+  exit 0
+fi
 
 if [[ -n "$MATCHED" ]]; then
   echo "needs_e2e: YES -- browser-visible files changed:" >&2

--- a/scripts/needs_e2e.sh
+++ b/scripts/needs_e2e.sh
@@ -25,7 +25,11 @@ if [[ -z "$BASE" ]]; then
   exit 0
 fi
 
-if ! CHANGED="$(git diff --name-only "$BASE"...HEAD 2>/dev/null)"; then
+# --no-renames: with rename detection ON, `git diff --name-only` reports
+# only the DESTINATION of a rename, so moving a live template out of the
+# UI tree looks like a change to wherever it landed. A deletion dressed as
+# a rename must not be quieter than a deletion.
+if ! CHANGED="$(git diff --no-renames --name-only "$BASE"...HEAD 2>/dev/null)"; then
   echo "needs_e2e: could not diff against '$BASE', assuming YES" >&2
   exit 0
 fi
@@ -37,15 +41,28 @@ fi
 
 # Anything that can change what a browser sees, or how it is tested.
 #
-# `couchpotato/ui/` covers templates, static assets and the new UI's Python
-# views. `couchpotato/templates/` is the other live Jinja render root (the
-# login page). The Playwright config and fixtures decide what runs at all, and
+# `couchpotato/ui/` holds the Jinja templates and the new UI's Python views.
+# `couchpotato/static/` is a SEPARATE tree, mounted at /static, holding the
+# client-side JavaScript those templates load -- including movie-filter.js,
+# which is exactly what tests/e2e/filters.spec.ts exercises. An earlier
+# version of this comment claimed couchpotato/ui/ covered static assets; it
+# does not, and the browser suites were skippable for the JS driving the UI.
+# `couchpotato/templates/` is the other live Jinja render root (the login
+# page). The Playwright config and fixtures decide what runs at all, and
 # package-lock pins the browser itself.
-UI_PATTERNS='^(couchpotato/ui/|couchpotato/templates/|tests/e2e/|playwright\.config\.ts$|package\.json$|package-lock\.json$|scripts/verify\.sh$|scripts/needs_e2e\.sh$|\.github/workflows/)'
+UI_PATTERNS='^(couchpotato/ui/|couchpotato/static/|couchpotato/templates/|tests/e2e/|playwright\.config\.ts$|package\.json$|package-lock\.json$|scripts/verify\.sh$|scripts/needs_e2e\.sh$|\.github/workflows/)'
 
-if echo "$CHANGED" | grep -qE "$UI_PATTERNS"; then
+# A here-string, NOT a pipe, and deliberately so. `echo ... | grep -q` made
+# grep exit at the first match; with enough remaining output to fill the pipe
+# buffer the writer took SIGPIPE, the pipeline returned 141 under `pipefail`,
+# and the `if` took the FALSE branch. The failure scaled the wrong way: the
+# more files a change touched, the more likely it was to SKIP the browser
+# suites. Measured on this machine: correct at 1,000 paths, wrong at 4,000.
+MATCHED="$(grep -E "$UI_PATTERNS" <<< "$CHANGED" || true)"
+
+if [[ -n "$MATCHED" ]]; then
   echo "needs_e2e: YES -- browser-visible files changed:" >&2
-  echo "$CHANGED" | grep -E "$UI_PATTERNS" | sed 's/^/  /' >&2
+  sed 's/^/  /' <<< "$MATCHED" >&2
   exit 0
 fi
 

--- a/scripts/needs_e2e.sh
+++ b/scripts/needs_e2e.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Does this change need the browser suites (E2E, accessibility, mobile)?
+#
+# THE SINGLE SOURCE OF TRUTH for that question. The pre-push hook and the CI
+# workflow both call this, and that is the whole point: two copies of "what
+# counts as a UI change" drift, and when they drift the quieter side silently
+# stops covering something. `tests/unit/test_needs_e2e.sh_contract.py` fails if
+# either caller stops using it.
+#
+# Exit 0  = run the browser suites.
+# Exit 1  = they can be skipped for this change.
+#
+# Usage:  scripts/needs_e2e.sh <base-ref>
+#
+# Erring: when in ANY doubt -- no base ref, an unreadable diff, an unrecognised
+# path -- this exits 0. A slow gate is an annoyance; a skipped gate that should
+# have run is how a UI regression reaches master.
+set -euo pipefail
+
+BASE="${1:-}"
+
+if [[ -z "$BASE" ]]; then
+  echo "needs_e2e: no base ref given, assuming YES" >&2
+  exit 0
+fi
+
+if ! CHANGED="$(git diff --name-only "$BASE"...HEAD 2>/dev/null)"; then
+  echo "needs_e2e: could not diff against '$BASE', assuming YES" >&2
+  exit 0
+fi
+
+if [[ -z "$CHANGED" ]]; then
+  echo "needs_e2e: no changed files, assuming YES" >&2
+  exit 0
+fi
+
+# Anything that can change what a browser sees, or how it is tested.
+#
+# `couchpotato/ui/` covers templates, static assets and the new UI's Python
+# views. `couchpotato/templates/` is the other live Jinja render root (the
+# login page). The Playwright config and fixtures decide what runs at all, and
+# package-lock pins the browser itself.
+UI_PATTERNS='^(couchpotato/ui/|couchpotato/templates/|tests/e2e/|playwright\.config\.ts$|package\.json$|package-lock\.json$|scripts/verify\.sh$|scripts/needs_e2e\.sh$|\.github/workflows/)'
+
+if echo "$CHANGED" | grep -qE "$UI_PATTERNS"; then
+  echo "needs_e2e: YES -- browser-visible files changed:" >&2
+  echo "$CHANGED" | grep -E "$UI_PATTERNS" | sed 's/^/  /' >&2
+  exit 0
+fi
+
+echo "needs_e2e: no -- nothing browser-visible changed ($(echo "$CHANGED" | wc -l | tr -d ' ') file(s))" >&2
+exit 1

--- a/scripts/push_base_ref.sh
+++ b/scripts/push_base_ref.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Which ref should a pre-push change-surface check diff against?
+#
+# The answer is the branch this work will MERGE INTO, and that is not
+# `@{upstream}`. Once a branch has been pushed, `@{upstream}` is its own
+# remote-tracking ref, so diffing against it narrows the question from "what
+# does this PR change" to "what did I change since my last push". A branch
+# whose first commit touches the UI and whose second is Python-only then takes
+# the fast path, even though the cumulative PR still changes the UI.
+#
+# CI has never had this problem: it diffs `github.base_ref` explicitly. That
+# made the drift worse rather than better, because the two callers of the
+# single source of truth were asking it different questions.
+#
+# Prints one ref on stdout. Errs towards a base that is FURTHER back (more
+# files in the diff, more likely to run the browser suites) rather than nearer.
+set -euo pipefail
+
+# What the remote itself calls its default branch, when that is known.
+if DEFAULT="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)"; then
+  if git rev-parse --verify --quiet "$DEFAULT" >/dev/null; then
+    echo "$DEFAULT"
+    exit 0
+  fi
+fi
+
+for candidate in origin/master origin/main master main; do
+  if git rev-parse --verify --quiet "$candidate" >/dev/null; then
+    echo "$candidate"
+    exit 0
+  fi
+done
+
+# Nothing resolvable. Print the empty string: needs_e2e.sh treats a missing
+# base ref as "assume YES", which is the safe end of this decision.
+echo ""

--- a/scripts/push_base_ref.sh
+++ b/scripts/push_base_ref.sh
@@ -25,6 +25,12 @@ if DEFAULT="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/n
   fi
 fi
 
+# Deliberately does not resolve `develop`, even though ci.yml's pull_request
+# trigger fires for it too. CI is unaffected -- the scope job always diffs the
+# real github.base_ref -- and a develop-targeted branch diffed against master
+# yields a SUPERSET of its changes, so the local gate over-runs rather than
+# under-runs. That is the correct direction here, and a choice, not an
+# oversight.
 for candidate in origin/master origin/main master main; do
   if git rev-parse --verify --quiet "$candidate" >/dev/null; then
     echo "$candidate"

--- a/tests/unit/test_hybrid_gate.py
+++ b/tests/unit/test_hybrid_gate.py
@@ -68,6 +68,12 @@ class TestTheScriptAnswersTheQuestion:
         'package-lock.json',                     # pins the browser itself
         'scripts/verify.sh',
         '.github/workflows/ci.yml',
+        # The classifier protects itself: editing it forces the full gate, so
+        # a PR cannot quietly defang its own coverage. Untested until now --
+        # and `couchpotato/static/` was dropped from this same pattern once
+        # and shipped green precisely because no case named it.
+        'scripts/needs_e2e.sh',
+        'scripts/push_base_ref.sh',
     ])
     def test_browser_visible_changes_need_the_suites(self, repo, path):
         repo['commit'](path)
@@ -406,3 +412,41 @@ class TestTheScopeStepDoesNotSpliceContextIntoTheShell:
             % step['run']
         )
         assert 'BASE_REF' in step.get('env', {})
+
+
+class TestABrokenClassifierStillErrsTowardsRunning:
+    def test_a_pattern_grep_cannot_apply_answers_YES_not_no(self, repo, tmp_path):
+        """Every other error path here errs towards YES. A `grep` that exits 2
+        on a malformed pattern must not be the one exception, because that one
+        resolves in the fail-OPEN direction: the classifier breaks and the
+        browser suites quietly stop running.
+
+        The pattern is a fixed literal today, so this is defence against a
+        future edit rather than a live bug. It is cheap, and the alternative
+        is a script whose invariant holds everywhere except in its own
+        failure.
+        """
+        import re
+        import subprocess as sp
+
+        broken = tmp_path / 'needs_e2e_broken.sh'
+        source = SCRIPT.read_text()
+        patched = re.sub(r"^UI_PATTERNS=.*$", "UI_PATTERNS='^(['", source,
+                         count=1, flags=re.M)
+        assert patched != source, 'the UI_PATTERNS line was not replaced'
+        broken.write_text(patched)
+        broken.chmod(0o755)
+
+        repo['commit']('docs/only-a-doc.md')
+
+        # Control: with the real pattern this same change answers NO, so a
+        # YES below can only come from the error branch.
+        assert _run('main', cwd=repo['dir']) == 1
+
+        result = sp.run([str(broken), 'main'], cwd=str(repo['dir']),
+                        capture_output=True, text=True)
+        assert result.returncode == 0, (
+            'a classifier that cannot run resolved to SKIP: rc=%d %s'
+            % (result.returncode, result.stderr)
+        )
+        assert 'classifier itself failed' in result.stderr

--- a/tests/unit/test_hybrid_gate.py
+++ b/tests/unit/test_hybrid_gate.py
@@ -110,6 +110,35 @@ class TestItErrsTowardsRunning:
         assert _run('main', cwd=repo['dir']) == 0
 
 
+def _ui_prefixes():
+    """Every path prefix in the script's own UI_PATTERNS.
+
+    Read from the script rather than hardcoded, so the drift guard cannot
+    fall behind the pattern it is guarding. It checked only
+    `couchpotato/ui/` before -- and `couchpotato/static/` was the prefix this
+    very PR had to add after it shipped missing, which is exactly the entry a
+    single hardcoded string would keep missing.
+    """
+    import re
+    line = [
+        ln for ln in SCRIPT.read_text().splitlines()
+        if ln.startswith('UI_PATTERNS=')
+    ]
+    assert len(line) == 1, 'UI_PATTERNS is not a single assignment'
+    prefixes = re.findall(r'[A-Za-z0-9_./\\-]+/(?=\||\))', line[0])
+    assert prefixes, 'no directory prefixes parsed out of UI_PATTERNS: %s' % line[0]
+    return [p.replace('\\', '') for p in prefixes]
+
+
+def test_the_drift_guard_reads_every_prefix_not_just_one():
+    """Guard on the guard: if the parse ever returns a single entry, the
+    drift check has quietly narrowed back to what it used to be."""
+    prefixes = _ui_prefixes()
+    assert 'couchpotato/ui/' in prefixes
+    assert 'couchpotato/static/' in prefixes
+    assert len(prefixes) >= 4, prefixes
+
+
 class TestBothCallersUseTheSharedScript:
     """The drift guard. If either side grows its own path list, the two stop
     agreeing and the quieter one silently covers less."""
@@ -134,9 +163,18 @@ class TestBothCallersUseTheSharedScript:
         assert any('$REPO_ROOT' in ln or './scripts' in ln for ln in calls), calls
 
     def test_the_workflow_actually_runs_it(self):
-        calls = self._invocations(CI)
-        assert calls, 'the workflow mentions the script but never executes it'
-        assert any('./scripts/needs_e2e.sh' in ln for ln in calls), calls
+        """Via the BASE branch's copy, deliberately -- see
+        TestTheClassifierIsTakenFromTheBaseBranch. What matters here is that
+        the workflow executes THE SCRIPT rather than re-deciding for itself."""
+        text = CI.read_text(encoding='utf-8')
+        code = [ln for ln in text.splitlines() if not ln.lstrip().startswith('#')]
+        assert any(
+            'scripts/needs_e2e.sh' in ln and ('git show' in ln or './' in ln)
+            for ln in code
+        ), 'the workflow mentions the script but never executes it'
+        assert any('"$CLASSIFIER"' in ln for ln in code), (
+            'the extracted classifier is never run'
+        )
 
     def test_neither_caller_hardcodes_its_own_ui_path_list(self):
         """A second list is the drift. `couchpotato/ui/` appearing in the hook
@@ -150,7 +188,8 @@ class TestBothCallersUseTheSharedScript:
             # diff, that answers the same question independently.
             lines = [
                 ln for ln in text.splitlines()
-                if 'couchpotato/ui/' in ln and not ln.lstrip().startswith('#')
+                if any(prefix in ln for prefix in _ui_prefixes())
+                and not ln.lstrip().startswith('#')
             ]
             assert not lines, (
                 '%s answers the UI question itself instead of asking the '
@@ -450,3 +489,123 @@ class TestABrokenClassifierStillErrsTowardsRunning:
             % (result.returncode, result.stderr)
         )
         assert 'classifier itself failed' in result.stderr
+
+
+class TestThePushBaseFallsBackAndFailsSafe:
+    """The `origin/HEAD` symref is set by `git clone` and by nothing else --
+    a repo initialised with `git init` and given a remote by hand has no such
+    ref, and a stale one survives a renamed default branch. Both fall through
+    to the candidate ladder, and neither had a test.
+    """
+
+    BASE_SCRIPT = REPO / 'scripts' / 'push_base_ref.sh'
+
+    def _base(self, cwd):
+        import subprocess as sp
+        return sp.run([str(self.BASE_SCRIPT)], cwd=str(cwd),
+                      capture_output=True, text=True).stdout.strip()
+
+    def _repo_without_origin_head(self, tmp_path):
+        import subprocess as sp
+        origin = tmp_path / 'origin.git'
+        sp.run(['git', 'init', '-q', '--bare', '-b', 'master', str(origin)],
+               check=True, capture_output=True)
+        work = tmp_path / 'work'
+        work.mkdir()
+
+        def _git(*args):
+            sp.run(['git', *args], cwd=str(work), check=True, capture_output=True)
+
+        _git('init', '-q', '-b', 'master')
+        _git('config', 'user.email', 't@example.com')
+        _git('config', 'user.name', 'T')
+        _git('remote', 'add', 'origin', str(origin))
+        (work / 'seed.txt').write_text('seed\n')
+        _git('add', '-A')
+        _git('commit', '-qm', 'seed')
+        _git('push', '-q', 'origin', 'master')
+        _git('fetch', '-q', 'origin')
+        # Modern git sets origin/HEAD on fetch. Remove it, because the case
+        # under test is a repo that has never had one.
+        sp.run(['git', 'symbolic-ref', '--delete', 'refs/remotes/origin/HEAD'],
+               cwd=str(work), capture_output=True)
+        return work, _git
+
+    def test_the_candidate_ladder_is_used_when_origin_HEAD_is_unset(self, tmp_path):
+        work, git = self._repo_without_origin_head(tmp_path)
+
+        import subprocess as sp
+        symref = sp.run(['git', 'symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'],
+                        cwd=str(work), capture_output=True, text=True)
+        assert symref.returncode != 0, (
+            'origin/HEAD exists, so this fixture cannot exercise the ladder'
+        )
+
+        assert self._base(work).endswith('master')
+
+    def test_a_repo_with_no_resolvable_base_answers_EMPTY(self, tmp_path):
+        """And empty is the safe end: needs_e2e.sh treats a missing base ref
+        as 'assume YES'. Asserted end to end rather than trusted to a comment.
+        """
+        import subprocess as sp
+        work = tmp_path / 'lonely'
+        work.mkdir()
+        sp.run(['git', 'init', '-q', '-b', 'nothing-standard', str(work)],
+               check=True, capture_output=True)
+        for args in (['config', 'user.email', 't@example.com'],
+                     ['config', 'user.name', 'T']):
+            sp.run(['git', *args], cwd=str(work), check=True, capture_output=True)
+        (work / 'a.txt').write_text('a\n')
+        sp.run(['git', 'add', '-A'], cwd=str(work), check=True, capture_output=True)
+        sp.run(['git', 'commit', '-qm', 'one'], cwd=str(work), check=True,
+               capture_output=True)
+
+        assert self._base(work) == ''
+
+        # End to end: the empty answer must make the classifier say YES.
+        result = sp.run([str(SCRIPT), ''], cwd=str(work),
+                        capture_output=True, text=True)
+        assert result.returncode == 0, (
+            'an unresolvable base resolved to SKIP: %s' % result.stderr
+        )
+
+
+class TestTheClassifierIsTakenFromTheBaseBranch:
+    """A PR that edits the classifier must not be gated by its own edit.
+
+    `actions/checkout` gives the workflow the PR's merge ref, so running the
+    working-tree copy would let an author make it `exit 1` unconditionally:
+    both required browser jobs skip, a skipped job satisfies a required check,
+    and the change that disabled the gate merges without ever running it.
+
+    Listing `scripts/needs_e2e.sh` in UI_PATTERNS does not close this. That
+    entry only forces a full run while it is still there, and the PR being
+    defended against is the one that removes it.
+    """
+
+    def test_the_scope_job_runs_the_base_copy_not_the_checkout(self):
+        scope = yaml.safe_load(CI.read_text())['jobs']['scope']
+        step = [s for s in scope['steps'] if s.get('id') == 'decide'][0]
+        run = '\n'.join(
+            ln for ln in step['run'].splitlines()
+            if not ln.lstrip().startswith('#')
+        )
+
+        assert 'git show "origin/$BASE_REF:scripts/needs_e2e.sh"' in run, (
+            'the scope job classifies with the PR\'s own copy of the '
+            'classifier, so a PR can decide it does not need to be tested'
+        )
+        assert './scripts/needs_e2e.sh' not in run, (
+            'the working-tree classifier is still being executed'
+        )
+
+    def test_the_pre_push_hook_DOES_use_the_working_tree_copy(self):
+        """Deliberately different, and worth stating.
+
+        The hook is the author's own gate on their own machine. There is no
+        adversary to defend against there -- someone editing their local
+        classifier to skip tests can equally pass `--no-verify` -- and using
+        the base copy locally would mean the author could not test a change to
+        the classifier at all.
+        """
+        assert 'scripts/needs_e2e.sh' in HOOK.read_text()

--- a/tests/unit/test_hybrid_gate.py
+++ b/tests/unit/test_hybrid_gate.py
@@ -1,0 +1,182 @@
+"""The local gate and CI must agree about what needs browser tests (T16).
+
+The hybrid gate skips E2E, accessibility and mobile when nothing
+browser-visible changed — locally in `.githooks/pre-push`, and on pull requests
+in `ci.yml`. That is only safe while BOTH sides ask the same question.
+
+Two copies of "what counts as a UI change" drift, and when they drift the
+quieter side silently stops covering something — which is indistinguishable
+from working. So there is exactly one implementation,
+`scripts/needs_e2e.sh`, and these tests fail if either caller stops using it
+or if the script stops erring towards running.
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip('yaml')
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / 'scripts' / 'needs_e2e.sh'
+HOOK = REPO / '.githooks' / 'pre-push'
+CI = REPO / '.github' / 'workflows' / 'ci.yml'
+
+BROWSER_JOBS = ('ui-e2e-tests', 'accessibility')
+
+
+def _run(*args, cwd):
+    return subprocess.run(
+        [str(SCRIPT), *args], cwd=str(cwd), capture_output=True, text=True
+    ).returncode
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A throwaway git repo, so the script is exercised against real diffs
+    rather than a mocked `git`."""
+    def _git(*args):
+        subprocess.run(['git', *args], cwd=tmp_path, check=True,
+                       capture_output=True, text=True)
+
+    _git('init', '-q', '-b', 'main')
+    _git('config', 'user.email', 't@example.com')
+    _git('config', 'user.name', 'T')
+    (tmp_path / 'seed.txt').write_text('seed\n')
+    _git('add', '-A')
+    _git('commit', '-qm', 'seed')
+
+    _git('checkout', '-q', '-b', 'work')
+
+    def _commit(path, body='x\n'):
+        target = tmp_path / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+        _git('add', '-A')
+        _git('commit', '-qm', 'change %s' % path)
+
+    return {'dir': tmp_path, 'commit': _commit}
+
+
+class TestTheScriptAnswersTheQuestion:
+    @pytest.mark.parametrize('path', [
+        'couchpotato/ui/templates/base.html',
+        'couchpotato/ui/static/app.js',
+        'couchpotato/templates/login.html',      # the other live render root
+        'tests/e2e/navigation.spec.ts',
+        'playwright.config.ts',
+        'package-lock.json',                     # pins the browser itself
+        'scripts/verify.sh',
+        '.github/workflows/ci.yml',
+    ])
+    def test_browser_visible_changes_need_the_suites(self, repo, path):
+        repo['commit'](path)
+        assert _run('main', cwd=repo['dir']) == 0, path
+
+    @pytest.mark.parametrize('path', [
+        'couchpotato/core/plugins/renamer/main.py',
+        'tests/unit/test_something.py',
+        'docs/technical-debt.md',
+        'README.md',
+    ])
+    def test_non_browser_changes_do_not(self, repo, path):
+        repo['commit'](path)
+        assert _run('main', cwd=repo['dir']) == 1, path
+
+    def test_a_mixed_change_needs_them(self, repo):
+        """One browser-visible file among many is still a reason to run."""
+        repo['commit']('couchpotato/core/thing.py')
+        repo['commit']('couchpotato/ui/templates/base.html')
+        assert _run('main', cwd=repo['dir']) == 0
+
+
+class TestItErrsTowardsRunning:
+    """A slow gate is an annoyance. A skipped gate that should have run is how
+    a UI regression reaches master, so every uncertain case must answer YES."""
+
+    def test_no_base_ref(self, repo):
+        assert _run(cwd=repo['dir']) == 0
+
+    def test_an_unresolvable_base_ref(self, repo):
+        assert _run('no-such-ref', cwd=repo['dir']) == 0
+
+    def test_an_empty_diff(self, repo):
+        assert _run('main', cwd=repo['dir']) == 0
+
+
+class TestBothCallersUseTheSharedScript:
+    """The drift guard. If either side grows its own path list, the two stop
+    agreeing and the quieter one silently covers less."""
+
+    @staticmethod
+    def _invocations(path):
+        """Non-comment lines that actually RUN the script.
+
+        Substring-matching the filename was vacuous: the hook's own comment
+        mentions `needs_e2e.sh`, so replacing the real call with `if false;`
+        left the test green. Mutation testing caught it. A guard that passes
+        because of a comment is not a guard.
+        """
+        return [
+            ln for ln in path.read_text(encoding='utf-8').splitlines()
+            if 'needs_e2e.sh' in ln and not ln.lstrip().startswith('#')
+        ]
+
+    def test_the_pre_push_hook_actually_runs_it(self):
+        calls = self._invocations(HOOK)
+        assert calls, 'the hook mentions the script but never executes it'
+        assert any('$REPO_ROOT' in ln or './scripts' in ln for ln in calls), calls
+
+    def test_the_workflow_actually_runs_it(self):
+        calls = self._invocations(CI)
+        assert calls, 'the workflow mentions the script but never executes it'
+        assert any('./scripts/needs_e2e.sh' in ln for ln in calls), calls
+
+    def test_neither_caller_hardcodes_its_own_ui_path_list(self):
+        """A second list is the drift. `couchpotato/ui/` appearing in the hook
+        or in a workflow path filter means somebody re-answered the question
+        locally instead of asking the script."""
+        for caller in (HOOK, CI):
+            text = caller.read_text(encoding='utf-8')
+            # Prose is fine -- an unrelated job's comment mentions the UI
+            # directory, and always did. What must not exist is a second
+            # DECISION: a `paths:`/`paths-ignore:` filter, or a grep of the
+            # diff, that answers the same question independently.
+            lines = [
+                ln for ln in text.splitlines()
+                if 'couchpotato/ui/' in ln and not ln.lstrip().startswith('#')
+            ]
+            assert not lines, (
+                '%s answers the UI question itself instead of asking the '
+                'script; there must be exactly one implementation: %s'
+                % (caller.name, lines)
+            )
+
+
+class TestTheBrowserJobsAreGatedButStillReport:
+    def test_both_browser_jobs_depend_on_the_scope_decision(self):
+        workflow = yaml.safe_load(CI.read_text(encoding='utf-8'))
+        for job in BROWSER_JOBS:
+            spec = workflow['jobs'][job]
+            assert 'scope' in (spec.get('needs') or []), job
+            assert spec.get('if') == "needs.scope.outputs.browser == 'true'", job
+
+    def test_the_scope_job_forces_yes_off_pull_requests(self):
+        """The change-surface rule is a PR-time optimisation. Master and the
+        nightly run are held to the full suite regardless, or a long stretch of
+        Python-only work would never exercise the UI at all."""
+        text = CI.read_text(encoding='utf-8')
+        assert "github.event_name }}\" != \"pull_request\"" in text
+        assert 'browser=true' in text
+
+    def test_a_nightly_schedule_exists(self):
+        workflow = yaml.safe_load(CI.read_text(encoding='utf-8'))
+        triggers = workflow.get(True) or workflow.get('on')
+        assert 'schedule' in triggers, 'no nightly run: a quiet week would never test the UI'
+
+    def test_the_accessibility_job_did_not_rejoin_the_serial_chain(self):
+        """CI-003 removed `needs: ui-e2e-tests` from accessibility because it
+        cost 516s of a 656s wall-clock. Depending on `scope` is fine — that job
+        is seconds — but depending on a test job again would undo that work."""
+        workflow = yaml.safe_load(CI.read_text(encoding='utf-8'))
+        assert workflow['jobs']['accessibility'].get('needs') == ['scope']

--- a/tests/unit/test_hybrid_gate.py
+++ b/tests/unit/test_hybrid_gate.py
@@ -159,14 +159,16 @@ class TestTheBrowserJobsAreGatedButStillReport:
         for job in BROWSER_JOBS:
             spec = workflow['jobs'][job]
             assert 'scope' in (spec.get('needs') or []), job
-            assert spec.get('if') == "needs.scope.outputs.browser == 'true'", job
+            # Fail-closed: an ABSENT answer must still run the suites. See
+            # TestTheBrowserJobsFailClosedWhenScopeCannotDecide.
+            assert "needs.scope.outputs.browser != 'false'" in spec.get('if', ''), job
 
     def test_the_scope_job_forces_yes_off_pull_requests(self):
         """The change-surface rule is a PR-time optimisation. Master and the
         nightly run are held to the full suite regardless, or a long stretch of
         Python-only work would never exercise the UI at all."""
         text = CI.read_text(encoding='utf-8')
-        assert "github.event_name }}\" != \"pull_request\"" in text
+        assert '"$EVENT_NAME" != "pull_request"' in text
         assert 'browser=true' in text
 
     def test_a_nightly_schedule_exists(self):
@@ -180,3 +182,227 @@ class TestTheBrowserJobsAreGatedButStillReport:
         is seconds — but depending on a test job again would undo that work."""
         workflow = yaml.safe_load(CI.read_text(encoding='utf-8'))
         assert workflow['jobs']['accessibility'].get('needs') == ['scope']
+
+
+class TestTheLiveStaticAssetTreeIsCovered:
+    """`couchpotato/static/` is a SEPARATE tree from `couchpotato/ui/`, and it
+    is the one holding the client-side JavaScript the modern UI actually loads
+    (`base.html` pulls in `static/scripts/ui/index.js`). The first version of
+    this matcher covered only `couchpotato/ui/` and its comment claimed that
+    "covers static assets" -- which was simply wrong about the layout.
+
+    `movie-filter.js` is the code `tests/e2e/filters.spec.ts` exercises, so the
+    hole let a change to the exact file a named E2E spec covers take the fast
+    path. The gap shipped green because no parametrised case named this
+    directory at all.
+    """
+
+    @pytest.mark.parametrize('path', [
+        'couchpotato/static/scripts/ui/movie-filter.js',
+        'couchpotato/static/scripts/ui/profile-editor.js',
+        'couchpotato/static/sw.js',
+        'couchpotato/static/manifest.json',
+        'couchpotato/static/style/main.css',
+    ])
+    def test_a_change_to_a_served_static_asset_needs_the_suites(self, repo, path):
+        repo['commit'](path)
+        assert _run('main', cwd=repo['dir']) == 0, path
+
+
+class TestARenameAwayFromTheUiStillCounts:
+    def test_moving_a_template_out_of_the_ui_tree_needs_the_suites(self, repo):
+        """Git rename detection reports only the DESTINATION. Moving a live
+        template to `docs/` therefore looked like a docs-only change, so the
+        rendered UI could lose a template while every browser suite was
+        skipped. A deletion dressed as a rename must not be quieter than a
+        deletion."""
+        import subprocess as sp
+
+        def _git(*args):
+            sp.run(['git', *args], cwd=repo['dir'], check=True, capture_output=True)
+
+        # The template must exist on the BASE, or the net diff is just an
+        # added docs file and the test proves nothing.
+        _git('checkout', '-q', 'main')
+        target = repo['dir'] / 'couchpotato' / 'ui' / 'templates'
+        target.mkdir(parents=True, exist_ok=True)
+        (target / 'view.html').write_text('x' * 400)
+        _git('add', '-A')
+        _git('commit', '-qm', 'template lives here')
+        _git('checkout', '-q', 'work')
+        _git('rebase', '-q', 'main')
+
+        _git('rm', '-q', 'couchpotato/ui/templates/view.html')
+        (repo['dir'] / 'docs').mkdir(exist_ok=True)
+        (repo['dir'] / 'docs' / 'view.txt').write_text('x' * 400)
+        _git('add', '-A')
+        _git('commit', '-qm', 'move it out')
+
+        # Precondition: git really does collapse this to a rename, otherwise
+        # the test passes for the wrong reason.
+        renamed = sp.run(['git', 'diff', '--name-only', 'main...HEAD'],
+                         cwd=repo['dir'], capture_output=True, text=True).stdout.split()
+        assert renamed == ['docs/view.txt'], (
+            'git did not detect a rename, so this fixture cannot provoke the '
+            'bug: %r' % renamed
+        )
+
+        assert _run('main', cwd=repo['dir']) == 0
+
+
+class TestALargeDiffDoesNotSilentlySkip:
+    def test_an_early_match_among_thousands_of_files_still_answers_yes(self, repo):
+        """SIGPIPE under `pipefail`, and a fail-OPEN one.
+
+        `echo "$CHANGED" | grep -q` made `grep` exit at the first match. With
+        enough remaining output to fill the pipe buffer, the writer took
+        SIGPIPE, the pipeline returned 141, and `if` took the FALSE branch --
+        so the more browser-visible files a change touched, the more likely it
+        was to skip the browser suites. Measured locally: correct at 1,000
+        paths, wrong at 4,000.
+
+        The fixture must therefore be big enough to fill the buffer. A handful
+        of files cannot provoke it and would pass against the bug.
+        """
+        import subprocess as sp
+        target = repo['dir'] / 'couchpotato' / 'ui' / 'templates'
+        target.mkdir(parents=True, exist_ok=True)
+        (target / 'aaa.html').write_text('x\n')     # sorts early: matched first
+        bulk = repo['dir'] / 'zzz_bulk'
+        bulk.mkdir(exist_ok=True)
+        for i in range(6000):
+            (bulk / ('file_%05d.py' % i)).write_text('x\n')
+        sp.run(['git', 'add', '-A'], cwd=repo['dir'], check=True, capture_output=True)
+        sp.run(['git', 'commit', '-qm', 'a lot'], cwd=repo['dir'], check=True,
+               capture_output=True)
+
+        assert _run('main', cwd=repo['dir']) == 0, (
+            'a browser-visible file was lost in a large diff'
+        )
+
+
+class TestThePushBaseIsTheTargetBranchNotTheLastPush:
+    """`@{upstream}` is the branch's OWN remote-tracking ref once it has been
+    pushed, not the branch it will merge into.
+
+    So the first push of a branch diffed against master and ran the full gate,
+    and every push after that diffed against the previous push. A branch whose
+    first commit touched the UI and whose second was Python-only took the fast
+    path locally while the cumulative PR still changed the UI. CI was
+    unaffected (it diffs `github.base_ref` explicitly), which is worse rather
+    than better: the two callers of the "single source of truth" were asking
+    it different questions, the exact drift this design exists to prevent.
+    """
+
+    BASE_SCRIPT = REPO / 'scripts' / 'push_base_ref.sh'
+
+    def _remote_repo(self, tmp_path):
+        import subprocess as sp
+        origin = tmp_path / 'origin.git'
+        sp.run(['git', 'init', '-q', '--bare', '-b', 'master', str(origin)],
+               check=True, capture_output=True)
+        clone = tmp_path / 'clone'
+        sp.run(['git', 'clone', '-q', str(origin), str(clone)],
+               check=True, capture_output=True)
+
+        def _git(*args, cwd=clone):
+            return sp.run(['git', *args], cwd=str(cwd), check=True,
+                          capture_output=True, text=True).stdout.strip()
+
+        _git('config', 'user.email', 't@example.com')
+        _git('config', 'user.name', 'T')
+        (clone / 'seed.txt').write_text('seed\n')
+        _git('add', '-A')
+        _git('commit', '-qm', 'seed')
+        _git('push', '-q', 'origin', 'master')
+        return clone, _git
+
+    def _base(self, cwd):
+        import subprocess as sp
+        return sp.run([str(self.BASE_SCRIPT)], cwd=str(cwd),
+                      capture_output=True, text=True).stdout.strip()
+
+    def test_before_the_first_push_the_base_is_master(self, tmp_path):
+        clone, git = self._remote_repo(tmp_path)
+        git('checkout', '-q', '-b', 'feature')
+        assert self._base(clone).endswith('master')
+
+    def test_AFTER_the_first_push_the_base_is_STILL_master(self, tmp_path):
+        """The regression itself. With `@{upstream}` this returned
+        `origin/feature` and the gate narrowed to "since my last push"."""
+        clone, git = self._remote_repo(tmp_path)
+        git('checkout', '-q', '-b', 'feature')
+        (clone / 'a.txt').write_text('a\n')
+        git('add', '-A')
+        git('commit', '-qm', 'one')
+        git('push', '-q', '-u', 'origin', 'feature')
+
+        # Precondition: upstream really is the branch's own ref now, so this
+        # test would be vacuous if it were not.
+        assert git('rev-parse', '--abbrev-ref', '--symbolic-full-name',
+                   '@{upstream}') == 'origin/feature'
+
+        assert self._base(clone).endswith('master'), (
+            'the pre-push base narrowed to the last push'
+        )
+
+    def test_the_hook_uses_the_helper_and_not_the_upstream_ref(self):
+        code = [
+            line for line in HOOK.read_text().splitlines()
+            if line.strip() and not line.lstrip().startswith('#')
+        ]
+        assert not any('@{upstream}' in line for line in code), (
+            'the hook went back to diffing against its own last push'
+        )
+        assert any('push_base_ref.sh' in line for line in code)
+
+
+class TestTheBrowserJobsFailClosedWhenScopeCannotDecide:
+    """A skipped job SATISFIES a required status check on GitHub.
+
+    So if `scope` dies before writing its output -- a failed checkout, a
+    classifier that cannot run -- then `needs.scope.outputs.browser` is empty,
+    `== 'true'` is false, both browser jobs skip, and the PR is mergeable with
+    no E2E and no accessibility coverage at all. The condition must therefore
+    key on the only value that is safe to skip on: an explicit 'false'.
+    """
+
+    @pytest.fixture
+    def jobs(self):
+        return yaml.safe_load(CI.read_text())['jobs']
+
+    @pytest.mark.parametrize('job', BROWSER_JOBS)
+    def test_the_gate_is_an_explicit_false_not_a_missing_true(self, jobs, job):
+        condition = jobs[job]['if']
+        assert "needs.scope.outputs.browser != 'false'" in condition, (
+            '%s skips whenever scope fails to produce an answer' % job
+        )
+        assert "needs.scope.outputs.browser == 'true'" not in condition, (
+            '%s still keys on the presence of a true, so an absent answer '
+            'silently skips it' % job
+        )
+
+    @pytest.mark.parametrize('job', BROWSER_JOBS)
+    def test_a_failed_scope_job_does_not_skip_the_browser_job(self, jobs, job):
+        """`needs:` alone would skip the dependent job when scope fails, no
+        matter what the `if` says, so the condition must survive that."""
+        condition = jobs[job]['if']
+        assert 'cancelled()' in condition, (
+            '%s relies on the implicit success() of its needs, so a failed '
+            'scope job skips it before the condition is even read' % job
+        )
+
+
+class TestTheScopeStepDoesNotSpliceContextIntoTheShell:
+    def test_the_classifier_reads_its_inputs_from_env(self):
+        """Not exploitable today -- the `pull_request` trigger is filtered to
+        two literal branches. It is the shape that matters: the filter is one
+        careless widening away from being untrusted input in a `run:` block,
+        and `env:` costs nothing."""
+        scope = yaml.safe_load(CI.read_text())['jobs']['scope']
+        step = [s for s in scope['steps'] if s.get('id') == 'decide'][0]
+        assert '${{' not in step['run'], (
+            'GitHub context is interpolated straight into the shell: %s'
+            % step['run']
+        )
+        assert 'BASE_REF' in step.get('env', {})

--- a/tests/unit/test_hybrid_gate.py
+++ b/tests/unit/test_hybrid_gate.py
@@ -614,6 +614,53 @@ class TestTheClassifierIsTakenFromTheBaseBranch:
             'the working-tree classifier is still being executed'
         )
 
+    def test_a_base_without_the_classifier_runs_the_browser_suites(self):
+        """The bootstrap case, and it is not hypothetical: this job failed on
+        its own PR with `fatal: path 'scripts/needs_e2e.sh' exists on disk,
+        but not in 'origin/master'`, because the PR that introduces the
+        classifier is by definition a PR whose base does not have one.
+
+        Worth noting how it was found. The local tests assert the workflow's
+        TEXT; only CI executes it, so a shell error in that step is invisible
+        to `make verify`. The lesson is not "add more text assertions" -- it
+        is that this step's failure mode has to be safe, because the gate
+        cannot fully test itself.
+
+        No trusted answer available resolves the same way every other
+        uncertainty here does: run them.
+        """
+        scope = yaml.safe_load(CI.read_text())['jobs']['scope']
+        step = [s for s in scope['steps'] if s.get('id') == 'decide'][0]
+        code = [
+            ln for ln in step['run'].splitlines()
+            if not ln.lstrip().startswith('#')
+        ]
+        starts = [i for i, ln in enumerate(code) if 'if ! git show' in ln]
+        assert starts, (
+            'the classifier extraction is unguarded, so a base branch without '
+            'it fails the job instead of running the suites'
+        )
+
+        # Line-exact `fi`, not a substring search: 'fi' also occurs inside
+        # 'classifier', and splitting on it cut the block in half. The same
+        # substring trap that once turned `_make_plugin` into
+        # `_make_make_plugin`.
+        start = starts[0]
+        ends = [
+            i for i, ln in enumerate(code)
+            if i > start and ln.strip() == 'fi'
+        ]
+        assert ends, 'the guard block is never closed'
+        block = code[start:ends[0]]
+
+        assert any('browser=true' in ln for ln in block), (
+            'a base with no classifier does not resolve to running the '
+            'suites: %r' % block
+        )
+        assert not any('browser=false' in ln for ln in block), (
+            'the no-classifier path can resolve to SKIP'
+        )
+
     def test_the_pre_push_hook_DOES_use_the_working_tree_copy(self):
         """Deliberately different, and worth stating.
 

--- a/tests/unit/test_hybrid_gate.py
+++ b/tests/unit/test_hybrid_gate.py
@@ -216,6 +216,21 @@ class TestTheBrowserJobsAreGatedButStillReport:
         assert '"$EVENT_NAME" != "pull_request"' in text
         assert 'browser=true' in text
 
+    def test_the_nightly_cannot_be_cancelled_by_a_master_push(self):
+        """A scheduled run and a push to master share `github.ref`, so a
+        concurrency group keyed on ref alone let one cancel the other --
+        silently, because a cancelled run is not a failed one.
+
+        The nightly exists for weeks when nothing else runs, and a merge
+        landing near the cron time is precisely when it would be lost.
+        """
+        workflow = yaml.safe_load(CI.read_text(encoding='utf-8'))
+        group = workflow['concurrency']['group']
+        assert 'github.event_name' in group, (
+            'the nightly shares a concurrency group with master pushes and '
+            'can be cancelled by one: %s' % group
+        )
+
     def test_a_nightly_schedule_exists(self):
         workflow = yaml.safe_load(CI.read_text(encoding='utf-8'))
         triggers = workflow.get(True) or workflow.get('on')


### PR DESCRIPTION
The gate was paid for **twice, serially**: the pre-push hook runs all of `scripts/verify.sh` (~7.3 min, ~5 of it browser suites), then CI re-runs nearly the same work (~8.5 min to a mergeable PR). About **15 minutes per push cycle** for one set of tests.

## The design changed from the sketch, and it's a better trade

Not *"PRs skip E2E"*. Coverage follows the **change surface**, the same rule on both sides — so a UI change still gets full browser coverage on its own PR. The case that most needs it loses nothing; only changes that cannot affect a rendered page take the fast path.

| | local | PR CI |
|---|---|---|
| Python-only change | ~2.3 min | ~4 min |
| UI change | ~7.3 min (unchanged) | ~8.5 min (unchanged) |
| master / nightly | — | full suite, always |

## One implementation of the question, not two

`scripts/needs_e2e.sh` is called by the hook **and** by a `scope` job in the workflow. Two copies of "what counts as a UI change" drift, and the quieter side then silently stops covering something — which is indistinguishable from working. A test fails if either caller stops invoking it or grows its own path list.

It errs towards **running**: no base ref, an unreadable diff, an empty diff, or anything under `couchpotato/ui/`, `couchpotato/templates/`, `tests/e2e/`, `playwright.config.ts`, `package-lock.json`, `verify.sh` or `.github/workflows/` all answer yes. A slow gate is an annoyance; a skipped gate that should have run is how a UI regression reaches master.

A **nightly run** is added so a quiet week of Python-only work still exercises the UI against master.

## A deliberate reliance on a weakness, recorded not hidden

This depends on GitHub treating a **skipped required check as satisfying branch protection** — the same behaviour that once let the accessibility verdict be *absent* rather than red on broken branches (#232). It is acceptable here only because the skip is decided by the change surface and because master and the nightly always run. It is stated at the line rather than left for someone to discover.

`accessibility` gains `needs: [scope]` and nothing else — scope takes seconds, so it does not re-enter the serial chain CI-003 removed it from (516s of a 656s wall-clock), and a test pins that it never gains a test-job dependency again.

## Evidence

Six mutations, five caught immediately:

| mutation | result |
|---|---|
| no base ref → assume NO (fail-open) | red |
| unreadable diff → assume NO | red |
| drop `couchpotato/templates/` from the pattern | red |
| browser jobs stop gating on scope | red |
| scope stops forcing YES on master | red |

**The sixth exposed a vacuous guard of my own.** The drift test substring-matched `needs_e2e.sh` — which appears in the hook's own *comment* — so replacing the real call with `if false;` left it green. It now requires a non-comment invocation, and the mutation turns it red.

The script is exercised against real git diffs in a throwaway repo, not a mocked `git`.

`make verify` green (`GATE_RC=0`), and this change self-consistently demands the **full** gate for itself, since it touches `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc