### PR TITLE
chore(sonar): wire the repo into the self-hosted SonarQube for reporting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -95,3 +95,12 @@ test_data/
 # Untracked root-level dev scripts (gitignored, so invisible to git but not to
 # Docker).
 test_*.py
+
+# Scan and coverage outputs. Gitignored, so invisible to git -- but the build
+# context is the filesystem, not the index, and Dockerfile:117 copies the whole
+# context in. Without these, anyone who runs the documented Sonar workflow
+# bakes their coverage reports and scanner metadata into the runtime image.
+coverage/
+coverage.xml
+htmlcov/
+.scannerwork/

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,9 @@ mutants/
 .e2e-*
 .claude/worktrees/
 .claude/active-plan
+
+# SonarQube: scanner working directory and the coverage reports it ingests.
+# Added BEFORE the first scan -- generating them first is how a coverage
+# artefact ends up committed.
+.scannerwork/
+coverage/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@playwright/test": "^1.62.1",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/vitest-runner": "^9.6.1",
-        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/coverage-v8": "^4.1.10",
         "jsdom": "^30.0.1",
         "vitest": "^4.1.10"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@playwright/test": "^1.62.1",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/vitest-runner": "^9.6.1",
+        "@vitest/coverage-v8": "4.1.10",
         "jsdom": "^30.0.1",
         "vitest": "^4.1.10"
       }
@@ -602,6 +603,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -2360,6 +2371,37 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -2623,6 +2665,25 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/axe-core": {
       "version": "4.12.1",
@@ -4279,6 +4340,13 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -4587,6 +4655,97 @@
       "dependencies": {
         "node-fetch": "^2.6.1",
         "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jpeg-js": {
@@ -5386,6 +5545,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@playwright/test": "^1.62.1",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
-    "@vitest/coverage-v8": "4.1.10",
+    "@vitest/coverage-v8": "^4.1.10",
     "jsdom": "^30.0.1",
     "vitest": "^4.1.10"
   },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@playwright/test": "^1.62.1",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
+    "@vitest/coverage-v8": "4.1.10",
     "jsdom": "^30.0.1",
     "vitest": "^4.1.10"
   },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -23,6 +23,11 @@ sonar.test.inclusions=\
   **/*.test.ts,\
   **/*.spec.ts
 
