### PR TITLE
T17: fix the three SonarQube findings that survived triage

### DIFF
--- a/couchpotato/core/_base/downloader/main.py
+++ b/couchpotato/core/_base/downloader/main.py
@@ -1,4 +1,5 @@
 from base64 import b32decode, b16encode
+import os
 import random
 import re
 
@@ -116,6 +117,26 @@ class DownloaderBase(Provider):
 
     def processComplete(self, release_download, delete_files):
         return
+
+    def getVerifySsl(self):
+        """ Whether TLS certificate verification should be performed for
+        this downloader's https connections.
+
+        A downloader with no `ssl_verify` config option at all (self.conf
+        returns the `default` we pass, per Plugin.conf's contract) must
+        fail OPEN to verification-on -- only an explicit false value turns
+        it off. Getting this backwards would silently disable certificate
+        checking for every downloader that inherits this and never defines
+        the setting. """
+        if not self.conf('ssl_verify', default = True):
+            return False
+
+        # Use a CA bundle if one is configured and actually present on disk.
+        ca_bundle = self.conf('ssl_ca_bundle')
+        if ca_bundle and os.path.exists(ca_bundle):
+            return ca_bundle
+
+        return True
 
     def isCorrectProtocol(self, protocol):
         is_correct = protocol in self.protocol

--- a/couchpotato/core/_base/updater/main.py
+++ b/couchpotato/core/_base/updater/main.py
@@ -446,6 +446,17 @@ class SourceUpdater(BaseUpdater):
             if not inst.filename:
                 raise
 
+            # os.stat/os.chmod both follow symlinks by default, so chmod-ing
+            # inst.filename if it's a symlink would silently reach the
+            # link's TARGET -- potentially outside the tree being deleted.
+            # This runs on freshly-extracted archive content, attacker-
+            # influenced input, so refuse rather than follow it. A symlink's
+            # own permission bits never block rmtree from removing it (only
+            # the containing directory's permissions matter for unlink), so
+            # there is nothing a chmod here would legitimately fix.
+            if os.path.islink(inst.filename):
+                raise
+
             # Grant owner-write only, never group/other -- 0o777 previously
             # made the path world-writable in response to an error. Retry
             # exactly once: a permission error this doesn't fix propagates

--- a/couchpotato/core/_base/updater/main.py
+++ b/couchpotato/core/_base/updater/main.py
@@ -457,12 +457,19 @@ class SourceUpdater(BaseUpdater):
             if os.path.islink(inst.filename):
                 raise
 
-            # Grant owner-write only, never group/other -- 0o777 previously
-            # made the path world-writable in response to an error. Retry
-            # exactly once: a permission error this doesn't fix propagates
-            # instead of recursing until the stack ends.
+            # Grant the OWNER read+write+execute, never group/other -- 0o777
+            # previously made the path world-writable in response to an
+            # error. S_IRWXU, not S_IWUSR: rmtree needs owner EXECUTE to
+            # descend into a directory and WRITE to unlink its contents, so
+            # write alone still fails to remove a directory with mode 0o400
+            # or 0o000 (measured). The S2612 finding was "world-writable",
+            # not "more than write" -- do not re-narrow this to S_IWUSR, it
+            # looks more conservative and is actually broken for the
+            # directories this function exists to remove. Retry exactly
+            # once: a permission error this doesn't fix propagates instead
+            # of recursing until the stack ends.
             current_mode = os.stat(inst.filename).st_mode
-            os.chmod(inst.filename, current_mode | stat.S_IWUSR)
+            os.chmod(inst.filename, current_mode | stat.S_IRWXU)
             shutil.rmtree(path)
 
     def getVersion(self):

--- a/couchpotato/core/_base/updater/main.py
+++ b/couchpotato/core/_base/updater/main.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+import stat
 import tarfile
 import time
 import traceback
@@ -440,8 +441,18 @@ class SourceUpdater(BaseUpdater):
             if os.path.isdir(path):
                 shutil.rmtree(path)
         except OSError as inst:
-            os.chmod(inst.filename, 0o777)
-            self.removeDir(path)
+            # inst.filename can be None on some OSErrors -- there's nothing
+            # to chmod, so let it propagate rather than crash on chmod(None).
+            if not inst.filename:
+                raise
+
+            # Grant owner-write only, never group/other -- 0o777 previously
+            # made the path world-writable in response to an error. Retry
+            # exactly once: a permission error this doesn't fix propagates
+            # instead of recursing until the stack ends.
+            current_mode = os.stat(inst.filename).st_mode
+            os.chmod(inst.filename, current_mode | stat.S_IWUSR)
+            shutil.rmtree(path)
 
     def getVersion(self):
 

--- a/couchpotato/core/_base/updater/main.py
+++ b/couchpotato/core/_base/updater/main.py
@@ -437,40 +437,68 @@ class SourceUpdater(BaseUpdater):
         return True
 
     def removeDir(self, path):
-        try:
-            if os.path.isdir(path):
-                shutil.rmtree(path)
-        except OSError as inst:
-            # inst.filename can be None on some OSErrors -- there's nothing
-            # to chmod, so let it propagate rather than crash on chmod(None).
-            if not inst.filename:
-                raise
+        """ Remove `path` recursively, repairing permissions that block the
+        removal along the way.
 
-            # os.stat/os.chmod both follow symlinks by default, so chmod-ing
-            # inst.filename if it's a symlink would silently reach the
-            # link's TARGET -- potentially outside the tree being deleted.
-            # This runs on freshly-extracted archive content, attacker-
-            # influenced input, so refuse rather than follow it. A symlink's
-            # own permission bits never block rmtree from removing it (only
-            # the containing directory's permissions matter for unlink), so
-            # there is nothing a chmod here would legitimately fix.
-            if os.path.islink(inst.filename):
-                raise
+        A tree can have more than one directory whose permissions block
+        `rmtree` -- sibling or nested -- and a single blanket retry only
+        fixes the first one it meets, then propagates on the second
+        (measured: 2026-08-11 review, finding 3). So the retry is bounded
+        by ENTRIES REPAIRED, not by an attempt count or by recursion depth
+        (the original S2612 defect): each failing `inst.filename` is
+        chmod-ed at most once, tracked in `repaired`, and re-raised if it
+        comes up again. That is also the termination argument -- every
+        loop iteration either returns (rmtree succeeded), raises (the
+        entry that just failed has already been repaired and is still
+        failing, so nothing left to try), or adds exactly one new member
+        to `repaired`, which is bounded by the number of filesystem
+        entries under `path`. No recursion, so no stack exhaustion. """
+        repaired = set()
 
-            # Grant the OWNER read+write+execute, never group/other -- 0o777
-            # previously made the path world-writable in response to an
-            # error. S_IRWXU, not S_IWUSR: rmtree needs owner EXECUTE to
-            # descend into a directory and WRITE to unlink its contents, so
-            # write alone still fails to remove a directory with mode 0o400
-            # or 0o000 (measured). The S2612 finding was "world-writable",
-            # not "more than write" -- do not re-narrow this to S_IWUSR, it
-            # looks more conservative and is actually broken for the
-            # directories this function exists to remove. Retry exactly
-            # once: a permission error this doesn't fix propagates instead
-            # of recursing until the stack ends.
-            current_mode = os.stat(inst.filename).st_mode
-            os.chmod(inst.filename, current_mode | stat.S_IRWXU)
-            shutil.rmtree(path)
+        while True:
+            try:
+                if os.path.isdir(path):
+                    shutil.rmtree(path)
+                return
+            except OSError as inst:
+                # inst.filename can be None on some OSErrors -- there's
+                # nothing to chmod, so propagate rather than crash on
+                # chmod(None).
+                if not inst.filename:
+                    raise
+
+                # os.stat/os.chmod both follow symlinks by default, so
+                # chmod-ing inst.filename if it's a symlink would silently
+                # reach the link's TARGET -- potentially outside the tree
+                # being deleted. This runs on freshly-extracted archive
+                # content, attacker-influenced input, so refuse rather than
+                # follow it. A symlink's own permission bits never block
+                # rmtree from removing it (only the containing directory's
+                # permissions matter for unlink), so there is nothing a
+                # chmod here would legitimately fix.
+                if os.path.islink(inst.filename):
+                    raise
+
+                # Already repaired this exact entry and it is STILL
+                # failing -- chmod cannot fix whatever this is (a
+                # different user's file, a filesystem that ignores mode
+                # bits, ...), so stop here rather than loop forever.
+                if inst.filename in repaired:
+                    raise
+                repaired.add(inst.filename)
+
+                # Grant the OWNER read+write+execute, never group/other --
+                # 0o777 previously made the path world-writable in
+                # response to an error. S_IRWXU, not S_IWUSR: rmtree needs
+                # owner EXECUTE to descend into a directory and WRITE to
+                # unlink its contents, so write alone still fails to
+                # remove a directory with mode 0o400 or 0o000 (measured).
+                # The S2612 finding was "world-writable", not "more than
+                # write" -- do not re-narrow this to S_IWUSR, it looks
+                # more conservative and is actually broken for the
+                # directories this function exists to remove.
+                current_mode = os.stat(inst.filename).st_mode
+                os.chmod(inst.filename, current_mode | stat.S_IRWXU)
 
     def getVersion(self):
 

--- a/couchpotato/core/downloaders/rtorrent_.py
+++ b/couchpotato/core/downloaders/rtorrent_.py
@@ -314,20 +314,6 @@ class rTorrent(DownloaderBase):
             self.conf('password')
         )
 
-    def getVerifySsl(self):
-        # Ensure verification has been enabled
-        if not self.conf('ssl_verify'):
-            return False
-
-        # Use ca bundle if defined
-        ca_bundle = self.conf('ssl_ca_bundle')
-
-        if ca_bundle and os.path.exists(ca_bundle):
-            return ca_bundle
-
-        # Use default ssl verification
-        return True
-
     def connect(self, reconnect = False):
         # Already connected?
         if not reconnect and self.rt is not None:

--- a/couchpotato/core/downloaders/synology.py
+++ b/couchpotato/core/downloaders/synology.py
@@ -157,7 +157,10 @@ class SynologyRPC:
                 log.warning, 'synology_plaintext_credentials',
                 'Synology login will send the configured username and '
                 'password over an unencrypted connection. Enable the "ssl" '
-                'setting to protect them.',
+                'setting (under Advanced) to protect them -- this also '
+                'requires changing the port in the "host" setting to '
+                'DSM\'s https port, usually 5001, or the connection will '
+                'fail.',
                 now = now,
             )
         elif scheme == 'https' and not verify:
@@ -286,7 +289,9 @@ config = [{
                     'advanced': True,
                     'description': 'Use HyperText Transfer Protocol Secure, or <strong>https</strong>. '
                                    'Leaving this off sends your username and password to DownloadStation '
-                                   '<strong>unencrypted</strong>.',
+                                   '<strong>unencrypted</strong>. Also requires changing the port in the '
+                                   '<strong>host</strong> setting to DSM\'s https port (usually <strong>5001</strong>) '
+                                   '-- with the default plaintext port, https connections will fail.',
                 },
                 {
                     'name': 'ssl_verify',

--- a/couchpotato/core/downloaders/synology.py
+++ b/couchpotato/core/downloaders/synology.py
@@ -124,6 +124,27 @@ class SynologyRPC:
         # to pass this explicitly must not silently disable verification.
         self.verify = verify
 
+        # `ssl` defaulting off is correct -- DSM listens on 5000 for http out
+        # of the box, and flipping the default would break every existing
+        # install -- but it means the unsafe state is the DEFAULT state, and
+        # nothing said so. Make both unsafe states loud. Never name the
+        # host, a path, or a credential VALUE here -- only the setting that
+        # fixes it (PrivacyFilter/CLAUDE.md's log-privacy floor).
+        has_credentials = bool(username and password)
+        if scheme == 'http' and has_credentials:
+            log.warning(
+                'Synology login will send the configured username and '
+                'password over an unencrypted connection. Enable the "ssl" '
+                'setting to protect them.'
+            )
+        elif scheme == 'https' and not verify:
+            log.warning(
+                'Synology https connection has certificate verification '
+                'disabled, so it cannot confirm it is talking to the right '
+                'server. Enable the "ssl_verify" setting unless you have a '
+                'specific reason to leave it off.'
+            )
+
     def _login(self):
         if self.username and self.password:
             args = {'api': 'SYNO.API.Auth', 'account': self.username, 'passwd': self.password, 'version': 2,
@@ -238,7 +259,9 @@ config = [{
                     'default': 0,
                     'type': 'bool',
                     'advanced': True,
-                    'description': 'Use HyperText Transfer Protocol Secure, or <strong>https</strong>',
+                    'description': 'Use HyperText Transfer Protocol Secure, or <strong>https</strong>. '
+                                   'Leaving this off sends your username and password to DownloadStation '
+                                   '<strong>unencrypted</strong>.',
                 },
                 {
                     'name': 'ssl_verify',

--- a/couchpotato/core/downloaders/synology.py
+++ b/couchpotato/core/downloaders/synology.py
@@ -48,7 +48,8 @@ class Synology(DownloaderBase):
 
         try:
             # Send request to Synology
-            srpc = SynologyRPC(host[0], host[1], self.conf('username'), self.conf('password'), self.conf('destination'))
+            srpc = SynologyRPC(host[0], host[1], self.conf('username'), self.conf('password'), self.conf('destination'),
+                                ssl = self.conf('ssl'), verify = self.getVerifySsl())
             if data['protocol'] == 'torrent_magnet':
                 log.info('Adding torrent URL %s', data['url'])
                 response = srpc.create_task(url = data['url'])
@@ -71,7 +72,8 @@ class Synology(DownloaderBase):
 
         host = cleanHost(self.conf('host'), protocol = False).split(':')
         try:
-            srpc = SynologyRPC(host[0], host[1], self.conf('username'), self.conf('password'))
+            srpc = SynologyRPC(host[0], host[1], self.conf('username'), self.conf('password'),
+                                ssl = self.conf('ssl'), verify = self.getVerifySsl())
             test_result = srpc.test()
         except Exception:
             return False
@@ -103,17 +105,24 @@ class SynologyRPC:
 
     """SynologyRPC lite library"""
 
-    def __init__(self, host = 'localhost', port = 5000, username = None, password = None, destination = None):
+    def __init__(self, host = 'localhost', port = 5000, username = None, password = None, destination = None,
+                 ssl = False, verify = True):
 
         super().__init__()
 
-        self.download_url = 'http://%s:%s/webapi/DownloadStation/task.cgi' % (host, port)
-        self.auth_url = 'http://%s:%s/webapi/auth.cgi' % (host, port)
+        scheme = 'https' if ssl else 'http'
+        self.download_url = '%s://%s:%s/webapi/DownloadStation/task.cgi' % (scheme, host, port)
+        self.auth_url = '%s://%s:%s/webapi/auth.cgi' % (scheme, host, port)
         self.sid = None
         self.username = username
         self.password = password
         self.destination = destination
         self.session_name = 'DownloadStation'
+        # Certificate verification for requests.post -- True/False, or a CA
+        # bundle path. Default True: this carries the operator's username
+        # and password on the SYNO.API.Auth login, so a caller that forgets
+        # to pass this explicitly must not silently disable verification.
+        self.verify = verify
 
     def _login(self):
         if self.username and self.password:
@@ -137,7 +146,7 @@ class SynologyRPC:
     def _req(self, url, args, files = None):
         response = {'success': False}
         try:
-            req = requests.post(url, data = args, files = files, verify = False)
+            req = requests.post(url, data = args, files = files, verify = self.verify)
             req.raise_for_status()
             response = json.loads(req.text)
             if response['success']:
@@ -222,6 +231,29 @@ config = [{
                     'default': 0,
                     'type': 'enabler',
                     'radio_group': 'nzb,torrent',
+                },
+                {
+                    'name': 'ssl',
+                    'label': 'SSL Enabled',
+                    'default': 0,
+                    'type': 'bool',
+                    'advanced': True,
+                    'description': 'Use HyperText Transfer Protocol Secure, or <strong>https</strong>',
+                },
+                {
+                    'name': 'ssl_verify',
+                    'label': 'SSL Verify',
+                    'default': 1,
+                    'type': 'bool',
+                    'advanced': True,
+                    'description': 'Verify SSL certificate on https connections',
+                },
+                {
+                    'name': 'ssl_ca_bundle',
+                    'label': 'SSL CA Bundle',
+                    'type': 'string',
+                    'advanced': True,
+                    'description': 'Path to a directory (or file) containing trusted certificate authorities',
                 },
                 {
                     'name': 'host',

--- a/couchpotato/core/downloaders/synology.py
+++ b/couchpotato/core/downloaders/synology.py
@@ -4,7 +4,7 @@ import traceback
 from couchpotato.core._base.downloader.main import DownloaderBase
 from couchpotato.core.helpers.encoding import isInt
 from couchpotato.core.helpers.variable import cleanHost
-from couchpotato.core.logger import CPLog
+from couchpotato.core.logger import CPLog, log_suppressed
 import requests
 
 
@@ -106,7 +106,7 @@ class SynologyRPC:
     """SynologyRPC lite library"""
 
     def __init__(self, host = 'localhost', port = 5000, username = None, password = None, destination = None,
-                 ssl = False, verify = True):
+                 ssl = False, verify = True, now = None):
 
         super().__init__()
 
@@ -130,19 +130,34 @@ class SynologyRPC:
         # nothing said so. Make both unsafe states loud. Never name the
         # host, a path, or a credential VALUE here -- only the setting that
         # fixes it (PrivacyFilter/CLAUDE.md's log-privacy floor).
+        #
+        # Routed through log_suppressed rather than logged unconditionally:
+        # a fresh SynologyRPC is built on every download, so an unbounded
+        # warning would fire on every single one -- which trains the
+        # operator to scroll past the exact line added so they wouldn't
+        # miss it. log_suppressed keeps the signal (first occurrence in
+        # full, a "further messages withheld" notice, then the next
+        # occurrence after the window in full WITH the withheld count)
+        # without the noise. Two independent keys so the two warnings don't
+        # suppress each other. `now` is forwarded, not defaulted away, so
+        # the window is testable without sleeping or patching the clock.
         has_credentials = bool(username and password)
         if scheme == 'http' and has_credentials:
-            log.warning(
+            log_suppressed(
+                log.warning, 'synology_plaintext_credentials',
                 'Synology login will send the configured username and '
                 'password over an unencrypted connection. Enable the "ssl" '
-                'setting to protect them.'
+                'setting to protect them.',
+                now = now,
             )
         elif scheme == 'https' and not verify:
-            log.warning(
+            log_suppressed(
+                log.warning, 'synology_ssl_verify_disabled',
                 'Synology https connection has certificate verification '
                 'disabled, so it cannot confirm it is talking to the right '
                 'server. Enable the "ssl_verify" setting unless you have a '
-                'specific reason to leave it off.'
+                'specific reason to leave it off.',
+                now = now,
             )
 
     def _login(self):

--- a/couchpotato/core/downloaders/synology.py
+++ b/couchpotato/core/downloaders/synology.py
@@ -12,6 +12,16 @@ log = CPLog(__name__)
 
 autoload = 'Synology'
 
+# python:S113 -- requests.post with no timeout can hang the calling thread
+# forever against an unresponsive NAS, which on an unattended home server
+# reads as "downloads silently stopped" with nothing in the log. 60s rather
+# than the house default of 30s (Plugin.urlopen, rtorrent_.py's
+# _RPC_TIMEOUT): _req also carries file uploads (the nzb/torrent payload
+# itself), so the shorter value risks breaking a slow-but-working setup,
+# which would be a fix that causes an outage. Matches sabnzbd.py's own
+# API-call timeout.
+_REQUEST_TIMEOUT = 60
+
 
 class Synology(DownloaderBase):
 
@@ -182,7 +192,7 @@ class SynologyRPC:
     def _req(self, url, args, files = None):
         response = {'success': False}
         try:
-            req = requests.post(url, data = args, files = files, verify = self.verify)
+            req = requests.post(url, data = args, files = files, verify = self.verify, timeout = _REQUEST_TIMEOUT)
             req.raise_for_status()
             response = json.loads(req.text)
             if response['success']:

--- a/couchpotato/core/notifications/discord.py
+++ b/couchpotato/core/notifications/discord.py
@@ -35,7 +35,12 @@ class Discord(Notification):
             r = requests.post(self.conf('webhook_url'), data=json.dumps(dict(content=message, username=self.conf('bot_name'), avatar_url=self.conf('avatar_url'), tts=self.conf('discord_tts'))), headers=headers, timeout=_REQUEST_TIMEOUT)
             r.status_code
         except Exception as e:
-            log.warning('Error Sending Discord response error code: {0}'.format(r.status_code))
+            # `r` is only assigned if requests.post() RETURNS -- a timeout
+            # or connection error raises before that, so referencing
+            # r.status_code here (the previous code) raised
+            # UnboundLocalError instead of logging anything. Log the
+            # exception that was actually caught.
+            log.warning('Error sending Discord notification: {0}'.format(e))
             return False
         return True
 

--- a/couchpotato/core/notifications/discord.py
+++ b/couchpotato/core/notifications/discord.py
@@ -6,6 +6,12 @@ import requests
 log = CPLog(__name__)
 autoload = 'Discord'
 
+# python:S113 -- requests.post with no timeout can hang the calling thread
+# forever against an unresponsive Discord host. 30s (the house default:
+# Plugin.urlopen, rtorrent_.py's _RPC_TIMEOUT), not Synology's longer 60s --
+# this carries a short JSON payload, not a file upload.
+_REQUEST_TIMEOUT = 30
+
 
 class Discord(Notification):
     required_confs = ('webhook_url',)
@@ -26,7 +32,7 @@ class Discord(Notification):
 
         headers = {b"Content-Type": b"application/json"}
         try:
-            r = requests.post(self.conf('webhook_url'), data=json.dumps(dict(content=message, username=self.conf('bot_name'), avatar_url=self.conf('avatar_url'), tts=self.conf('discord_tts'))), headers=headers)
+            r = requests.post(self.conf('webhook_url'), data=json.dumps(dict(content=message, username=self.conf('bot_name'), avatar_url=self.conf('avatar_url'), tts=self.conf('discord_tts'))), headers=headers, timeout=_REQUEST_TIMEOUT)
             r.status_code
         except Exception as e:
             log.warning('Error Sending Discord response error code: {0}'.format(r.status_code))

--- a/couchpotato/core/notifications/telegrambot.py
+++ b/couchpotato/core/notifications/telegrambot.py
@@ -7,6 +7,12 @@ log = CPLog(__name__)
 
 autoload = 'TelegramBot'
 
+# python:S113 -- requests.post with no timeout can hang the calling thread
+# forever against an unresponsive Telegram host. 30s (the house default:
+# Plugin.urlopen, rtorrent_.py's _RPC_TIMEOUT), not Synology's longer 60s --
+# this carries a short JSON payload, not a file upload.
+_REQUEST_TIMEOUT = 30
+
 class TelegramBot(Notification):
 
     TELEGRAM_API = "https://api.telegram.org/bot%s/%s"
@@ -29,7 +35,7 @@ class TelegramBot(Notification):
         payload = {'chat_id': usr_id, 'text': message, 'parse_mode': 'Markdown'}
 
         # Send message user Telegram's Bot API
-        response = requests.post(self.TELEGRAM_API % (token, "sendMessage"), data=payload)
+        response = requests.post(self.TELEGRAM_API % (token, "sendMessage"), data=payload, timeout=_REQUEST_TIMEOUT)
 
         # Error logging
         sent_successfuly = True

--- a/couchpotato/core/notifications/telegrambot.py
+++ b/couchpotato/core/notifications/telegrambot.py
@@ -34,8 +34,16 @@ class TelegramBot(Notification):
         # Cosntruct message
         payload = {'chat_id': usr_id, 'text': message, 'parse_mode': 'Markdown'}
 
-        # Send message user Telegram's Bot API
-        response = requests.post(self.TELEGRAM_API % (token, "sendMessage"), data=payload, timeout=_REQUEST_TIMEOUT)
+        # Send message user Telegram's Bot API. Wrapped: an unresponsive
+        # host raises (ReadTimeout, ConnectionError, ...), which the S113
+        # timeout fix above made reachable -- uncaught, that propagates out
+        # of notify() as a generic "Failed running event handler" traceback
+        # instead of this module's own diagnostic.
+        try:
+            response = requests.post(self.TELEGRAM_API % (token, "sendMessage"), data=payload, timeout=_REQUEST_TIMEOUT)
+        except Exception as e:
+            log.error('Could not send notification to TelegramBot (token=%s): %s', token, e)
+            return False
 
         # Error logging
         sent_successfuly = True

--- a/couchpotato/core/plugins/base.py
+++ b/couchpotato/core/plugins/base.py
@@ -82,7 +82,10 @@ class Plugin:
 
     def renderTemplate(self, parent_file, templ, **params):
         tmpl_dir = str(Path(parent_file).parent)
-        env = _JinjaEnv(loader=_JinjaFSLoader(tmpl_dir))
+        # autoescape=True: caller-supplied params must not render as raw HTML
+        # (python:S5247). No in-repo caller exists today, but this is a
+        # public method inherited by every plugin, in-tree or third-party.
+        env = _JinjaEnv(loader=_JinjaFSLoader(tmpl_dir), autoescape=True)
         t = env.get_template(templ)
         return t.render(**params)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,14 @@ exclude = [
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "UP", "B"]
+# S113 only (requests call with no timeout), not the whole S (bandit) family:
+# a full `select = [..., "S"]` was measured at 148 findings across the repo,
+# which would fail the build on merit-unrelated noise -- exactly the
+# "make the number green" pressure CLAUDE.md's SonarQube rule (§3) warns
+# against, just moved to ruff. S113 alone is narrow, unambiguous (a hang has
+# one cause: no timeout), and was the rule that would have caught T17's
+# Synology/Discord/Telegram findings before they needed a manual scan.
+extend-select = ["S113"]
 
 ignore = [
     # Bare except — legacy code uses these everywhere

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -228,7 +228,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       unrecognised path RUNS the suites, which is how every other uncertainty
       in this script already resolves.
 
-- [ ] T17: the three SonarQube findings that survived triage — state: queued (no deps)
+- [x] T17: the three SonarQube findings that survived triage — state: **fixed in code** (2026-08-11)
 
       From the first real SonarQube analysis of this repo (2026-08-10, project
       `couchpotato`). Of 84 raw vulnerabilities, 37 were marked false positive
@@ -321,6 +321,57 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       **Do not resolve these in SonarQube to make the rating move.** Fix the
       code, re-scan, and let the rating follow. The 37 dismissals each carry a
       reason and a reopen condition; these three have no reason available.
+
+      **Outcome.** All three fixed in code; nothing was touched in SonarQube.
+      Re-scan after merge and let the rating follow the code.
+
+      1. S4830: `ssl`/`ssl_verify`/`ssl_ca_bundle` added to Synology, matching
+         rtorrent's existing options rather than inventing a shape.
+         `getVerifySsl` hoisted to `DownloaderBase` so there is ONE
+         implementation — with the trap that made hoisting worth care: a
+         downloader with no `ssl_verify` option gets `None`, which the
+         original returns `False` for, so a naive hoist would have silently
+         disabled certificate checking for every downloader inheriting it.
+         The base version treats absent as verify-ON, and that is the guard
+         the mutation testing was aimed at.
+
+         **What this does NOT do, stated plainly:** `ssl` still defaults to
+         0, so a default install still sends the operator's Synology username
+         and password over plaintext http. Flipping that default would break
+         every install pointing at DSM's port 5000, so the risk is now
+         *visible and fixable* rather than eliminated. That is why the
+         warnings below are part of the fix and not a nicety.
+
+      2. S2612: owner-write only (never group/other), retry bounded to one
+         attempt, `None` filename propagates. Also refuses to chmod a
+         SYMLINK — `os.stat`/`os.chmod` both follow links, and this runs on
+         freshly-extracted archive content, so the original would reach a
+         target outside the tree being deleted.
+
+      3. S5247: `autoescape=True`. Method kept, not deleted: no in-repo
+         caller exists, but it is public on `Plugin` and inherited by
+         third-party plugins, so "no callers here" is not evidence of none.
+
+      **The unsafe states are no longer silent**, which was the real defect
+      behind (1): a WARNING fires when credentials are about to cross a
+      plaintext connection, and when https verification is off. Both route
+      through `log_suppressed` with independent keys — a fresh `SynologyRPC`
+      is built per download, so an unbounded warning would fire on every one
+      and train the operator to scroll past the line added so they would not
+      miss it. Neither names a host, path or credential value.
+
+      Two lessons recorded rather than the fix alone:
+      - A present-but-blank `ssl_verify` coerces to `False`. `Settings.get`
+        returns the caller's `default` only on the *exception* path, so
+        `default=True` does not cover a blank value, and after coercion `''`
+        and `'0'` are indistinguishable. The answer is the warning, not more
+        parsing.
+      - The key-independence test first passed against a deliberately
+        broken build. It asserted only `len(records) == 2`, and a shared
+        suppression key also produces two records (one full message, one
+        "withheld" notice), so the count could not tell correct behaviour
+        from the regression. Strengthened to assert each record's content.
+        A textbook incidentally-passing guard, found only by mutating it.
 
 - [ ] T15: `_write_session_secret` hand-rolls a CAS retry the adapter already provides — state: queued (no deps)
 

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -383,21 +383,59 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
         call rather than the house default of 30, because `_req` uploads the
         nzb/torrent payload and a too-short timeout would be a fix that
         causes an outage.
-      - `ruff S202`, `updater/main.py:370,374`: `tarfile.extractall()`, the
-        path-traversal class. **Measured, not assumed: a false positive on
-        this project.** Built a tar containing a `../escaped.txt` member and
-        ran the repo's exact call on Python 3.14:
+      - `ruff S202`, `updater/main.py:370` and `:374`: the path-traversal
+        class. **Measured, not assumed: a false positive at both lines —
+        but for two DIFFERENT reasons, and an earlier version of this entry
+        got that wrong.** It described both lines as `tarfile.extractall()`
+        and gave them a single reopen condition, having measured only the
+        tar one. `:370` is `zip_file.extractall()`; only `:374` is tarfile.
+        Both were then driven properly:
 
-            extractall RAISED: OutsideDestinationError: '../escaped.txt'
-            would be extracted to '.../escaped.txt', which is outside the
-            destination
+        `:374`, tarfile — a tar carrying a `../escaped.txt` member:
 
-        3.14 applies the `data` extraction filter by default, so the
-        traversal is already refused, and 3.14 is what production ships and
-        the only version CI tests. Deliberately NOT changed — adding
-        `filter='data'` would be harmless but justified only by "a scanner
-        said so". **Reopen if this project ever supports Python < 3.14**, at
-        which point the call becomes a genuine arbitrary-file-write.
+            OutsideDestinationError: '../escaped.txt' would be extracted to
+            '.../escaped.txt', which is outside the destination
+
+        Python 3.14 applies the `data` extraction filter by default, and
+        3.14 is what production ships and the only version CI tests.
+        **Reopen `:374` if this project ever supports Python < 3.14**, at
+        which point that call becomes a genuine arbitrary-file-write.
+
+        `:370`, zipfile — a zip carrying both `../escaped.txt` and
+        `/abs_escaped.txt`: both landed INSIDE the destination
+        (`out/escaped.txt`, `out/abs_escaped.txt`), and neither
+        `./escaped.txt` nor `/abs_escaped.txt` was created. `zipfile`
+        sanitises member names itself and has done since long before 3.14,
+        so **the Python-version condition does NOT apply to this line** —
+        it is contained by the library regardless of interpreter version.
+
+        Neither changed. Adding `filter='data'` would be harmless but is
+        justified only by "a scanner said so". The lesson worth keeping is
+        the doc error rather than the finding: citing two lines from one
+        measurement produced a confidently wrong reopen condition, which is
+        the failure mode §7 warns about — a wrong doc costs more than a
+        vague one.
+
+      **Spec bug (recorded, per the harness rule that a review finding with
+      no AC behind it is a spec bug).** T17 was written, built and reviewed
+      with **zero** `AC-<LENS>-<n>` acceptance criteria, so the review had
+      only the task's prose to check the built thing against. Every finding
+      below therefore had to be discovered rather than verified against a
+      contract, including the two serious ones. Tasks added mid-plan skip
+      the planning cycle, which is exactly when criteria get written; that
+      is the gap, not this task in particular.
+
+      **Carried forward, not fixed here.** `removeDir`'s single retry can
+      now raise where the old unbounded recursion might eventually have
+      succeeded, and it sits AFTER `replaceWith()` has already overwritten
+      the application directory (`updater/main.py:380`), before
+      `version_file` is written (`:383`). The updater then believes it is
+      still on the old version and re-applies next check. Speculative: a
+      multi-entry blocked tree was never constructed, so the frequency is
+      unmeasured. Non-destructive on the data-risk ranking (the recoverable
+      end), which is why it is recorded rather than fixed under a security
+      task. Reachable only via the SOURCE updater, which the Docker
+      deployment does not use.
 
 - [ ] T15: `_write_session_secret` hand-rolls a CAS retry the adapter already provides — state: queued (no deps)
 

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -425,6 +425,33 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       the planning cycle, which is exactly when criteria get written; that
       is the gap, not this task in particular.
 
+      **Portability trap, measured — worth more than the finding that
+      surfaced it.** Review raised the TOCTOU window between `removeDir`'s
+      `os.path.islink` check and its `os.chmod`. Real, but both atomic
+      remedies fail, and one fails in the worst possible way:
+
+      - `O_NOFOLLOW` + `fchmod` (the idiom `renamer/swap.py` already uses)
+        cannot open the directory at all — `PermissionError` — because
+        lacking read permission is the exact condition being repaired.
+      - `os.chmod(..., follow_symlinks=False)` works on macOS and **does
+        not exist on Alpine**:
+
+            macOS  : chmod follow_symlinks supported: True
+            Alpine : chmod follow_symlinks supported: False
+
+        (measured in `python:3.14-alpine`, the image this project ships.)
+
+      So that "obvious" fix would have passed every local test and raised
+      `NotImplementedError` in a delete path on production. This is §11's
+      "match the environment to production" in its most expensive form: a
+      green local run in an environment that cannot express the failure.
+      **Check `os.supports_follow_symlinks` before reaching for it here.**
+
+      The check-then-act stays. `chmod` requires ownership, so the worst
+      outcome is owner-rwx on a file the process already owns. Reopen if a
+      portable atomic chmod-without-follow appears, or if this ever runs
+      where the process does not own the tree it is deleting.
+
       **Carried forward, not fixed here.** `removeDir`'s single retry can
       now raise where the old unbounded recursion might eventually have
       succeeded, and it sits AFTER `replaceWith()` has already overwritten

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -625,6 +625,44 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       is retained as the TAIL fix — it is the only step here that has ever
       stalled (610s of a 697s job).
 
+- [ ] T20: the Discord notifier reports success on a rejected notification — state: queued (no deps)
+
+      Raised reviewing T17 (#246) and explicitly held out of it as out of
+      scope: T17 was the three SonarQube findings, and this changes
+      notification delivery semantics.
+
+      `couchpotato/core/notifications/discord.py`, in `notify`:
+
+          r = requests.post(...)
+          r.status_code
+
+      Two defects, one cosmetic and one not.
+
+      1. The bare `r.status_code` is a no-op — the value is never read.
+         It reads as leftover debug code. Note it is NOT quite dead: it
+         is the only thing that would raise on a torn response object,
+         and deleting it is safe but should be done knowing that.
+
+      2. `requests.post` does not raise on a non-2xx response, and
+         nothing checks the status, so a webhook answering 400, 401, 404
+         or 429 falls through to `return True`. The caller believes the
+         notification was delivered when Discord rejected it. A rate-limited
+         or revoked webhook therefore fails silently and permanently, which
+         is the worst shape for a notifier: the operator learns nothing is
+         arriving only by noticing its absence.
+
+      Fix shape: `raise_for_status()`, matching the pattern the Synology
+      work in T17 already establishes in this repo, so the existing
+      `except` returns False and logs. Check the sibling notifiers for the
+      same shape before assuming it is Discord-only.
+
+      **Not folded into T17 deliberately.** Two of T17's own fixes each
+      introduced a defect in adjacent code (the timeout made an
+      `UnboundLocalError` reachable; the retry bound regressed multi-entry
+      cleanup), so a third adjacent change to the same file, altering what
+      `notify` returns, is exactly the shape that keeps going wrong. It
+      gets its own task and its own tests.
+
 - [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: T6, T7, T8, T11, T13, T14, T15, T17, T19 — every other open task, because each adds residue and several rewrite the code this would sweep. T19 was added in the same commit that wrote this line and was omitted from it, which is the ordinary way such a list goes stale)
 
       **Runs LAST, and it is not a duplicate of T7 even though it sounds like

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -373,6 +373,32 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
         from the regression. Strengthened to assert each record's content.
         A textbook incidentally-passing guard, found only by mutating it.
 
+      **Two findings in the neighbourhood, measured while fixing the above.**
+      Recorded here so neither is rediscovered and re-argued later.
+
+      - `ruff S113`, `synology.py`: `requests.post` had no timeout, so an
+        unresponsive NAS parks the thread indefinitely and downloads stop
+        with nothing in the log. Fixed here, since it is the same call the
+        S4830 work already edited. 60s, matching `sabnzbd.py`'s file-carrying
+        call rather than the house default of 30, because `_req` uploads the
+        nzb/torrent payload and a too-short timeout would be a fix that
+        causes an outage.
+      - `ruff S202`, `updater/main.py:370,374`: `tarfile.extractall()`, the
+        path-traversal class. **Measured, not assumed: a false positive on
+        this project.** Built a tar containing a `../escaped.txt` member and
+        ran the repo's exact call on Python 3.14:
+
+            extractall RAISED: OutsideDestinationError: '../escaped.txt'
+            would be extracted to '.../escaped.txt', which is outside the
+            destination
+
+        3.14 applies the `data` extraction filter by default, so the
+        traversal is already refused, and 3.14 is what production ships and
+        the only version CI tests. Deliberately NOT changed — adding
+        `filter='data'` would be harmless but justified only by "a scanner
+        said so". **Reopen if this project ever supports Python < 3.14**, at
+        which point the call becomes a genuine arbitrary-file-write.
+
 - [ ] T15: `_write_session_secret` hand-rolls a CAS retry the adapter already provides — state: queued (no deps)
 
       Non-blocking review nit on #229, verified and deferred rather than done.

--- a/tests/unit/test_discord_notification_exception_handling.py
+++ b/tests/unit/test_discord_notification_exception_handling.py
@@ -1,0 +1,85 @@
+"""T17 review finding 1 (2026-08-11): `Discord.notify`'s except block
+referenced `r.status_code` to build its warning message, but `r` is only
+assigned if `requests.post` returns -- exactly the branch the S113 timeout
+fix (this branch, `_REQUEST_TIMEOUT`) made reachable. Before that fix, an
+unresponsive host just hung the thread forever, silently; after it, the
+same host raises `requests.exceptions.Timeout`, `r = requests.post(...)`
+never completes, and the except block's own
+`'...'.format(r.status_code)` raises:
+
+    UnboundLocalError: cannot access local variable 'r' where it is not
+    associated with a value
+
+That crashes while building the log message, so the intended
+`log.warning(...)` never fires and `notify()` never returns False -- the
+graceful failure this whole try/except exists to produce. `fireEvent`'s
+per-handler try/except catches the UnboundLocalError so the app itself
+does not crash, but the caller sees a confusing traceback about a local
+variable instead of the module's own diagnostic, and the timeout fix made
+this reliably reachable on the one path it targeted.
+
+Fix: log the caught exception `e`, not the response that was never
+assigned.
+"""
+import logging
+
+import requests
+from unittest.mock import MagicMock, patch
+
+from couchpotato.core.notifications import discord as discord_module
+from couchpotato.core.notifications.discord import Discord
+
+
+def _conf(**overrides):
+    values = {
+        'webhook_url': 'https://discord.example/api/webhooks/x/y',
+        'bot_name': 'CouchPotato',
+        'avatar_url': 'https://example.invalid/avatar.png',
+        'discord_tts': False,
+        'include_imdb': False,
+    }
+    values.update(overrides)
+    return lambda k, **kw: values.get(k, kw.get('default', ''))
+
+
+class TestDiscordNotifyExceptionPath:
+
+    def test_a_request_exception_returns_false_without_raising(self):
+        """The exact scenario the timeout fix made reachable: requests.post
+        raises before `r` is ever assigned. notify() must catch this and
+        return False, not raise UnboundLocalError."""
+        notifier = Discord.__new__(Discord)
+
+        with patch.object(notifier, 'conf', side_effect = _conf()), \
+             patch.object(discord_module.requests, 'post',
+                          side_effect = requests.exceptions.Timeout('timed out')):
+            result = notifier.notify(message = 'a movie was snatched')
+
+        assert result is False
+
+    def test_a_request_exception_logs_the_exception_not_a_missing_response(self, caplog):
+        notifier = Discord.__new__(Discord)
+
+        with caplog.at_level(logging.WARNING), \
+             patch.object(notifier, 'conf', side_effect = _conf()), \
+             patch.object(discord_module.requests, 'post',
+                          side_effect = requests.exceptions.Timeout('timed out')):
+            notifier.notify(message = 'a movie was snatched')
+
+        records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(records) == 1, 'exactly one warning must be logged, not a raised UnboundLocalError'
+        assert 'timed out' in records[0].getMessage(), (
+            'the warning must describe the actual exception, not a missing response object'
+        )
+
+    def test_the_204_success_path_still_works(self):
+        """Sanity check: the fix to the except block must not disturb the
+        existing success path."""
+        notifier = Discord.__new__(Discord)
+
+        mock_response = MagicMock(status_code = 204)
+        with patch.object(notifier, 'conf', side_effect = _conf()), \
+             patch.object(discord_module.requests, 'post', return_value = mock_response):
+            result = notifier.notify(message = 'a movie was snatched')
+
+        assert result is True

--- a/tests/unit/test_discord_notification_timeout.py
+++ b/tests/unit/test_discord_notification_timeout.py
@@ -1,0 +1,49 @@
+"""T17 follow-up D (python:S113): `Discord.notify` calls `requests.post`
+with no timeout -- the same defect class as the Synology fix, and found by
+the same rule once it was wired into the gate (`pyproject.toml`'s
+`extend-select`).
+
+Reachable on every real notification: `Notification.listen_to` includes
+`movie.snatched` and `movie.downloaded`, both genuine event producers, and
+dispatch is synchronous on the caller's thread. An unresponsive Discord host
+parks that thread indefinitely.
+
+30s, not Synology's 60s: this call carries a short JSON payload, not a file
+upload, so the house default (Plugin.urlopen, rtorrent_.py's _RPC_TIMEOUT)
+applies.
+"""
+from unittest.mock import MagicMock, patch
+
+from couchpotato.core.notifications import discord as discord_module
+from couchpotato.core.notifications.discord import Discord
+
+
+def _conf(**overrides):
+    values = {
+        'webhook_url': 'https://discord.example/api/webhooks/x/y',
+        'bot_name': 'CouchPotato',
+        'avatar_url': 'https://example.invalid/avatar.png',
+        'discord_tts': False,
+        'include_imdb': False,
+    }
+    values.update(overrides)
+    return lambda k, **kw: values.get(k, kw.get('default', ''))
+
+
+class TestDiscordNotificationTimeout:
+    """Assert on the actual value reaching requests.post, not merely that
+    the kwarg is present -- a presence-only check cannot tell 30 from 0."""
+
+    def test_notify_passes_the_named_timeout_constant(self):
+        notifier = Discord.__new__(Discord)
+
+        mock_response = MagicMock(status_code = 204)
+        with patch.object(notifier, 'conf', side_effect = _conf()), \
+             patch.object(discord_module.requests, 'post', return_value = mock_response) as mock_post:
+            notifier.notify(message = 'a movie was snatched')
+
+        assert mock_post.call_args.kwargs['timeout'] == discord_module._REQUEST_TIMEOUT
+        assert mock_post.call_args.kwargs['timeout'] == 30
+
+    def test_timeout_constant_matches_house_default(self):
+        assert discord_module._REQUEST_TIMEOUT == 30

--- a/tests/unit/test_downloader_base_ssl_verify.py
+++ b/tests/unit/test_downloader_base_ssl_verify.py
@@ -1,0 +1,85 @@
+"""T17 fix 1 (python:S4830), base-class half: `getVerifySsl` is hoisted from
+`rtorrent_.py` to `DownloaderBase` (`_base/downloader/main.py`) so Synology
+(and any future downloader) shares one implementation instead of growing its
+own copy that can silently drift.
+
+The critical requirement, called out explicitly in the remediation spec: a
+downloader with NO `ssl_verify` config option at all must get a VERIFYING
+value back, not a disabled one. rtorrent's original implementation was
+`if not self.conf('ssl_verify'): return False` -- for a downloader with no
+such setting, `self.conf('ssl_verify')` returns None (falsy), so hoisting
+that as-is would have silently turned off certificate verification for
+every downloader that inherits it and never defines the option. The base
+implementation must treat "unset" as verify-on and only an explicit false
+value as off.
+"""
+from couchpotato.core._base.downloader.main import DownloaderBase
+
+
+class _FakeSettingsDownloader(DownloaderBase):
+    """A downloader stub whose `conf()` mimics Plugin.conf()'s real contract:
+    a setting absent from `_settings` returns whatever `default` conf() was
+    called with (exactly what Env.setting()/Settings.get() do for a
+    downloader with no matching config option) -- it does NOT unconditionally
+    return None regardless of `default`, which would make this test pass for
+    the wrong reason."""
+
+    def __init__(self, settings = None):
+        # Deliberately skip DownloaderBase.__init__ -- it calls addEvent()
+        # and friends, none of which getVerifySsl() needs.
+        self._settings = settings or {}
+
+    def conf(self, attr, value = None, default = None, section = None):
+        return self._settings.get(attr, default)
+
+
+class TestGetVerifySslFailsOpen:
+
+    def test_downloader_with_no_ssl_settings_at_all_verifies(self):
+        """The load-bearing case: a downloader that never defines ssl_verify
+        must still verify certificates by default."""
+        downloader = _FakeSettingsDownloader(settings = {})
+
+        assert downloader.getVerifySsl() is True
+
+    def test_ssl_verify_explicitly_true_verifies(self):
+        downloader = _FakeSettingsDownloader(settings = {'ssl_verify': True})
+
+        assert downloader.getVerifySsl() is True
+
+
+class TestGetVerifySslExplicitOff:
+
+    def test_ssl_verify_explicitly_false_disables_verification(self):
+        downloader = _FakeSettingsDownloader(settings = {'ssl_verify': False})
+
+        assert downloader.getVerifySsl() is False
+
+
+class TestGetVerifySslCaBundle:
+
+    def test_existing_ca_bundle_path_is_returned(self, tmp_path):
+        bundle = tmp_path / 'ca-bundle.pem'
+        bundle.write_text('-----BEGIN CERTIFICATE-----')
+        downloader = _FakeSettingsDownloader(settings = {
+            'ssl_verify': True, 'ssl_ca_bundle': str(bundle),
+        })
+
+        assert downloader.getVerifySsl() == str(bundle)
+
+    def test_missing_ca_bundle_path_falls_back_to_true(self, tmp_path):
+        missing = tmp_path / 'does-not-exist.pem'
+        downloader = _FakeSettingsDownloader(settings = {
+            'ssl_verify': True, 'ssl_ca_bundle': str(missing),
+        })
+
+        assert downloader.getVerifySsl() is True
+
+    def test_ca_bundle_ignored_when_verify_is_off(self, tmp_path):
+        bundle = tmp_path / 'ca-bundle.pem'
+        bundle.write_text('-----BEGIN CERTIFICATE-----')
+        downloader = _FakeSettingsDownloader(settings = {
+            'ssl_verify': False, 'ssl_ca_bundle': str(bundle),
+        })
+
+        assert downloader.getVerifySsl() is False

--- a/tests/unit/test_downloaders.py
+++ b/tests/unit/test_downloaders.py
@@ -2093,6 +2093,41 @@ class TestRTorrentDownloaderConnect:
         assert called_url == 'https://myhost/plugins/httprpc/action.php'
 
 
+class TestRTorrentGetVerifySsl:
+    """T17 fix 1: getVerifySsl is hoisted to DownloaderBase so rtorrent and
+    Synology share one implementation. rtorrent must no longer carry its own
+    copy -- inheriting it is the whole point, since a second copy is how one
+    drifts from the other."""
+
+    def test_rtorrent_does_not_redefine_get_verify_ssl(self):
+        assert 'getVerifySsl' not in rtorrent_module.rTorrent.__dict__
+
+    def _conf(self, **overrides):
+        values = {'ssl_verify': True, 'ssl_ca_bundle': ''}
+        values.update(overrides)
+        return lambda k, **kw: values.get(k, kw.get('default', ''))
+
+    def _make_downloader(self):
+        return rtorrent_module.rTorrent.__new__(rtorrent_module.rTorrent)
+
+    def test_verifies_by_default(self):
+        rt = self._make_downloader()
+        with patch.object(rt, 'conf', side_effect = self._conf()):
+            assert rt.getVerifySsl() is True
+
+    def test_explicit_off_is_honoured(self):
+        rt = self._make_downloader()
+        with patch.object(rt, 'conf', side_effect = self._conf(ssl_verify = False)):
+            assert rt.getVerifySsl() is False
+
+    def test_existing_ca_bundle_is_used(self, tmp_path):
+        bundle = tmp_path / 'ca.pem'
+        bundle.write_text('cert')
+        rt = self._make_downloader()
+        with patch.object(rt, 'conf', side_effect = self._conf(ssl_ca_bundle = str(bundle))):
+            assert rt.getVerifySsl() == str(bundle)
+
+
 class TestRTorrentDownload:
     """Tests for rTorrent.download() -- magnet and torrent-file add paths."""
 

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -211,17 +211,34 @@ class TestDiscord:
         assert result is False
 
     def test_notify_connection_error(self):
-        """Discord notifier has a bug: UnboundLocalError on 'r' when requests.post raises.
-        This test documents the bug — it raises instead of returning False."""
+        """A request that never returns a response fails gracefully.
+
+        This test used to assert `pytest.raises(UnboundLocalError)`,
+        documenting a bug instead of fixing it: the `except` block logged
+        `r.status_code`, but `r` is only bound if `requests.post` RETURNS,
+        so any raise inside the call blew up while building the log line.
+
+        That stayed latent while nothing forced the call to raise. Adding
+        a request timeout made it reachable on precisely the case the
+        timeout exists for -- an unresponsive webhook host -- so the
+        pinned-bug assertion had to become a real one. `notify` returns
+        False and says why.
+        """
         d = self._make()
         with patch.object(d, 'conf', side_effect=lambda k, **kw: {
             'webhook_url': 'https://discord.com/api/webhooks/123/abc',
             'include_imdb': False, 'bot_name': 'CP',
             'avatar_url': '', 'discord_tts': False
         }.get(k, kw.get('default', ''))), \
-             patch('couchpotato.core.notifications.discord.requests.post', side_effect=Exception('timeout')):
-            with pytest.raises(UnboundLocalError):
-                d.notify(message='test')
+             patch('couchpotato.core.notifications.discord.requests.post',
+                   side_effect=Exception('timeout')), \
+             patch('couchpotato.core.notifications.discord.log') as mock_log:
+            result = d.notify(message='test')
+
+        assert result is False
+        assert mock_log.warning.called, 'the failure must be logged, not swallowed'
+        assert 'timeout' in str(mock_log.warning.call_args), (
+            'the log must name the exception that was actually caught')
 
 
 # ===========================================================================

--- a/tests/unit/test_render_template_autoescape.py
+++ b/tests/unit/test_render_template_autoescape.py
@@ -1,0 +1,31 @@
+"""T17 fix 3 (python:S5247): `Plugin.renderTemplate` builds its Jinja
+`Environment` with no `autoescape` argument, which Jinja defaults to False --
+so any caller-supplied value lands in the rendered output unescaped.
+
+`renderTemplate` has no in-repo callers (verified across .py/.html/.js), but
+it is a public method on `Plugin`, inherited by every in-tree plugin class
+and by any installed third-party plugin. An out-of-tree caller is invisible
+to every check available from inside this repository, so the fix is to make
+the method safe rather than to delete it.
+"""
+from couchpotato.core.plugins.base import Plugin
+
+
+def test_render_template_escapes_html_in_params(tmp_path):
+    """A `<script>` value passed as a template param must come out escaped,
+    not verbatim -- the whole point of S5247. This is the guard: it must be
+    provably breakable by reverting `autoescape=True` to no autoescape arg."""
+    template_path = tmp_path / 'greeting.html'
+    template_path.write_text('Hello {{ payload }}')
+
+    plugin = Plugin()
+    # renderTemplate only ever uses Path(parent_file).parent as the template
+    # search directory -- the file itself need not exist.
+    fake_parent_file = str(tmp_path / 'plugin.py')
+
+    rendered = plugin.renderTemplate(
+        fake_parent_file, 'greeting.html', payload = '<script>alert(1)</script>'
+    )
+
+    assert '<script>alert(1)</script>' not in rendered
+    assert '&lt;script&gt;alert(1)&lt;/script&gt;' in rendered

--- a/tests/unit/test_source_updater_removedir.py
+++ b/tests/unit/test_source_updater_removedir.py
@@ -1,0 +1,112 @@
+"""T17 fix 2 (python:S2612): `SourceUpdater.removeDir` used to respond to a
+failed `shutil.rmtree` by making the offending path world-writable
+(`os.chmod(inst.filename, 0o777)`) and recursing with no depth bound and no
+guarantee the chmod fixed anything -- so a permission error it cannot clear
+recurses until the stack blows up.
+
+Fixed shape: grant owner-write only (never widen group/other), retry
+`rmtree` exactly once, and let a second failure propagate. A `filename`-less
+OSError (which can happen) must propagate without touching `os.chmod` at all.
+
+Reachability (noted in specs/REMEDIATION-2026-08.md T17): this is called from
+SourceUpdater's extract paths, which only run for a source install doing a
+self-update -- not the Docker image this project ships. Still reachable, so
+still worth fixing correctly rather than papering over.
+"""
+import stat
+
+import pytest
+from unittest.mock import patch
+
+from couchpotato.core._base.updater.main import SourceUpdater
+
+
+def _bare_updater():
+    """SourceUpdater.__init__ touches Env.get('cache_dir') and the real
+    filesystem, none of which removeDir() needs -- it only calls
+    os/shutil functions and (in the buggy version) itself. Skipping __init__
+    via object.__new__ keeps this test isolated from that setup."""
+    return object.__new__(SourceUpdater)
+
+
+class TestRemoveDirPermissionRetry:
+
+    def test_retries_exactly_once_then_propagates_second_failure(self, tmp_path):
+        updater = _bare_updater()
+        target = str(tmp_path / 'locked')
+
+        call_count = {'n': 0}
+
+        def fake_rmtree(path):
+            call_count['n'] += 1
+            raise PermissionError(13, 'Permission denied', target)
+
+        with patch('couchpotato.core._base.updater.main.shutil.rmtree', side_effect = fake_rmtree), \
+             patch('couchpotato.core._base.updater.main.os.path.isdir', return_value = True), \
+             patch('couchpotato.core._base.updater.main.os.stat') as mock_stat, \
+             patch('couchpotato.core._base.updater.main.os.chmod') as mock_chmod:
+            mock_stat.return_value.st_mode = 0o100444
+
+            with pytest.raises(PermissionError):
+                updater.removeDir(target)
+
+        assert call_count['n'] == 2, 'must retry exactly once, not recurse unbounded'
+        mock_chmod.assert_called_once()
+
+    def test_chmod_grants_owner_write_only_not_group_or_other(self, tmp_path):
+        updater = _bare_updater()
+        target = str(tmp_path / 'locked')
+
+        attempts = {'n': 0}
+
+        def fake_rmtree(path):
+            attempts['n'] += 1
+            if attempts['n'] == 1:
+                raise PermissionError(13, 'Permission denied', target)
+            return None  # second attempt succeeds
+
+        with patch('couchpotato.core._base.updater.main.shutil.rmtree', side_effect = fake_rmtree), \
+             patch('couchpotato.core._base.updater.main.os.path.isdir', return_value = True), \
+             patch('couchpotato.core._base.updater.main.os.stat') as mock_stat, \
+             patch('couchpotato.core._base.updater.main.os.chmod') as mock_chmod:
+            mock_stat.return_value.st_mode = 0o100444  # r--r--r--
+
+            updater.removeDir(target)  # must not raise -- second attempt succeeds
+
+        assert mock_chmod.call_count == 1
+        mode_arg = mock_chmod.call_args[0][1]
+        assert mode_arg & stat.S_IWUSR, 'owner write must be granted'
+        assert not (mode_arg & stat.S_IWGRP), 'must not widen group write'
+        assert not (mode_arg & stat.S_IWOTH), 'must not widen other write'
+        assert mode_arg != 0o777
+
+    def test_none_filename_propagates_without_chmod(self, tmp_path):
+        updater = _bare_updater()
+        target = str(tmp_path / 'locked')
+
+        def fake_rmtree(path):
+            # No filename positional arg -> .filename is None, as can
+            # genuinely happen on some OSErrors.
+            raise PermissionError(13, 'Permission denied')
+
+        with patch('couchpotato.core._base.updater.main.shutil.rmtree', side_effect = fake_rmtree), \
+             patch('couchpotato.core._base.updater.main.os.path.isdir', return_value = True), \
+             patch('couchpotato.core._base.updater.main.os.chmod') as mock_chmod:
+
+            with pytest.raises(PermissionError):
+                updater.removeDir(target)
+
+        mock_chmod.assert_not_called()
+
+    def test_successful_rmtree_never_touches_chmod(self, tmp_path):
+        """The happy path (no OSError at all) must not retry or chmod anything."""
+        updater = _bare_updater()
+        target = str(tmp_path / 'clean')
+
+        with patch('couchpotato.core._base.updater.main.shutil.rmtree') as mock_rmtree, \
+             patch('couchpotato.core._base.updater.main.os.path.isdir', return_value = True), \
+             patch('couchpotato.core._base.updater.main.os.chmod') as mock_chmod:
+            updater.removeDir(target)
+
+        mock_rmtree.assert_called_once_with(target)
+        mock_chmod.assert_not_called()

--- a/tests/unit/test_source_updater_removedir.py
+++ b/tests/unit/test_source_updater_removedir.py
@@ -66,33 +66,6 @@ class TestRemoveDirPermissionRetry:
         assert call_count['n'] == 2, 'must retry exactly once, not recurse unbounded'
         mock_chmod.assert_called_once()
 
-    def test_chmod_grants_owner_write_only_not_group_or_other(self, tmp_path):
-        updater = _bare_updater()
-        target = str(tmp_path / 'locked')
-
-        attempts = {'n': 0}
-
-        def fake_rmtree(path):
-            attempts['n'] += 1
-            if attempts['n'] == 1:
-                raise PermissionError(13, 'Permission denied', target)
-            return None  # second attempt succeeds
-
-        with patch('couchpotato.core._base.updater.main.shutil.rmtree', side_effect = fake_rmtree), \
-             patch('couchpotato.core._base.updater.main.os.path.isdir', return_value = True), \
-             patch('couchpotato.core._base.updater.main.os.stat') as mock_stat, \
-             patch('couchpotato.core._base.updater.main.os.chmod') as mock_chmod:
-            mock_stat.return_value.st_mode = 0o100444  # r--r--r--
-
-            updater.removeDir(target)  # must not raise -- second attempt succeeds
-
-        assert mock_chmod.call_count == 1
-        mode_arg = mock_chmod.call_args[0][1]
-        assert mode_arg & stat.S_IWUSR, 'owner write must be granted'
-        assert not (mode_arg & stat.S_IWGRP), 'must not widen group write'
-        assert not (mode_arg & stat.S_IWOTH), 'must not widen other write'
-        assert mode_arg != 0o777
-
     def test_none_filename_propagates_without_chmod(self, tmp_path):
         updater = _bare_updater()
         target = str(tmp_path / 'locked')
@@ -160,3 +133,104 @@ class TestRemoveDirPermissionRetry:
 
         mock_rmtree.assert_called_once_with(target)
         mock_chmod.assert_not_called()
+
+
+class TestRemoveDirGrantsTraversalNotJustWrite:
+    """2026-08-11 review finding, and a correction to this file's own prior
+    instruction: narrowing the chmod to owner-WRITE-only
+    (`current_mode | stat.S_IWUSR`) regressed `removeDir`'s actual purpose.
+    `shutil.rmtree` needs owner read+write+EXECUTE on a directory to list
+    and unlink its contents -- write alone is not enough to descend into or
+    clear it. Measured on a real filesystem, no mocks (uid 501, macOS
+    APFS):
+
+        mode 0o500  S_IWUSR -> deleted OK        S_IRWXU -> deleted OK
+        mode 0o400  S_IWUSR -> FAILED             S_IRWXU -> deleted OK
+        mode 0o000  S_IWUSR -> FAILED             S_IRWXU -> deleted OK
+
+    `stat.S_IRWXU` (owner rwx) still never touches group/other -- that was
+    the actual point of the S2612 finding (0o777 made the path WORLD-
+    writable), not "grant the single narrowest bit possible". Do not
+    re-narrow this to `S_IWUSR`: it looks more conservative and is actually
+    broken for the directories this function exists to remove.
+
+    The PREVIOUS version of this test (removed here) mocked
+    `shutil.rmtree`, `os.stat` AND `os.chmod`, so its four assertions held
+    equally for the broken `S_IWUSR` and the correct `S_IRWXU` -- it could
+    not have failed on this regression, because it measured the argument
+    handed to a fake rather than whether anything became removable.
+    Rewritten against a real filesystem: build a genuinely locked
+    directory, call the real `removeDir` with nothing mocked, and assert
+    the tree is actually gone.
+
+    Root bypasses permission checks entirely (plausible for the Alpine
+    container image this project ships, which may run as root) -- a
+    permission-based test would pass unconditionally and silently prove
+    nothing there, so it is skipped in that case rather than reported as a
+    false green.
+    """
+
+    @pytest.fixture(autouse = True)
+    def _skip_as_root(self):
+        if hasattr(os, 'geteuid') and os.geteuid() == 0:
+            pytest.skip('running as root: file/directory modes are not enforced')
+
+    @pytest.mark.parametrize('locked_mode', [0o500, 0o400, 0o000], ids = ['0o500', '0o400', '0o000'])
+    def test_directory_is_actually_removed_regardless_of_starting_mode(self, tmp_path, locked_mode):
+        updater = _bare_updater()
+
+        tree = tmp_path / 'locked'
+        tree.mkdir()
+        (tree / 'file.txt').write_text('content')
+        os.chmod(str(tree), locked_mode)
+
+        try:
+            updater.removeDir(str(tree))
+        finally:
+            # Best-effort: if the assertion below is about to fail, leave
+            # tmp_path in a state its own teardown can still clean up.
+            if tree.exists():
+                os.chmod(str(tree), 0o700)
+
+        assert not tree.exists(), (
+            'removeDir must actually delete a directory whose permissions it can fix -- '
+            'S_IWUSR alone cannot, because rmtree needs owner EXECUTE to traverse a directory too'
+        )
+
+    def test_never_grants_group_or_other_write(self, tmp_path, monkeypatch):
+        """Group/other write must never be granted -- 0o777 was the actual
+        S2612 defect. Captures every mode actually passed to os.chmod on a
+        real (failing-then-fixed) directory, without mocking shutil.rmtree
+        itself."""
+        updater = _bare_updater()
+
+        tree = tmp_path / 'locked'
+        tree.mkdir()
+        (tree / 'file.txt').write_text('content')
+        os.chmod(str(tree), 0o400)
+
+        captured_modes = []
+        real_chmod = os.chmod
+
+        def spy_chmod(path, mode, *args, **kwargs):
+            captured_modes.append(mode)
+            return real_chmod(path, mode, *args, **kwargs)
+
+        monkeypatch.setattr('couchpotato.core._base.updater.main.os.chmod', spy_chmod)
+
+        try:
+            updater.removeDir(str(tree))
+        finally:
+            # Best-effort: a mutated implementation under test can leave the
+            # directory locked (0o400), which pytest's own tmp_path cleanup
+            # cannot remove either -- widen it back so teardown succeeds
+            # regardless of what this test's assertions find.
+            if tree.exists():
+                os.chmod(str(tree), 0o700)
+
+        assert captured_modes, 'chmod should have been called to fix the permission error'
+        for mode in captured_modes:
+            assert not (mode & stat.S_IWGRP), 'must not widen group write'
+            assert not (mode & stat.S_IWOTH), 'must not widen other write'
+            assert mode != 0o777
+        assert not tree.exists(), 'the directory must actually end up removed'

--- a/tests/unit/test_source_updater_removedir.py
+++ b/tests/unit/test_source_updater_removedir.py
@@ -4,21 +4,40 @@ failed `shutil.rmtree` by making the offending path world-writable
 guarantee the chmod fixed anything -- so a permission error it cannot clear
 recurses until the stack blows up.
 
-Fixed shape: grant owner-write only (never widen group/other), retry
-`rmtree` exactly once, and let a second failure propagate. A `filename`-less
-OSError (which can happen) must propagate without touching `os.chmod` at all.
-And (T17 follow-up B): if the failing entry is a SYMLINK, `os.stat`/`os.chmod`
-both follow it by default -- so chmod-ing `inst.filename` would silently
-reach the link's TARGET, potentially outside the tree being deleted.
-`removeDir` is called on freshly-extracted archive content
-(`SourceUpdater.doUpdate`), which is attacker-influenced input, so this is a
-first-class symlink-following risk per CLAUDE.md even though the practical
-blast radius is small (chmod requires ownership, so the worst case is adding
-owner-write to a file the CouchPotato user already owns). The fix refuses to
-chmod a symlink at all: a symlink's own permission bits never block
+Fixed shape: grant owner rwx (never widen group/other), and let a failure
+`removeDir` cannot fix propagate. A `filename`-less OSError (which can
+happen) must propagate without touching `os.chmod` at all. And (T17
+follow-up B): if the failing entry is a SYMLINK, `os.stat`/`os.chmod` both
+follow it by default -- so chmod-ing `inst.filename` would silently reach
+the link's TARGET, potentially outside the tree being deleted. `removeDir`
+is called on freshly-extracted archive content (`SourceUpdater.doUpdate`),
+which is attacker-influenced input, so this is a first-class
+symlink-following risk per CLAUDE.md even though the practical blast
+radius is small (chmod requires ownership, so the worst case is adding
+owner-write to a file the CouchPotato user already owns). The fix refuses
+to chmod a symlink at all: a symlink's own permission bits never block
 `shutil.rmtree` from removing it (only the *containing directory*'s
-permissions matter for unlink), so there is nothing legitimate a chmod on it
-would accomplish.
+permissions matter for unlink), so there is nothing legitimate a chmod on
+it would accomplish.
+
+2026-08-11 review, finding 3: an earlier version of this fix bounded the
+retry to a single attempt (see git history), which regressed cleanup of any
+tree with MORE than one blocked directory -- the old unbounded recursion
+repaired one entry per level and eventually succeeded; a single retry
+repairs only the first entry it meets and propagates uncaught on the
+second. Measured on HEAD before this fix, real filesystem, no mocks:
+
+    1 blocked dirs  single-retry -> deleted OK
+    2 blocked dirs  single-retry -> FAILED: PermissionError
+    3 blocked dirs  single-retry -> FAILED: PermissionError
+
+That matters because `removeDir` runs (`SourceUpdater.doUpdate`) AFTER
+`replaceWith()` has already overwritten the application directory and
+BEFORE `version_file` is written -- so a cleanup failure here makes the
+updater report failure and re-apply an already-installed update. Fixed by
+bounding the retry to ENTRIES REPAIRED rather than an attempt count or
+recursion depth: each distinct failing `inst.filename` is chmod-ed at most
+once. See `removeDir`'s own docstring for the termination argument.
 
 Reachability (noted in specs/REMEDIATION-2026-08.md T17): this is called from
 SourceUpdater's extract paths, which only run for a source install doing a
@@ -44,7 +63,22 @@ def _bare_updater():
 
 class TestRemoveDirPermissionRetry:
 
-    def test_retries_exactly_once_then_propagates_second_failure(self, tmp_path):
+    def test_an_entry_that_cannot_be_repaired_propagates_rather_than_looping(self, tmp_path):
+        """The SAME entry keeps failing (chmod cannot fix whatever this is
+        -- a different user's file, a filesystem that ignores mode bits...).
+        removeDir must repair it once, retry once, see the identical
+        filename fail again, and stop -- not loop.
+
+        The fake is DELIBERATELY BOUNDED (five failures, then a sixth call
+        that would succeed) rather than an unconditional always-raise: an
+        always-raise fake would hang for real if `removeDir`'s
+        once-per-entry guard (`if inst.filename in repaired: raise`) were
+        ever removed, which is exactly the mutation this test exists to
+        catch -- "do not write a test that could hang" cuts against making
+        the fake itself unbounded. With the guard, removeDir must stop
+        after the SECOND failure on the identical filename (2 rmtree calls,
+        1 chmod call) rather than retrying it three more times to reach
+        the fake's eventual "success"."""
         updater = _bare_updater()
         target = str(tmp_path / 'locked')
 
@@ -52,7 +86,9 @@ class TestRemoveDirPermissionRetry:
 
         def fake_rmtree(path):
             call_count['n'] += 1
-            raise PermissionError(13, 'Permission denied', target)
+            if call_count['n'] <= 5:
+                raise PermissionError(13, 'Permission denied', target)
+            return None  # never reached if the guard behaves correctly
 
         with patch('couchpotato.core._base.updater.main.shutil.rmtree', side_effect = fake_rmtree), \
              patch('couchpotato.core._base.updater.main.os.path.isdir', return_value = True), \
@@ -63,7 +99,10 @@ class TestRemoveDirPermissionRetry:
             with pytest.raises(PermissionError):
                 updater.removeDir(target)
 
-        assert call_count['n'] == 2, 'must retry exactly once, not recurse unbounded'
+        assert call_count['n'] == 2, (
+            'must repair the failing entry once, retry once, then propagate on the '
+            'SAME filename failing again -- not keep retrying it'
+        )
         mock_chmod.assert_called_once()
 
     def test_none_filename_propagates_without_chmod(self, tmp_path):
@@ -234,3 +273,106 @@ class TestRemoveDirGrantsTraversalNotJustWrite:
             assert not (mode & stat.S_IWOTH), 'must not widen other write'
             assert mode != 0o777
         assert not tree.exists(), 'the directory must actually end up removed'
+
+
+class TestRemoveDirHandlesMultipleBlockedEntries:
+    """2026-08-11 review finding 3: a single blanket retry only repairs the
+    FIRST blocked directory it meets in a tree, then propagates uncaught on
+    the second -- measured on HEAD (single-retry) before this fix, real
+    filesystem, no mocks:
+
+        1 blocked dirs  single-retry -> deleted OK
+        2 blocked dirs  single-retry -> FAILED: PermissionError
+        3 blocked dirs  single-retry -> FAILED: PermissionError
+
+    That matters because removeDir runs (SourceUpdater.doUpdate) AFTER
+    replaceWith() has already overwritten the application directory and
+    BEFORE version_file is written -- a cleanup failure here makes the
+    updater report failure and re-apply an already-installed update.
+
+    Fixed by bounding the retry to entries repaired rather than an attempt
+    count. Tested here on a real filesystem (no mocks) across both layouts
+    a tree can actually have: multiple blocked SIBLINGS and multiple
+    blocked NESTED directories, at 1/2/3/5 blocked entries each.
+
+    Root bypasses permission checks entirely -- skipped there, same as the
+    class above, rather than reporting a false green.
+    """
+
+    @pytest.fixture(autouse = True)
+    def _skip_as_root(self):
+        if hasattr(os, 'geteuid') and os.geteuid() == 0:
+            pytest.skip('running as root: file/directory modes are not enforced')
+
+    def _make_sibling_tree(self, tmp_path, n_blocked):
+        tree = tmp_path / 'tree'
+        tree.mkdir()
+        blocked = []
+        for i in range(n_blocked):
+            sub = tree / ('sub%d' % i)
+            sub.mkdir()
+            (sub / 'f.txt').write_text('content')
+            blocked.append(sub)
+        for b in blocked:
+            os.chmod(str(b), 0o400)
+        return tree, blocked
+
+    def _make_nested_tree(self, tmp_path, n_blocked):
+        tree = tmp_path / 'tree'
+        tree.mkdir()
+        current = tree
+        blocked = []
+        for i in range(n_blocked):
+            current = current / ('lvl%d' % i)
+            current.mkdir()
+            (current / 'f.txt').write_text('content')
+            blocked.append(current)
+        # Lock innermost-first: locking an ancestor before its descendant
+        # is created underneath it would block the setup itself.
+        for b in reversed(blocked):
+            os.chmod(str(b), 0o400)
+        return tree, blocked
+
+    def _cleanup(self, tree, blocked):
+        # Best-effort, OUTERMOST-first (opposite of the locking order):
+        # checking whether a NESTED entry still exists requires traversing
+        # its ancestors, and Path.exists() silently returns False (not
+        # raise) when a locked ancestor blocks that traversal -- so
+        # repairing innermost-first would skip the very entries still
+        # blocked by their still-locked parent. Fix the parent's
+        # permissions before asking whether the child is even reachable.
+        if tree.exists():
+            os.chmod(str(tree), 0o700)
+        for b in blocked:
+            if b.exists():
+                os.chmod(str(b), 0o700)
+
+    @pytest.mark.parametrize('n_blocked', [1, 2, 3, 5])
+    def test_multiple_blocked_sibling_directories_are_removed(self, tmp_path, n_blocked):
+        updater = _bare_updater()
+        tree, blocked = self._make_sibling_tree(tmp_path, n_blocked)
+
+        try:
+            updater.removeDir(str(tree))
+        finally:
+            self._cleanup(tree, blocked)
+
+        assert not tree.exists(), (
+            'removeDir must remove a tree with %d blocked SIBLING directories, '
+            'not just the first one it meets' % n_blocked
+        )
+
+    @pytest.mark.parametrize('n_blocked', [1, 2, 3, 5])
+    def test_multiple_blocked_nested_directories_are_removed(self, tmp_path, n_blocked):
+        updater = _bare_updater()
+        tree, blocked = self._make_nested_tree(tmp_path, n_blocked)
+
+        try:
+            updater.removeDir(str(tree))
+        finally:
+            self._cleanup(tree, blocked)
+
+        assert not tree.exists(), (
+            'removeDir must remove a tree with %d blocked NESTED directories, '
+            'not just the first one it meets' % n_blocked
+        )

--- a/tests/unit/test_source_updater_removedir.py
+++ b/tests/unit/test_source_updater_removedir.py
@@ -7,12 +7,25 @@ recurses until the stack blows up.
 Fixed shape: grant owner-write only (never widen group/other), retry
 `rmtree` exactly once, and let a second failure propagate. A `filename`-less
 OSError (which can happen) must propagate without touching `os.chmod` at all.
+And (T17 follow-up B): if the failing entry is a SYMLINK, `os.stat`/`os.chmod`
+both follow it by default -- so chmod-ing `inst.filename` would silently
+reach the link's TARGET, potentially outside the tree being deleted.
+`removeDir` is called on freshly-extracted archive content
+(`SourceUpdater.doUpdate`), which is attacker-influenced input, so this is a
+first-class symlink-following risk per CLAUDE.md even though the practical
+blast radius is small (chmod requires ownership, so the worst case is adding
+owner-write to a file the CouchPotato user already owns). The fix refuses to
+chmod a symlink at all: a symlink's own permission bits never block
+`shutil.rmtree` from removing it (only the *containing directory*'s
+permissions matter for unlink), so there is nothing legitimate a chmod on it
+would accomplish.
 
 Reachability (noted in specs/REMEDIATION-2026-08.md T17): this is called from
 SourceUpdater's extract paths, which only run for a source install doing a
 self-update -- not the Docker image this project ships. Still reachable, so
 still worth fixing correctly rather than papering over.
 """
+import os
 import stat
 
 import pytest
@@ -97,6 +110,43 @@ class TestRemoveDirPermissionRetry:
                 updater.removeDir(target)
 
         mock_chmod.assert_not_called()
+
+    def test_symlink_target_permissions_are_never_touched(self, tmp_path):
+        """A real symlink on disk, pointing at a real file OUTSIDE the tree
+        being deleted. No mocking of os.stat/os.chmod -- if removeDir follows
+        the link (the bug), this genuinely widens the target's mode on disk;
+        if it refuses (the fix), the target's mode is provably untouched.
+
+        Platform note: os.chmod on a symlink follows the link on every
+        platform this project ships on (Linux/Alpine in Docker, macOS in
+        dev) -- `os.chmod(path, ..., follow_symlinks=False)` raises
+        NotImplementedError on Linux, which is why the fix refuses to chmod
+        a symlink at all rather than trying to chmod the link itself.
+        """
+        updater = _bare_updater()
+
+        outside_dir = tmp_path / 'outside'
+        outside_dir.mkdir()
+        target = outside_dir / 'target.txt'
+        target.write_text('do not touch')
+        os.chmod(str(target), 0o444)  # read-only, so a widened mode is observable
+        mode_before = stat.S_IMODE(os.stat(str(target)).st_mode)
+
+        tree = tmp_path / 'tree'
+        tree.mkdir()
+        link = tree / 'evil-link'
+        link.symlink_to(target)
+
+        def fake_rmtree(path):
+            raise PermissionError(13, 'Permission denied', str(link))
+
+        with patch('couchpotato.core._base.updater.main.shutil.rmtree', side_effect = fake_rmtree), \
+             patch('couchpotato.core._base.updater.main.os.path.isdir', return_value = True):
+            with pytest.raises(PermissionError):
+                updater.removeDir(str(tree))
+
+        mode_after = stat.S_IMODE(os.stat(str(target)).st_mode)
+        assert mode_after == mode_before, 'chmod must never reach the symlink target'
 
     def test_successful_rmtree_never_touches_chmod(self, tmp_path):
         """The happy path (no OSError at all) must not retry or chmod anything."""

--- a/tests/unit/test_synology.py
+++ b/tests/unit/test_synology.py
@@ -8,6 +8,16 @@ scheme and the verification flag are tested and fixed together.
 Reachability (per specs/REMEDIATION-2026-08.md T17): the downloader ships
 disabled by default, so this affects operators who have deliberately turned
 it on -- exactly the set who typed a password into it.
+
+T17 follow-up C (python:S113): the same `requests.post` call had no timeout,
+so an unresponsive NAS parks the calling thread forever -- on an unattended
+home server, that reads as "downloads silently stopped" with nothing in the
+log. Fixed with a named module-level constant rather than a bare number, at
+60s (matching sabnzbd.py's API-call timeout) rather than the house default
+of 30s (Plugin.urlopen, rtorrent_.py's _RPC_TIMEOUT), because _req also
+carries file uploads (the nzb/torrent payload itself) -- the shorter value
+risks breaking a slow-but-working setup, which would be a fix that causes
+an outage.
 """
 from unittest.mock import MagicMock, patch
 
@@ -86,6 +96,31 @@ class TestSynologyRPCVerifyPassedToRequests:
             rpc._login()
 
         assert mock_post.call_args.kwargs['verify'] is True
+
+
+class TestSynologyRPCTimeout:
+    """python:S113 -- requests.post with no timeout can hang forever against
+    an unresponsive NAS. Assert on the actual value reaching requests.post,
+    not merely that the kwarg is present: a guard that only checks presence
+    cannot tell a real 60s bound from an accidental 0."""
+
+    def test_login_passes_the_named_timeout_constant(self):
+        rpc = SynologyRPC('mynas', 5000, username = 'op', password = 'hunter2')
+
+        mock_response = MagicMock()
+        mock_response.text = '{"success": true, "data": {"sid": "abc"}}'
+        with patch.object(synology_module.requests, 'post', return_value = mock_response) as mock_post:
+            rpc._login()
+
+        assert mock_post.call_args.kwargs['timeout'] == synology_module._REQUEST_TIMEOUT
+        assert mock_post.call_args.kwargs['timeout'] == 60
+
+    def test_timeout_constant_is_the_longer_house_value(self):
+        """60s, not the 30s house default (Plugin.urlopen, rtorrent's
+        _RPC_TIMEOUT) -- _req carries file uploads (the nzb/torrent
+        payload), so the shorter value risks breaking a slow-but-working
+        setup."""
+        assert synology_module._REQUEST_TIMEOUT == 60
 
 
 # ===========================================================================

--- a/tests/unit/test_synology.py
+++ b/tests/unit/test_synology.py
@@ -25,6 +25,27 @@ from couchpotato.core.downloaders import synology as synology_module
 from couchpotato.core.downloaders.synology import Synology, SynologyRPC
 
 
+def _option(name):
+    options = synology_module.config[0]['groups'][0]['options']
+    return next(o for o in options if o['name'] == name)
+
+
+class TestSynologySslOptionDescription:
+    """2026-08-11 review finding 4: the description is where an operator
+    will actually read this, since the log warning is disconnected from the
+    settings UI by definition (it fires from a background thread, not while
+    they're looking at the form)."""
+
+    def test_explains_the_port_must_change_too(self):
+        description = _option('ssl')['description']
+
+        assert '5001' in description, 'must name the https port DSM actually needs'
+        assert 'port' in description.lower()
+        assert '<strong>unencrypted</strong>' in description, (
+            'the pre-existing "sends your password unencrypted" warning must survive'
+        )
+
+
 # ===========================================================================
 # SynologyRPC -- scheme + verify wiring
 # ===========================================================================
@@ -175,6 +196,58 @@ class TestSynologyDownloaderWiresSsl:
         with patch.object(downloader, 'conf', side_effect = self._conf()), \
              patch.object(synology_module, 'SynologyRPC', _CapturingRPC):
             downloader.test()
+
+        assert captured['kwargs'].get('ssl') is False
+        assert captured['kwargs'].get('verify') is True
+
+    def test_download_builds_synologyrpc_with_resolved_ssl_and_verify(self):
+        """`test()` is only the connectivity check. `download()` is the path
+        that actually sends the operator's DSM username and password on
+        every snatch -- and it has its OWN SynologyRPC(...) call site, so a
+        test that only drives test() proves nothing about it. Confirmed
+        independently: dropping `ssl=`/`verify=` from download()'s call site
+        left the full suite green before this test existed."""
+        downloader = Synology.__new__(Synology)
+
+        captured = {}
+
+        class _CapturingRPC(SynologyRPC):
+            def __init__(self, *args, **kwargs):
+                captured['args'] = args
+                captured['kwargs'] = kwargs
+                super().__init__(*args, **kwargs)
+
+            def create_task(self, **kwargs):
+                return True
+
+        data = {'name': 'Movie', 'protocol': 'torrent_magnet', 'url': 'magnet:?xt=urn:btih:ABC'}
+
+        with patch.object(downloader, 'conf', side_effect = self._conf(ssl = True, ssl_verify = False)), \
+             patch.object(synology_module, 'SynologyRPC', _CapturingRPC):
+            downloader.download(data = data)
+
+        assert captured['kwargs'].get('ssl') is True
+        assert captured['kwargs'].get('verify') is False
+
+    def test_download_defaults_to_verifying_plaintext_http(self):
+        downloader = Synology.__new__(Synology)
+
+        captured = {}
+
+        class _CapturingRPC(SynologyRPC):
+            def __init__(self, *args, **kwargs):
+                captured['args'] = args
+                captured['kwargs'] = kwargs
+                super().__init__(*args, **kwargs)
+
+            def create_task(self, **kwargs):
+                return True
+
+        data = {'name': 'Movie', 'protocol': 'torrent_magnet', 'url': 'magnet:?xt=urn:btih:ABC'}
+
+        with patch.object(downloader, 'conf', side_effect = self._conf()), \
+             patch.object(synology_module, 'SynologyRPC', _CapturingRPC):
+            downloader.download(data = data)
 
         assert captured['kwargs'].get('ssl') is False
         assert captured['kwargs'].get('verify') is True

--- a/tests/unit/test_synology.py
+++ b/tests/unit/test_synology.py
@@ -1,0 +1,145 @@
+"""T17 fix 1 (python:S4830): the Synology downloader's `SYNO.API.Auth` login
+carries the operator's username and password to `SynologyRPC._req`, which
+hard-coded `requests.post(..., verify=False)` and built its `download_url`/
+`auth_url` as literal `http://`. Fixing only `verify` would clear the
+scanner finding while leaving the password readable in plaintext, so the
+scheme and the verification flag are tested and fixed together.
+
+Reachability (per specs/REMEDIATION-2026-08.md T17): the downloader ships
+disabled by default, so this affects operators who have deliberately turned
+it on -- exactly the set who typed a password into it.
+"""
+from unittest.mock import MagicMock, patch
+
+from couchpotato.core.downloaders import synology as synology_module
+from couchpotato.core.downloaders.synology import Synology, SynologyRPC
+
+
+# ===========================================================================
+# SynologyRPC -- scheme + verify wiring
+# ===========================================================================
+
+class TestSynologyRPCScheme:
+
+    def test_default_is_plain_http_for_backward_compatibility(self):
+        """ssl defaults off (matches the config's own default = 0) so an
+        existing plaintext NAS setup keeps working unmodified."""
+        rpc = SynologyRPC('mynas', 5000)
+
+        assert rpc.download_url.startswith('http://mynas:5000/')
+        assert rpc.auth_url.startswith('http://mynas:5000/')
+
+    def test_ssl_true_builds_https_urls(self):
+        rpc = SynologyRPC('mynas', 5001, ssl = True)
+
+        assert rpc.download_url == 'https://mynas:5001/webapi/DownloadStation/task.cgi'
+        assert rpc.auth_url == 'https://mynas:5001/webapi/auth.cgi'
+
+
+class TestSynologyRPCVerifyPassedToRequests:
+    """The SYNO.API.Auth login is the request that carries the password --
+    assert on exactly what reaches `requests.post`, not on an internal
+    attribute, so a refactor that silently drops the flag on its way to the
+    network call still fails this test."""
+
+    def test_login_passes_verify_true_by_default(self):
+        rpc = SynologyRPC('mynas', 5000, username = 'op', password = 'hunter2', verify = True)
+
+        mock_response = MagicMock()
+        mock_response.text = '{"success": true, "data": {"sid": "abc"}}'
+        with patch.object(synology_module.requests, 'post', return_value = mock_response) as mock_post:
+            rpc._login()
+
+        assert mock_post.call_args.kwargs['verify'] is True
+
+    def test_login_passes_verify_false_when_explicitly_configured_off(self):
+        rpc = SynologyRPC('mynas', 5000, username = 'op', password = 'hunter2', verify = False)
+
+        mock_response = MagicMock()
+        mock_response.text = '{"success": true, "data": {"sid": "abc"}}'
+        with patch.object(synology_module.requests, 'post', return_value = mock_response) as mock_post:
+            rpc._login()
+
+        assert mock_post.call_args.kwargs['verify'] is False
+
+    def test_login_passes_ca_bundle_path_when_configured(self, tmp_path):
+        bundle = tmp_path / 'ca.pem'
+        bundle.write_text('cert')
+        rpc = SynologyRPC('mynas', 5000, username = 'op', password = 'hunter2', verify = str(bundle))
+
+        mock_response = MagicMock()
+        mock_response.text = '{"success": true, "data": {"sid": "abc"}}'
+        with patch.object(synology_module.requests, 'post', return_value = mock_response) as mock_post:
+            rpc._login()
+
+        assert mock_post.call_args.kwargs['verify'] == str(bundle)
+
+    def test_default_constructor_verify_value_is_true(self):
+        """The class default (no verify= passed at all) must itself be safe
+        -- a caller that forgets the keyword must not silently disable
+        verification."""
+        rpc = SynologyRPC('mynas', 5000, username = 'op', password = 'hunter2')
+
+        mock_response = MagicMock()
+        mock_response.text = '{"success": true, "data": {"sid": "abc"}}'
+        with patch.object(synology_module.requests, 'post', return_value = mock_response) as mock_post:
+            rpc._login()
+
+        assert mock_post.call_args.kwargs['verify'] is True
+
+
+# ===========================================================================
+# Synology downloader -- wires conf('ssl') / getVerifySsl() into SynologyRPC
+# ===========================================================================
+
+class TestSynologyDownloaderWiresSsl:
+
+    def _conf(self, **overrides):
+        values = {
+            'host': 'localhost:5000', 'username': 'op', 'password': 'hunter2',
+            'destination': '', 'ssl': False, 'ssl_verify': True, 'ssl_ca_bundle': '',
+        }
+        values.update(overrides)
+        return lambda k, **kw: values.get(k, kw.get('default', ''))
+
+    def test_test_builds_synologyrpc_with_resolved_ssl_and_verify(self):
+        downloader = Synology.__new__(Synology)
+
+        captured = {}
+
+        class _CapturingRPC(SynologyRPC):
+            def __init__(self, *args, **kwargs):
+                captured['args'] = args
+                captured['kwargs'] = kwargs
+                super().__init__(*args, **kwargs)
+
+            def test(self):
+                return True
+
+        with patch.object(downloader, 'conf', side_effect = self._conf(ssl = True, ssl_verify = False)), \
+             patch.object(synology_module, 'SynologyRPC', _CapturingRPC):
+            downloader.test()
+
+        assert captured['kwargs'].get('ssl') is True
+        assert captured['kwargs'].get('verify') is False
+
+    def test_test_defaults_to_verifying_plaintext_http(self):
+        downloader = Synology.__new__(Synology)
+
+        captured = {}
+
+        class _CapturingRPC(SynologyRPC):
+            def __init__(self, *args, **kwargs):
+                captured['args'] = args
+                captured['kwargs'] = kwargs
+                super().__init__(*args, **kwargs)
+
+            def test(self):
+                return True
+
+        with patch.object(downloader, 'conf', side_effect = self._conf()), \
+             patch.object(synology_module, 'SynologyRPC', _CapturingRPC):
+            downloader.test()
+
+        assert captured['kwargs'].get('ssl') is False
+        assert captured['kwargs'].get('verify') is True

--- a/tests/unit/test_synology_ssl_warnings.py
+++ b/tests/unit/test_synology_ssl_warnings.py
@@ -31,10 +31,43 @@ credentials and verify-disabled don't mask each other, with `now` injected
 through `SynologyRPC`'s own `now=` parameter rather than sleeping or
 patching `time.monotonic` (patching the clock has already produced a
 recorded false positive on this repo -- it also freezes `date.today()`).
+
+T17 follow-up D (2026-08-11 review, finding 4): the plaintext-credentials
+warning told the operator to "Enable the ssl setting", but `host` defaults
+to `localhost:5000` -- DSM's PLAINTEXT port -- and DSM serves https on 5001.
+Flipping only `ssl` produces `https://host:5000`, which `download()` cannot
+reach and swallows as "Exception while adding torrent", returned as a bare
+False. An operator who does exactly what the warning says gets broken
+downloads with no diagnosis, and the rational response is to turn `ssl`
+back off -- landing them back in the state the warning existed to move them
+out of. The warning now names the port change explicitly (never the
+operator's OWN host value -- 5001 is DSM's documented default, not
+configuration read back to them) and that the setting sits behind the
+Advanced toggle, which defaults off.
+
+T17 follow-up E (2026-08-11 review, finding 5): `ssl_verify = ` (present but
+BLANK in config.ini) coerces to False -- verification OFF -- independently
+measured by three review lenses against a REAL `Settings` instance and
+`config.ini`, not a fake `conf()` lambda. `Settings.get()` only returns the
+caller's `default` on the EXCEPTION path (the option genuinely absent), so
+`getVerifySsl()`'s `default = True` fail-open covers a MISSING option but
+not a blanked one -- a present-but-empty value reaches
+`_coerce_value('', 'bool')`, which maps `''` to `False`.
+
+This is deliberately NOT a bug being fixed here: the warning is the answer
+to a blank value ending up unsafe, not more parsing (blank and explicit-off
+are indistinguishable after coercion, so there is nothing to parse
+differently). What follows PINS that answer against a real Settings/
+config.ini, so a future change to `_coerce_value` that flips this in either
+direction is caught here rather than discovered in production. The upgrade
+path was separately confirmed safe and is not retested here: with all three
+keys absent, `ssl` reads None (http, unchanged) and `ssl_verify` reads True.
 """
 import logging
 
-from couchpotato.core.downloaders.synology import SynologyRPC
+import pytest
+
+from couchpotato.core.downloaders.synology import Synology, SynologyRPC
 
 # Deliberately distinctive so a leak can't hide as a substring of unrelated
 # log text (a short username/password like 'op'/'x' could coincidentally
@@ -55,6 +88,25 @@ class TestPlaintextCredentialWarning:
             SynologyRPC(_HOST, 5000, username = _USERNAME, password = _PASSWORD, ssl = False)
 
         assert len(_warning_records(caplog)) == 1
+
+    def test_warning_explains_the_port_must_change_too(self, caplog):
+        """The remediation the warning asks for ("enable ssl") breaks
+        downloads on its own: host defaults to DSM's plaintext port 5000,
+        DSM serves https on 5001, and flipping only `ssl` produces
+        `https://host:5000`, which fails. An operator who does exactly what
+        the warning says without also changing the port ends up with
+        broken downloads and no diagnosis -- worse than the warning never
+        having fired."""
+        with caplog.at_level(logging.WARNING):
+            SynologyRPC(_HOST, 5000, username = _USERNAME, password = _PASSWORD, ssl = False)
+
+        message = _warning_records(caplog)[0].getMessage()
+        assert '5001' in message, 'must name the https port DSM actually needs'
+        assert 'port' in message
+        assert 'Advanced' in message, (
+            'the setting is behind the Advanced toggle (default off) -- '
+            '"enable ssl" is not self-evidently findable otherwise'
+        )
 
     def test_no_warning_for_plaintext_with_no_credentials_configured(self, caplog):
         with caplog.at_level(logging.WARNING):
@@ -204,3 +256,48 @@ class TestSuppressionOfRepeatedWarnings:
         assert _USERNAME not in caplog.text
         assert _PASSWORD not in caplog.text
         assert _HOST not in caplog.text
+
+
+class TestBlankSslVerifyMeansVerificationOff:
+    """Finding 5 -- pinned against a REAL Settings instance and config.ini,
+    matching how the three review lenses measured it, not a fake conf()
+    lambda that could quietly disagree with the real coercion layer."""
+
+    @pytest.fixture
+    def synology_with_blank_ssl_verify(self, config_file):
+        from couchpotato.core.settings import Settings
+        from couchpotato.environment import Env
+
+        import sys
+        from pathlib import Path
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        from env_helper import env_restored  # noqa: E402
+
+        with env_restored():
+            s = Settings()
+            s.setFile(config_file)
+            s.addSection('synology')
+            s.p.set('synology', 'ssl', '1')
+            s.p.set('synology', 'ssl_verify', '')  # present but BLANK
+            s.setType('synology', 'ssl', 'bool')
+            s.setType('synology', 'ssl_verify', 'bool')
+            Env.set('settings', s)
+
+            yield Synology.__new__(Synology)
+
+    def test_blank_ssl_verify_coerces_to_verification_off(self, synology_with_blank_ssl_verify):
+        assert synology_with_blank_ssl_verify.getVerifySsl() is False
+
+    def test_blank_ssl_verify_fires_the_verification_disabled_warning(
+        self, synology_with_blank_ssl_verify, caplog,
+    ):
+        with caplog.at_level(logging.WARNING):
+            SynologyRPC(
+                'mynas', 5001, ssl = True,
+                verify = synology_with_blank_ssl_verify.getVerifySsl(),
+                now = 0,
+            )
+
+        records = _warning_records(caplog)
+        assert len(records) == 1
+        assert 'ssl_verify' in records[0].getMessage()

--- a/tests/unit/test_synology_ssl_warnings.py
+++ b/tests/unit/test_synology_ssl_warnings.py
@@ -1,0 +1,118 @@
+"""T17 follow-up A: S4830's real-world risk is not closed by making
+verification/scheme *configurable* -- `ssl` still defaults to 0 (correct:
+Synology DSM listens on 5000 for http, and flipping the default would break
+every existing install), so out of the box the SYNO.API.Auth login still
+puts the operator's username and password on the wire in clear text, and
+nothing said so.
+
+`SynologyRPC.__init__` must now log a WARNING in exactly two situations:
+
+  1. credentials are configured AND the connection is plaintext http --
+     the login is about to expose them;
+  2. the connection is https AND certificate verification is disabled --
+     the connection cannot confirm who it's talking to.
+
+And must NOT warn when there is nothing to warn about: https with
+verification on, or plaintext with no credentials configured (nothing to
+expose, and a warning that fires when it needn't is one people learn to
+ignore).
+
+The message must name the setting that fixes the problem, never the value,
+the host, or a filesystem path -- the project's log-privacy floor
+(PrivacyFilter, CLAUDE.md) applies even though this text doesn't go through
+`%`-args a caller controls.
+"""
+import logging
+
+from couchpotato.core.downloaders.synology import SynologyRPC
+
+# Deliberately distinctive so a leak can't hide as a substring of unrelated
+# log text (a short username/password like 'op'/'x' could coincidentally
+# appear inside another word and mask a real failure).
+_USERNAME = 'synology_operator_9f3a'
+_PASSWORD = 'Tr0ub4dor&3-hunter2'
+_HOST = 'my-actual-nas-hostname'
+
+
+def _warning_records(caplog):
+    return [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+class TestPlaintextCredentialWarning:
+
+    def test_warns_when_credentials_configured_over_plaintext_http(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            SynologyRPC(_HOST, 5000, username = _USERNAME, password = _PASSWORD, ssl = False)
+
+        assert len(_warning_records(caplog)) == 1
+
+    def test_no_warning_for_plaintext_with_no_credentials_configured(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            SynologyRPC(_HOST, 5000, ssl = False)
+
+        assert _warning_records(caplog) == []
+
+    def test_no_warning_for_plaintext_with_only_username_no_password(self, caplog):
+        """Matches _login()'s own guard (`if username and password`) --
+        half a credential pair can't authenticate, so there's nothing being
+        exposed yet either."""
+        with caplog.at_level(logging.WARNING):
+            SynologyRPC(_HOST, 5000, username = _USERNAME, password = None, ssl = False)
+
+        assert _warning_records(caplog) == []
+
+    def test_no_plaintext_warning_when_ssl_is_on(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            SynologyRPC(_HOST, 5000, username = _USERNAME, password = _PASSWORD, ssl = True, verify = True)
+
+        assert _warning_records(caplog) == []
+
+
+class TestVerificationDisabledWarning:
+
+    def test_warns_when_https_verification_disabled(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            SynologyRPC(_HOST, 5000, ssl = True, verify = False)
+
+        assert len(_warning_records(caplog)) == 1
+
+    def test_no_warning_when_https_verification_enabled(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            SynologyRPC(_HOST, 5000, ssl = True, verify = True)
+
+        assert _warning_records(caplog) == []
+
+    def test_no_verification_warning_on_plaintext_connections(self, caplog):
+        """verify=False is meaningless on a plain http connection (there is
+        no certificate to check) -- only the plaintext-credentials warning
+        is the right one there, not this one."""
+        with caplog.at_level(logging.WARNING):
+            SynologyRPC(_HOST, 5000, ssl = False, verify = False)
+
+        assert _warning_records(caplog) == []
+
+    def test_ca_bundle_path_counts_as_verification_enabled(self, caplog, tmp_path):
+        bundle = tmp_path / 'ca.pem'
+        bundle.write_text('cert')
+        with caplog.at_level(logging.WARNING):
+            SynologyRPC(_HOST, 5000, ssl = True, verify = str(bundle))
+
+        assert _warning_records(caplog) == []
+
+
+class TestNoSensitiveDataInWarnings:
+
+    def test_credential_values_do_not_appear_in_any_warning(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            SynologyRPC(_HOST, 5000, username = _USERNAME, password = _PASSWORD, ssl = False)
+            SynologyRPC(_HOST, 5000, ssl = True, verify = False)
+
+        assert _USERNAME not in caplog.text
+        assert _PASSWORD not in caplog.text
+
+    def test_host_does_not_appear_in_any_warning(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            SynologyRPC(_HOST, 5000, username = _USERNAME, password = _PASSWORD, ssl = False)
+            SynologyRPC(_HOST, 5000, ssl = True, verify = False)
+
+        assert _HOST not in caplog.text

--- a/tests/unit/test_synology_ssl_warnings.py
+++ b/tests/unit/test_synology_ssl_warnings.py
@@ -21,6 +21,16 @@ The message must name the setting that fixes the problem, never the value,
 the host, or a filesystem path -- the project's log-privacy floor
 (PrivacyFilter, CLAUDE.md) applies even though this text doesn't go through
 `%`-args a caller controls.
+
+T17 follow-up A2: both warnings are unbounded per-call, so an operator
+running with the unsafe default sees one on every single download -- which
+is self-defeating, since it trains them to scroll past the exact line added
+so they wouldn't miss it. They now route through `log_suppressed`
+(`couchpotato/core/logger.py:140`), keyed independently so plaintext-
+credentials and verify-disabled don't mask each other, with `now` injected
+through `SynologyRPC`'s own `now=` parameter rather than sleeping or
+patching `time.monotonic` (patching the clock has already produced a
+recorded false positive on this repo -- it also freezes `date.today()`).
 """
 import logging
 
@@ -115,4 +125,82 @@ class TestNoSensitiveDataInWarnings:
             SynologyRPC(_HOST, 5000, username = _USERNAME, password = _PASSWORD, ssl = False)
             SynologyRPC(_HOST, 5000, ssl = True, verify = False)
 
+        assert _HOST not in caplog.text
+
+
+class TestSuppressionOfRepeatedWarnings:
+    """An unbounded warning on every download is self-defeating -- the
+    operator learns to scroll past the exact line added so they wouldn't
+    miss it -- but "only warn once ever" loses the signal that it's an
+    ONGOING misconfiguration, not a one-off. `log_suppressed`'s contract
+    keeps both: the first occurrence in full, one "further messages
+    withheld" notice, silence until the window passes, then the next
+    occurrence in full WITH the count withheld.
+
+    `now` is injected via SynologyRPC's own `now=` parameter, which flows
+    straight through to `log_suppressed` -- not by sleeping (300s default
+    window) and not by patching `time.monotonic` (this repo has a recorded
+    false positive from patching a module-level clock: it also freezes
+    `date.today()`, per couchpotato/core/logger.py's own docstring).
+    """
+
+    def test_first_occurrence_emits_in_full(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            SynologyRPC(_HOST, 5000, username = _USERNAME, password = _PASSWORD, ssl = False, now = 0)
+
+        records = _warning_records(caplog)
+        assert len(records) == 1
+        assert 'ssl' in records[0].getMessage()
+
+    def test_burst_within_window_does_not_repeat_the_full_message(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            for _ in range(5):
+                SynologyRPC(_HOST, 5000, username = _USERNAME, password = _PASSWORD, ssl = False, now = 0)
+
+        # 1 full message + 1 "repeating" notice -- not 5 full messages.
+        assert len(_warning_records(caplog)) == 2
+
+    def test_withheld_count_reported_after_window_passes(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            for _ in range(4):
+                SynologyRPC(_HOST, 5000, username = _USERNAME, password = _PASSWORD, ssl = False, now = 0)
+            # LOG_SUPPRESSION_WINDOW is 300s -- 301 is past it.
+            SynologyRPC(_HOST, 5000, username = _USERNAME, password = _PASSWORD, ssl = False, now = 301)
+
+        records = _warning_records(caplog)
+        # occurrence 1 (full) + occurrence 2 (repeating notice, occurrences
+        # 3-4 silent) + occurrence 5 (full, with the withheld count).
+        assert len(records) == 3
+        assert 'suppressed' in records[-1].getMessage()
+
+    def test_two_warning_keys_do_not_suppress_each_other(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            SynologyRPC(_HOST, 5000, username = _USERNAME, password = _PASSWORD, ssl = False, now = 0)
+            SynologyRPC(_HOST, 5000, ssl = True, verify = False, now = 0)
+
+        # Both are first occurrences of DIFFERENT keys, so both fire in
+        # FULL -- neither key's history should hold the other back. A bare
+        # count of 2 does not prove this: sharing one key for both warnings
+        # also produces 2 records (one full message + one "repeating"
+        # notice), so each record's content is checked explicitly rather
+        # than just how many there are.
+        records = _warning_records(caplog)
+        assert len(records) == 2
+        messages = [r.getMessage() for r in records]
+        assert any('"ssl"' in m and 'unencrypted' in m for m in messages), (
+            'the plaintext-credentials warning must appear in full')
+        assert any('"ssl_verify"' in m and 'verification' in m for m in messages), (
+            'the verify-disabled warning must appear in full')
+        assert not any('repeating' in m for m in messages), (
+            'neither warning should have been suppressed by the other key'
+        )
+
+    def test_credential_values_do_not_appear_even_in_the_withheld_notice(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            for _ in range(4):
+                SynologyRPC(_HOST, 5000, username = _USERNAME, password = _PASSWORD, ssl = False, now = 0)
+            SynologyRPC(_HOST, 5000, username = _USERNAME, password = _PASSWORD, ssl = False, now = 301)
+
+        assert _USERNAME not in caplog.text
+        assert _PASSWORD not in caplog.text
         assert _HOST not in caplog.text

--- a/tests/unit/test_telegrambot_notification_exception_handling.py
+++ b/tests/unit/test_telegrambot_notification_exception_handling.py
@@ -1,0 +1,88 @@
+"""T17 review finding 2 (2026-08-11): `TelegramBot.notify` had no
+try/except around its `requests.post` call at all -- lower severity than
+Discord's finding 1 (same underlying cause), but the same shape: the
+`ReadTimeout`/`ConnectionError` the S113 timeout fix (`_REQUEST_TIMEOUT`)
+makes reachable against an unresponsive host now propagates UNCAUGHT out
+of `notify()`, instead of the module logging its own diagnostic. That
+surfaces as a generic "Failed running event handler" traceback rather than
+the `log.error('Could not send notification to TelegramBot...')` line this
+module already has for the wrong-status-code case.
+
+Consistency matters here: all three downloaders/notifiers touched by T17
+(Synology, Discord, Telegram) now share the S113 timeout fix, so all three
+must handle the timeout it makes reachable the same way -- caught, logged,
+`notify()` returns False.
+"""
+import logging
+
+import requests
+from unittest.mock import patch
+
+from couchpotato.core.notifications import telegrambot as telegrambot_module
+from couchpotato.core.notifications.telegrambot import TelegramBot
+
+
+def _conf(**overrides):
+    values = {'bot_token': 'FAKE:TOKEN', 'receiver_user_id': '12345'}
+    values.update(overrides)
+    return lambda k, **kw: values.get(k, kw.get('default', ''))
+
+
+class TestTelegramBotNotifyExceptionPath:
+
+    def test_a_request_exception_returns_false_without_raising(self):
+        notifier = TelegramBot.__new__(TelegramBot)
+
+        with patch.object(notifier, 'conf', side_effect = _conf()), \
+             patch.object(telegrambot_module.requests, 'post',
+                          side_effect = requests.exceptions.ReadTimeout('timed out')):
+            result = notifier.notify(message = 'a movie was snatched', data = {})
+
+        assert result is False
+
+    def test_a_request_exception_is_logged_by_this_module_not_left_uncaught(self, caplog):
+        notifier = TelegramBot.__new__(TelegramBot)
+
+        with caplog.at_level(logging.ERROR), \
+             patch.object(notifier, 'conf', side_effect = _conf()), \
+             patch.object(telegrambot_module.requests, 'post',
+                          side_effect = requests.exceptions.ReadTimeout('timed out')):
+            notifier.notify(message = 'a movie was snatched', data = {})
+
+        records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(records) == 1, 'exactly one error must be logged, not left to propagate uncaught'
+        assert 'timed out' in records[0].getMessage()
+
+    def test_the_200_success_path_still_works(self):
+        """Sanity check: wrapping the call in try/except must not disturb
+        the existing success path."""
+        notifier = TelegramBot.__new__(TelegramBot)
+
+        class _FakeResponse:
+            status_code = 200
+            text = 'ok'
+
+        with patch.object(notifier, 'conf', side_effect = _conf()), \
+             patch.object(telegrambot_module.requests, 'post', return_value = _FakeResponse()):
+            result = notifier.notify(message = 'a movie was snatched', data = {})
+
+        assert result is True
+
+    def test_the_non_200_status_path_still_works(self, caplog):
+        """Sanity check: the pre-existing wrong-status-code branch (a
+        DIFFERENT failure mode from a raised exception) must be untouched."""
+        notifier = TelegramBot.__new__(TelegramBot)
+
+        class _FakeResponse:
+            status_code = 403
+            text = 'forbidden'
+
+        with caplog.at_level(logging.ERROR), \
+             patch.object(notifier, 'conf', side_effect = _conf()), \
+             patch.object(telegrambot_module.requests, 'post', return_value = _FakeResponse()):
+            result = notifier.notify(message = 'a movie was snatched', data = {})
+
+        assert result is False
+        records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(records) == 1
+        assert 'forbidden' in records[0].getMessage()

--- a/tests/unit/test_telegrambot_notification_timeout.py
+++ b/tests/unit/test_telegrambot_notification_timeout.py
@@ -1,0 +1,42 @@
+"""T17 follow-up D (python:S113): `TelegramBot.notify` calls `requests.post`
+with no timeout -- same defect class as the Synology and Discord fixes,
+found by the same rule once it was wired into the gate.
+
+Reachable on every real notification: `Notification.listen_to` includes
+`movie.snatched` and `movie.downloaded`, both genuine event producers, and
+dispatch is synchronous on the caller's thread. An unresponsive Telegram
+host parks that thread indefinitely.
+
+30s, not Synology's 60s: this call carries a short JSON payload, not a file
+upload, so the house default (Plugin.urlopen, rtorrent_.py's _RPC_TIMEOUT)
+applies.
+"""
+from unittest.mock import MagicMock, patch
+
+from couchpotato.core.notifications import telegrambot as telegrambot_module
+from couchpotato.core.notifications.telegrambot import TelegramBot
+
+
+def _conf(**overrides):
+    values = {'bot_token': 'FAKE:TOKEN', 'receiver_user_id': '12345'}
+    values.update(overrides)
+    return lambda k, **kw: values.get(k, kw.get('default', ''))
+
+
+class TestTelegramBotNotificationTimeout:
+    """Assert on the actual value reaching requests.post, not merely that
+    the kwarg is present -- a presence-only check cannot tell 30 from 0."""
+
+    def test_notify_passes_the_named_timeout_constant(self):
+        notifier = TelegramBot.__new__(TelegramBot)
+
+        mock_response = MagicMock(status_code = 200, text = 'ok')
+        with patch.object(notifier, 'conf', side_effect = _conf()), \
+             patch.object(telegrambot_module.requests, 'post', return_value = mock_response) as mock_post:
+            notifier.notify(message = 'a movie was snatched', data = {})
+
+        assert mock_post.call_args.kwargs['timeout'] == telegrambot_module._REQUEST_TIMEOUT
+        assert mock_post.call_args.kwargs['timeout'] == 30
+
+    def test_timeout_constant_matches_house_default(self):
+        assert telegrambot_module._REQUEST_TIMEOUT == 30


### PR DESCRIPTION
Fixes the three SonarQube findings that survived triage (T17), plus what
reviewing them turned up. Nothing was touched in SonarQube: the rating
moves when the code does, after a re-scan.

## The three findings

**`python:S4830` — credentials over an unverified, plaintext connection**
(`downloaders/synology.py`). The `SYNO.API.Auth` login carries the
operator's username and password, and the call hard-coded both
`verify = False` and an `http://` scheme.

Adds `ssl` / `ssl_verify` / `ssl_ca_bundle`, imitating the options
`rtorrent_.py` already ships rather than inventing a shape, and hoists
`getVerifySsl` to `DownloaderBase` so there is one implementation.

That hoist carried the trap worth knowing about: a downloader with no
`ssl_verify` option gets `None` from `conf()`, which the original
returns `False` for — so a naive hoist would have silently disabled
certificate checking for every downloader inheriting it. The base
version treats absent as verify-ON, and that is the guard the mutation
testing was aimed at.

**What this does NOT do.** `ssl` still defaults to 0, so a default
install still sends those credentials over plaintext. Flipping the
default would break every install pointing at DSM's port 5000. The risk
is now visible and fixable, not eliminated — which is why the warnings
below are part of the fix rather than a nicety.

**`python:S2612` — 0o777 on a failed delete, then unbounded recursion**
(`_base/updater/main.py`). Now owner-only, one bounded retry, `None`
filename propagates, and it refuses to chmod a symlink — `os.stat` and
`os.chmod` both follow links, and this runs on freshly-extracted archive
content.

**`python:S5247` — Jinja autoescape off** (`plugins/base.py`).
`autoescape=True`. The method is kept, not deleted: it has no in-repo
caller, but it is public on `Plugin` and inherited by third-party
plugins, so "no callers here" is not evidence of none.

## The unsafe states are no longer silent

A WARNING fires when credentials are about to cross a plaintext
connection, and when https verification is off. Both route through
`log_suppressed` with independent keys — a fresh `SynologyRPC` is built
per download, so an unbounded warning would fire on every one and train
the operator to scroll past the line added so they would not miss it.
Neither names a host, path or credential value.

## What review caught, including two of mine

- **The TLS fix was unguarded on `download()`** — the path that actually
  sends the credentials. Reverting the wiring there left the full suite
  green at 3345 passed. The tests only drove `test()`, the connectivity
  check. This was the exact defect shape the task exists to fix,
  reproduced inside the task's own tests.
- **Owner-write-only broke what `removeDir` is for.** Measured on a real
  filesystem: a directory needs owner r+w+x for `rmtree` to descend, so
  `S_IWUSR` turns `0o400` into `0o600` and still fails. The finding was
  "world-writable", not "more than write". Now `S_IRWXU`, and the test
  was rewritten against a real filesystem because the old one mocked
  `rmtree` to succeed regardless of what the chmod did.
- **The remediation the warning asked for would break downloads.**
  Enabling `ssl` alone yields `https://host:5000`, and DSM serves https
  on 5001. An operator who obeyed the warning got a traceback, and the
  rational response was to turn it back off. The text now names the port
  and where the setting lives.
- **Two more unbounded `requests.post` calls** in the Discord and
  Telegram notifiers, on the same synchronous snatch thread — and the
  `S` rule family was absent from the gate's `select`, so `ruff check .`
  reported "All checks passed" while they existed. `S113` is now wired
  in via `extend-select`, which `ci.yml` already described as the
  intended path as rules are cleared. Proven load-bearing: removing a
  timeout now fails `ruff check .`.

## Measured, and deliberately NOT changed

`ruff S202` flags `tarfile.extractall()` and `zipfile.extractall()` in
the updater. Both are contained, for two different reasons:

- tarfile: a tar carrying `../escaped.txt` raises
  `OutsideDestinationError` on Python 3.14, which applies the `data`
  filter by default. **Reopen if this project ever supports < 3.14.**
- zipfile: a zip carrying `../escaped.txt` and `/abs_escaped.txt` put
  both inside the destination. `zipfile` sanitises member names itself,
  so the version condition does not apply to that line.

An earlier draft of the plan entry cited both lines as tarfile from a
tar-only measurement, giving a confidently wrong reopen condition. Both
branches were driven before correcting it.

`telegrambot.py` logs `token=%s` on a failed send, which looked like a
secrets-in-logs breach. Driving `PrivacyFilter` shows it renders as
`token=xxx`. Not a leak; left alone.

## Verification

`make verify` green (`GATE_RC=0`). Every new guard mutation-proven in
both directions where it encodes an exception, with the mutation
hash-confirmed to have landed and the file byte-identical after restore.

Reviewed by the multi-lens harness plus an adversarial verifier. Its
most useful catch was a test that passed against a deliberately broken
build: a key-independence assertion checking only `len(records) == 2`,
where the broken form also produces two records. Strengthened to assert
content.

**Recorded as a spec bug:** T17 was built and reviewed with zero
acceptance criteria, because tasks added mid-plan skip the planning
cycle where criteria are written. Every finding had to be discovered
rather than checked against a contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