+# The test patterns below are repeated on purpose, even though they are
+# unreachable TODAY: sonar.exclusions only filters what sonar.sources can
+# reach, and the test patterns are currently disjoint from couchpotato/ and
+# scripts/. They become load-bearing the moment somebody adds a co-located
+# test -- precisely the trap this file exists to avoid.
 sonar.exclusions=\
   **/node_modules/**,\
   **/.venv/**,\

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,7 +12,10 @@ sonar.projectName=CouchPotato
 # The stakes are higher than usual on this repo. Tests are 63,543 lines against
 # 42,208 lines of production code -- MORE test than source. Misclassified, they
 # would not merely inflate ncloc, they would dominate it.
-sonar.sources=couchpotato,scripts
+# CouchPotato.py is the production entry point (Dockerfile:142). Leaving it
+# out kept startup, shutdown, signal and restart handling -- the code that
+# runs on every container boot -- out of the analysis entirely.
+sonar.sources=couchpotato,scripts,CouchPotato.py
 sonar.tests=tests
 
 # The root-level startup smoke script is a test, not production code.
@@ -61,8 +64,13 @@ sonar.sourceEncoding=UTF-8
 
 # Coverage is INGESTED, never computed. Generate BOTH before scanning:
 #
-#   .venv/bin/python -m pytest tests/unit/ -q \
+#   .venv/bin/python -m pytest tests/unit/ tests/integration/ -q \
 #       --cov=couchpotato --cov=scripts --cov-report=xml:coverage.xml
+#
+# Integration tests are included because `scripts/verify.sh` and CI both treat
+# them as required, and they are what actually exercise migration, the SQLite
+# adapter and plugin loading. Measuring coverage from unit tests alone would
+# under-report exactly the paths with the most to lose.
 #   npx vitest run --coverage
 #
 # Verified by measurement rather than by reading the reports: after the first

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,13 @@
+# The server URL and token are NOT committed, and that is the point rather
+# than an omission. This is a private repository analysed on a self-hosted
+# server at a LAN address; the token grants write access to that analysis.
+# Both are supplied at invocation time:
+#
+#   set -a; . ~/.sonar-token; set +a          # exports SONAR_TOKEN
+#   npx --yes sonarqube-scanner -Dsonar.host.url=http://172.16.11.10:9000
+#
+# Prefer the environment variable over `-Dsonar.token=`, which puts the value
+# in shell history and in the process list.
 sonar.projectKey=couchpotato
 sonar.projectName=CouchPotato
 
@@ -39,6 +49,7 @@ sonar.exclusions=\
   **/.git/**,\
   .claude/**,\
   libs/**,\
+  couchpotato/static/scripts/vendor/**,\
   test_data/**,\
   data/**,\
   reports/**,\
@@ -54,6 +65,12 @@ sonar.exclusions=\
 # .claude/** is load-bearing, not tidiness: .claude/worktrees holds FIVE full
 # checkouts of this repository (46 MB). Inside a source root they would report
 # the entire codebase as duplicated against itself.
+#
+# couchpotato/static/scripts/vendor/** is the same situation one directory
+# deeper and INSIDE a source root: third-party frontend bundles (htmx and
+# friends) that nobody here will fix. Excluding libs/ while analysing these
+# would apply the policy to whichever vendored code happened to sit outside
+# couchpotato/, which is not a policy.
 #
 # libs/** is vendored CodernityDB, kept only for one-time migration per
 # CLAUDE.md. It is 7,147 lines of third-party code nobody here will fix, and

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,70 @@
+sonar.projectKey=couchpotato
+sonar.projectName=CouchPotato
+
+# This project keeps ALL tests under tests/ -- verified, not assumed:
+#   find . -name 'test_*.py' -not -path './tests/*'   -> only test_startup_local.py
+#   find . -name '*.spec.ts' -not -path './tests/*'   -> nothing
+# So sources and tests do not overlap and the "root both at the same
+# directories" pattern is unnecessary here. Keeping them disjoint is stronger:
+# a file cannot be claimed by both buckets, which is the failure that rejects
+# an analysis outright.
+#
+# The stakes are higher than usual on this repo. Tests are 63,543 lines against
+# 42,208 lines of production code -- MORE test than source. Misclassified, they
+# would not merely inflate ncloc, they would dominate it.
+sonar.sources=couchpotato,scripts
+sonar.tests=tests
+
+# The root-level startup smoke script is a test, not production code.
+sonar.test.inclusions=\
+  tests/**,\
+  **/test_*.py,\
+  **/*_test.py,\
+  **/*.test.ts,\
+  **/*.spec.ts
+
+sonar.exclusions=\
+  **/node_modules/**,\
+  **/.venv/**,\
+  **/venv/**,\
+  **/__pycache__/**,\
+  **/.git/**,\
+  .claude/**,\
+  libs/**,\
+  test_data/**,\
+  data/**,\
+  reports/**,\
+  playwright-report/**,\
+  ds-bundle/**,\
+  coverage/**,\
+  htmlcov/**,\
+  tests/**,\
+  **/test_*.py,\
+  **/*.test.ts,\
+  **/*.spec.ts
+
+# .claude/** is load-bearing, not tidiness: .claude/worktrees holds FIVE full
+# checkouts of this repository (46 MB). Inside a source root they would report
+# the entire codebase as duplicated against itself.
+#
+# libs/** is vendored CodernityDB, kept only for one-time migration per
+# CLAUDE.md. It is 7,147 lines of third-party code nobody here will fix, and
+# counting it would move every metric while telling us nothing about our own.
+
+sonar.python.version=3.14
+sonar.sourceEncoding=UTF-8
+
+# Coverage is INGESTED, never computed. Generate BOTH before scanning:
+#
+#   .venv/bin/python -m pytest tests/unit/ -q \
+#       --cov=couchpotato --cov=scripts --cov-report=xml:coverage.xml
+#   npx vitest run --coverage
+#
+# Verified by measurement rather than by reading the reports: after the first
+# scan SonarQube reported 51.8% overall against 54.87% measured for Python
+# alone, which is the blend you get once the untested legacy JS is included.
+# An unmatched report is SILENT -- it shows as a false 0%, which looks like a
+# measurement rather than an error -- so the check is "did the number arrive
+# and is it plausible", not "do the paths look right".
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
Reporting and trend visualisation only. **Not a gate, and not in CI** — the
GitHub runners cannot reach `172.16.11.10`, and exposing the server to fix
that would put a private repo's full source and issue history on the internet
to save a manual command.

## The thing that decides whether any number means anything

Test classification. The stakes are higher here than usual: **tests are 63,543
lines against 42,208 of production code** — more test than source. Misclassified
they would not merely inflate `ncloc`, they would dominate it.

Verified rather than assumed that no tests are co-located
(`find . -name 'test_*.py' -not -path './tests/*'` returns only
`test_startup_local.py`), so sources and tests stay **disjoint** instead of
using the overlap-plus-inclusions pattern. Disjoint is stronger: a file cannot
be claimed by both buckets, which is the condition that rejects an analysis
outright.

Excluded, each for a reason:

- `.claude/**` — five full checkouts of this repository (46 MB). Inside a
  source root they would report the whole codebase as duplicated against itself.
- `libs/**` — vendored CodernityDB, kept only for one-time migration per
  CLAUDE.md. 7,147 lines nobody here will fix would move every metric while
  saying nothing about our own code.

## First scan, verified before any number was believed

| Check | Result |
|---|---|
| `ncloc` | **37,757** (py 26,658 / js 3,848 / web 7,251) — **zero** test files present |
| Duplication | **2.0%** |
| Vulnerabilities in real code | **84 of 84** in `couchpotato/core/**`; none in tests or `libs/` |
| Coverage | **51.8%** blended vs 54.87% measured for Python alone |

Coverage matching was checked by **measurement**, not by inspecting paths: an
unmatched report is silent and shows up as a plausible-looking 0%.

## Changes

- `sonar-project.properties` — config, with the reasoning inline.
- `@vitest/coverage-v8` devDependency, pinned to the vitest major in use.
  Without a provider there is no lcov, and omitting the lcov path does **not**
  avoid the problem: SonarQube counts unreported files as uncovered either way,
  so the choice was a real number or a false zero. `npm ls` clean after.
- `.scannerwork/` and `coverage/` gitignored **before** anything was generated.

A `[tool.coverage.run] relative_files` setting was added and then removed — it
changed the emitted paths not at all, and unproven config decays.

## Findings

Reported to the owner, **not acted on here**. Two of the 84 look genuine; the
rest are classified with reasons in the session notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc