### PR TITLE
T13: remove the session-secret readability probe that could not detect an unreadable store

### DIFF
--- a/couchpotato/__init__.py
+++ b/couchpotato/__init__.py
@@ -566,6 +566,20 @@ def ensure_session_secret(db=None) -> str:
     verified login: the write goes through the same compare-and-swap writer
     that makes concurrent creates safe, and a login is a rare ceremony that has
     already spent ~166 ms in bcrypt.
+
+    **This is the AC-SEC-33 enforcement point.** The read this function does
+    (`_session_secret_row`, straight against the adapter) is not wrapped in
+    anything that swallows exceptions, unlike `Settings.getProperty` (which
+    `get_session_secret` goes through and which logs at DEBUG and returns None
+    on any fault). So a store that genuinely cannot be read makes THIS function
+    raise, before it ever reaches the insert/update that would create a fresh
+    secret. `login_post` is the only caller that can reach this after
+    `not secret`, and its `except Exception` around the call is where "fail
+    closed on a raising store" actually happens -- there is deliberately no
+    separate readability probe: T13 removed one (`session_secret_store_is_readable`)
+    because `Env.prop` never raises in production (the same blanket `except` it
+    goes through), so the probe answered "readable" unconditionally and the
+    real protection was always this propagation, not the probe.
     """
     db = get_db() if db is None else db
 
@@ -640,27 +654,6 @@ def rotate_session_secret(db=None) -> str:
                  'The api_key is unchanged, so scripts, the userscript and '
                  'every downloader keep working.')
         return secret
-
-
-def session_secret_store_is_readable() -> bool:
-    """Can we tell "this install has no secret" from "we cannot see"?
-
-    The two are indistinguishable from `get_session_secret`, which answers None
-    to both -- and D14's login bootstrap must act on only ONE of them. A row
-    that is absent should be created; a store that RAISED must be left alone,
-    because writing a fresh secret over a row we cannot read would invalidate
-    every live session on the strength of a transient fault, and AC-SEC-33 and
-    AC-ARCH-6 both say a raising store means fail closed rather than fix it.
-
-    Uses the same read path `get_session_secret` uses, deliberately: a probe
-    down a different path would answer a different question, which is exactly
-    how the first version of this got it wrong.
-    """
-    try:
-        Env.prop(SESSION_SECRET_PROPERTY)
-    except Exception:
-        return False
-    return True
 
 
 def get_session_secret():
@@ -1361,20 +1354,22 @@ def create_app(api_key: str, web_base: str, static_dir: str = None) -> FastAPI:
         # of this source a valid session on every install.
         secret = get_session_secret()
 
-        if not secret and session_secret_store_is_readable():
+        if not secret:
             # D14. THE ONLY REQUEST PATH THAT MAY CREATE A SECRET, and it is
             # reached only here: after `check_password` has accepted the
-            # submitted password, and only when the store is READABLE and
-            # simply has no secret in it.
+            # submitted password.
             #
-            # That second condition is not belt-and-braces. `get_session_secret`
-            # answers None both to "this install has never had a secret" and to
-            # "the property store just raised", and those need opposite
-            # responses: create in the first, fail closed in the second.
-            # Creating on a raising store would write a fresh secret over a row
-            # nobody could read, signing every live session out on the strength
-            # of a transient fault -- and AC-SEC-33 says a raising store issues
-            # no cookie. Conflating them is what the first version of this did.
+            # `ensure_session_secret` is both the create-if-absent call AND the
+            # AC-SEC-33 enforcement point (see its docstring): a store that
+            # simply has no secret returns normally with a fresh one, while a
+            # store that cannot be READ raises out of `_session_secret_row`
+            # before any write is attempted, straight into the `except` below.
+            # There is deliberately no separate readability check here -- T13
+            # removed `session_secret_store_is_readable()`, which read via the
+            # same `Env.prop` / `Settings.getProperty` path as `get_session_secret`
+            # above and inherited its blanket `except Exception: return None`,
+            # so it answered "readable" for a store that was, measured, on
+            # fire. It was never load-bearing: this `try/except` was.
             #
             # D2 said "never on a request path" for two measured reasons, and
             # neither survives the move: `Settings.setProperty`'s unguarded
@@ -1397,10 +1392,11 @@ def create_app(api_key: str, web_base: str, static_dir: str = None) -> FastAPI:
             try:
                 secret = ensure_session_secret()
             except Exception:
-                # Fail closed, and say so. Redirecting with no cookie sends the
-                # operator back to the login page, which is honest: they are
-                # not signed in. Signing with '' or a constant to avoid the
-                # loop would hand a valid session to every reader of this file.
+                # AC-SEC-33's fail-closed branch. Redirecting with no cookie
+                # sends the operator back to the login page, which is honest:
+                # they are not signed in. Signing with '' or a constant to
+                # avoid the loop would hand a valid session to every reader of
+                # this file.
                 log.error('A correct password was accepted but the session '
                           'signing secret could not be created, so no session '
                           'was issued and the login cannot complete. Check '

--- a/couchpotato/__init__.py
+++ b/couchpotato/__init__.py
@@ -570,16 +570,21 @@ def ensure_session_secret(db=None) -> str:
     **This is the AC-SEC-33 enforcement point.** The read this function does
     (`_session_secret_row`, straight against the adapter) is not wrapped in
     anything that swallows exceptions, unlike `Settings.getProperty` (which
-    `get_session_secret` goes through and which logs at DEBUG and returns None
-    on any fault). So a store that genuinely cannot be read makes THIS function
-    raise, before it ever reaches the insert/update that would create a fresh
-    secret. `login_post` is the only caller that can reach this after
-    `not secret`, and its `except Exception` around the call is where "fail
-    closed on a raising store" actually happens -- there is deliberately no
-    separate readability probe: T13 removed one (`session_secret_store_is_readable`)
-    because `Env.prop` never raises in production (the same blanket `except` it
-    goes through), so the probe answered "readable" unconditionally and the
-    real protection was always this propagation, not the probe.
+    `get_session_secret` goes through). So a store that genuinely cannot be
+    read makes THIS function raise, before it ever reaches the insert/update
+    that would create a fresh secret. `login_post` is the only caller that
+    can reach this after `not secret`, and its `except Exception` around the
+    call is where "fail closed on a raising store" actually happens -- there
+    is deliberately no separate readability probe: T13 removed one
+    (`session_secret_store_is_readable`), because it read via `Env.prop` ->
+    `Settings.getProperty`, whose blanket `except Exception:` swallows the
+    ordinary read fault and returns None -- so for the fault shape that
+    matters (a store whose reads simply raise), the probe answered
+    "readable" and never protected anything. (`getProperty` does have one
+    narrower path that DOES propagate -- a `ValueError` on the first read
+    followed by a failing retry in its own recovery branch, which is not the
+    case this probe existed to catch.) The real protection was always this
+    function's propagation, not the probe.
     """
     db = get_db() if db is None else db
 
@@ -979,7 +984,8 @@ LOGIN_MESSAGES = {
         'error',
         'Your password was correct, but the server could not start a session, '
         'so you are not signed in. This is a server problem, not your '
-        'password. Check that the database is writable, then try again.',
+        'password. Check that the database is readable and writable, then '
+        'try again.',
     ),
     'rate_limited_signout': (
         'error',
@@ -1400,7 +1406,7 @@ def create_app(api_key: str, web_base: str, static_dir: str = None) -> FastAPI:
                 log.error('A correct password was accepted but the session '
                           'signing secret could not be created, so no session '
                           'was issued and the login cannot complete. Check '
-                          'that the database is writable. %s',
+                          'that the database is readable and writable. %s',
                           traceback.format_exc())
                 secret = None
 
@@ -1413,27 +1419,30 @@ def create_app(api_key: str, web_base: str, static_dir: str = None) -> FastAPI:
             # down. Failing closed is unchanged -- still no cookie.
             return render_login_page(reason='session_not_created', status_code=503)
 
-        if secret:
-            remember_me = tryInt(form.get('remember_me', 0)) > 0
-            lifetime = SESSION_LIFETIME_REMEMBERED if remember_me else SESSION_LIFETIME
-            # `max_age` is UNCHANGED from before this PR: 30 days when
-            # "remember me" is ticked, absent otherwise so the cookie dies
-            # with the browser process. Absent is the more conservative of
-            # the two and it is what operators already have; the reason it
-            # was called out as a defect was that the value stayed valid
-            # SERVER-side regardless, and that is what the signed expiry
-            # above fixes. Max-Age was never enforcement anyway -- a replay
-            # simply omits it.
-            #
-            # Every other attribute comes from `session_cookie_attributes`,
-            # which the logout deletion uses too so the two cannot drift.
-            response.set_cookie(
-                SESSION_COOKIE_NAME,
-                mint_session_token(secret, lifetime),
-                max_age=lifetime if remember_me else None,
-                **session_cookie_attributes(),
-            )
-            _expire_legacy_root_cookie(response)
+        # Reached only when `secret` is truthy: the `if not secret:` above
+        # already returned. A second `if secret:` guard here always evaluated
+        # the same and was dead weight -- exactly the shape D17 argues should
+        # be deleted rather than repaired (T13 follow-up).
+        remember_me = tryInt(form.get('remember_me', 0)) > 0
+        lifetime = SESSION_LIFETIME_REMEMBERED if remember_me else SESSION_LIFETIME
+        # `max_age` is UNCHANGED from before this PR: 30 days when
+        # "remember me" is ticked, absent otherwise so the cookie dies
+        # with the browser process. Absent is the more conservative of
+        # the two and it is what operators already have; the reason it
+        # was called out as a defect was that the value stayed valid
+        # SERVER-side regardless, and that is what the signed expiry
+        # above fixes. Max-Age was never enforcement anyway -- a replay
+        # simply omits it.
+        #
+        # Every other attribute comes from `session_cookie_attributes`,
+        # which the logout deletion uses too so the two cannot drift.
+        response.set_cookie(
+            SESSION_COOKIE_NAME,
+            mint_session_token(secret, lifetime),
+            max_age=lifetime if remember_me else None,
+            **session_cookie_attributes(),
+        )
+        _expire_legacy_root_cookie(response)
 
         return response
 

--- a/couchpotato/__init__.py
+++ b/couchpotato/__init__.py
@@ -1540,7 +1540,7 @@ def create_app(api_key: str, web_base: str, static_dir: str = None) -> FastAPI:
             log.error('Sign-out FAILED: the session signing secret could not '
                       'be rotated, so every existing session is STILL VALID on '
                       'every device. Nothing has been signed out. Check that '
-                      'the database is writable and try again. %s',
+                      'the database is readable and writable and try again. %s',
                       traceback.format_exc())
             # A real page rather than the plain-text 500 this used to be
             # (spec gap 7). The BEHAVIOUR is unchanged and deliberately so --

--- a/specs/PR2B-SESSION-COOKIE.md
+++ b/specs/PR2B-SESSION-COOKIE.md
@@ -190,7 +190,7 @@ They are decided here so the implementer does not decide them silently.
 - AC-SEC-30: The cookie is not the `api_key` and the old branch is gone rather than kept as a fallback: after login the cookie value does not contain `Env.setting('api_key')` as a substring (asserted against a realistic 32-character key), and `get_current_user` refuses a cookie whose value equals the `api_key`. Proven load-bearing by reinstating the `hmac.compare_digest(user, api_key)` branch at `couchpotato/__init__.py:199-202` and watching a named test go red. [merged with AC-QA-1, AC-QA-2, AC-QA-3, AC-SIMP-9]
 - AC-SEC-31: Forgery is refused in every shape, each a separate named test rather than a loop over one assertion: no signature; empty signature; truncated signature; a signature produced with a different secret; a payload mutated while keeping the original signature; a cookie whose payload is valid but whose signature is the payload itself. [merged with AC-QA-9]
 - AC-SEC-32: The signing secret is generated with the `secrets` module, carries at least 32 bytes of entropy, and two freshly created installs produce different secrets. It is never derived from `api_key`, `uuid4().hex`, `md5()`, time, the password hash, or any hardcoded literal. A test asserts the length and uniqueness properties and, via `inspect.getsource` (the idiom at `tests/unit/test_http_client.py:244`), that the generator is `secrets`.
-- AC-SEC-33: Fail closed when the secret is unavailable: if the property read or write raises, login issues no cookie and every session validation returns not-authenticated; the code never signs or verifies with an empty string, `None` or a constant fallback; one ERROR is logged naming the `config.ini` recovery path. Proven by monkeypatching `Settings.getProperty` to raise and asserting no `Set-Cookie` and refusal of a previously valid cookie. [merged with AC-QA-20, AC-ARCH-6, AC-OPS-42, AC-OPS-43, AC-DATA-6]
+- AC-SEC-33: Fail closed when the secret is unavailable: if the property read or write raises, login issues no cookie and every session validation returns not-authenticated; the code never signs or verifies with an empty string, `None` or a constant fallback; one ERROR is logged naming the `config.ini` recovery path. **Proof method (revised by T13/D17 — the original prescribed a fixture that could not prove this):** for the login-issuance half, break the read at `SQLiteAdapter._query_index` (the layer both `Settings.getProperty`, via `db.get`, and `_session_secret_row`, via `db.query`, resolve to for the `property` index — a patch of `Settings.getProperty` alone leaves `_session_secret_row`'s adapter read working and does not exercise this AC at all) and assert BOTH halves: no `Set-Cookie` is issued, AND no secret is written to the store. For the previously-valid-cookie half, `Settings.getProperty` is the real path `get_current_user` reads through, so patching it there is the correct fault and stays as-is. [merged with AC-QA-20, AC-ARCH-6, AC-OPS-42, AC-OPS-43, AC-DATA-6]
 - AC-SEC-34: The signature comparison is constant-time (`hmac.compare_digest` or equivalent), asserted at the verification function's source, and a plain `==` in that position fails the test. Both the signature check and any token-identifier check are covered.
 - AC-SEC-35: Expiry is enforced by the server, not the browser: the signed payload carries an absolute expiry checked on every request, so a cookie whose embedded expiry has passed is refused even when the client replays it with `Max-Age` and `Expires` stripped. Both D3 lifetimes have a boundary test (just inside accepted, just outside refused), driven by an injected clock, never by `sleep` and never by patching `time.time` globally. [merged with AC-QA-7, AC-QA-8, AC-A11Y-11]
 - AC-SEC-36: Logout revokes rather than forgets: a cookie captured before the logout route is replayed on a fresh client afterwards and is refused. A test asserting only the `Set-Cookie` deletion header does not satisfy this, because that is the behaviour the spec calls the defect. The test goes red if the D1 rotation is removed. [merged with AC-PROD-1, AC-QA-5, AC-DATA-7, AC-OPS-53]
@@ -624,12 +624,28 @@ against a store whose reads genuinely raise:
 `Settings.getProperty` wraps its own read in a blanket `except Exception:`
 that logs at DEBUG and returns `None` — a design predating this PR, kept so a
 missing property never crashes an unrelated settings read. `Env.prop` calls
-straight through it, so nothing the probe called ever raised in production,
-and `session_secret_store_is_readable()` answered `True` unconditionally: for
-an absent secret AND for a store that was, measured, unreadable. Its own test
+straight through it, so for the ordinary read fault (the store simply raises)
+the probe's own `except` was unreachable and `session_secret_store_is_readable()`
+answered `True` — for BOTH an absent secret and a store that was, measured,
+unreadable, which is the exact ambiguity it existed to resolve. Its own test
 passed only by monkeypatching `Settings.getProperty` itself to raise, which
 replaces the method wholesale and so never exercises the `except` inside it —
-proving the probe against a fault shape a real store cannot produce.
+proving the probe against a fault shape the ordinary broken-store case does
+not produce.
+
+**Correction, found by an adversarial re-drive of this exact claim:**
+`getProperty` is not unconditionally safe. Its `except ValueError:` recovery
+branch (`core/settings.py:648-650`, the corrupt-document path) makes its own,
+unwrapped `db.get(...)` call; if THAT call also raises, nothing catches it and
+the exception reaches `Env.prop` and the probe after all. Measured: a first
+read raising `ValueError` followed by a failing retry propagates out of
+`getProperty`. So the probe was not unconditionally `True` — it was `True`
+for the fault shape that matters (a store whose reads simply raise), which is
+the case a locked-out operator actually hits, and only reachable-`False` down
+a narrower path (corruption discovered, then the corruption-recovery read
+itself failing) that is not the case this probe existed to catch. The T13
+conclusion is unaffected by the correction; the original wording overstated
+what was measured.
 
 **Three attempts to fix the probe by repointing it were each worse than
 leaving it broken** (rule 11): pointing the probe at the adapter without also

--- a/specs/PR2B-SESSION-COOKIE.md
+++ b/specs/PR2B-SESSION-COOKIE.md
@@ -511,9 +511,9 @@ the lockout shape this spec exists to prevent, arriving by a different door.
   (AC-SEC-33) red on the first attempt — correctly, because creating a fresh
   secret over a row nobody can read signs every device out on the strength of a
   transient fault, and AC-ARCH-6 forbids the store's failure being "fixed" by
-  writing. The boundary is `session_secret_store_is_readable()`, which probes
-  down the SAME path `get_session_secret` uses; a probe down a different path
-  answers a different question.
+  writing. The boundary was `session_secret_store_is_readable()`, which probed
+  down the SAME path `get_session_secret` uses. **T13 (2026-08) found that
+  boundary could not do its job and removed it — see D17.**
 
 - **The rejection reasons are logged at INFO, not ERROR, and each carries its
   own suppression key.** INFO because a refused cookie is the ordinary outcome
@@ -596,8 +596,10 @@ writes a fresh secret over a row nobody can read, signing every live session out
 on the strength of a transient fault.
 
 **Amended:** the bootstrap fires only when the store is readable and simply has
-no secret in it. Implemented as `if not secret and
-session_secret_store_is_readable():` in `login_post`.
+no secret in it. Implemented (at the time) as `if not secret and
+session_secret_store_is_readable():` in `login_post`. **Superseded by D17: the
+"readable" half of that condition turned out to be unimplementable as a
+separate check, and the code no longer has one.**
 
 Recorded as a decision-quality note, not only a code note: an orchestrator
 decision that read as complete was not, and the check that caught it was running
@@ -609,6 +611,78 @@ Tranche E added one line (an `auth_off` marker) and asked whether it breaches
 AC-SIMP-3. Same ruling as `scripts/seed_e2e_data.py` and
 `scripts/check_test_traps.py`: AC-SIMP-3 governs "non-test, non-spec, non-docs"
 files. **No third amendment is needed; the nine-file product set holds.**
+
+## D17 (T13, 2026-08) — `session_secret_store_is_readable()` removed: it could not do its job
+
+D15 (both entries above) built the D14 amendment around a readability probe on
+the theory that "readable, but empty" and "raised" are answerable by asking
+`Env.prop(SESSION_SECRET_PROPERTY)` and seeing whether it raises. Measured
+against a store whose reads genuinely raise:
+
+    getProperty returned: None   <-- did NOT raise
+
+`Settings.getProperty` wraps its own read in a blanket `except Exception:`
+that logs at DEBUG and returns `None` — a design predating this PR, kept so a
+missing property never crashes an unrelated settings read. `Env.prop` calls
+straight through it, so nothing the probe called ever raised in production,
+and `session_secret_store_is_readable()` answered `True` unconditionally: for
+an absent secret AND for a store that was, measured, unreadable. Its own test
+passed only by monkeypatching `Settings.getProperty` itself to raise, which
+replaces the method wholesale and so never exercises the `except` inside it —
+proving the probe against a fault shape a real store cannot produce.
+
+**Three attempts to fix the probe by repointing it were each worse than
+leaving it broken** (rule 11): pointing the probe at the adapter without also
+moving `get_session_secret` made the two reads disagree, so a login issued a
+cookie while the secret was unreadable; pointing both at the adapter broke 22
+tests elsewhere that depended on `get_session_secret`'s existing
+swallow-and-return-None contract for the verification path (AC-ARCH-6 — that
+path must never write, and never raise into a request that carries no
+credential).
+
+**The actual fix is smaller: delete the probe.** Trace what it was gating.
+`login_post` calls `ensure_session_secret()` only after `not secret`; that
+function reads via `_session_secret_row`, straight against the
+`SQLiteAdapter` — no swallowing `except` between it and the caller. A store
+that cannot be read makes it raise, before any write is attempted, straight
+into the `try/except` already wrapped around the call in `login_post`. That
+`except` — logging the failure and leaving `secret = None`, which falls
+through to the 503 page — was always the real AC-SEC-33 enforcement. The
+probe's `True` answer for a raising store never mattered, because
+`ensure_session_secret` still failed the way AC-SEC-33 requires; the probe
+was dead weight that also lied about its own contract.
+
+**Behaviour is unchanged**, and that is the point of removing it rather than
+repairing it. With the probe: `not secret and session_secret_store_is_readable()`
+was `True and True` for both an absent and a raising store, so
+`ensure_session_secret()` ran either way. Without it: `not secret` alone
+reaches the same call, the same way, for the same two cases. Deleting a
+condition that always evaluated the same is behaviour-preserving by
+construction, not by re-review of every caller.
+
+`session_secret_store_is_readable()` is gone from `couchpotato/__init__.py`.
+The AC-SEC-33 enforcement point is documented where it is now true:
+`ensure_session_secret`'s docstring, and the `except Exception:` around its
+call in `login_post`.
+
+**A test was found vacuous by the same shape of measurement, and fixed rather
+than trusted:** `test_login_issues_no_cookie_when_the_secret_cannot_be_read`'s
+`broken_store` fixture patched `Settings.getProperty`, which
+`_session_secret_row` never calls — so the fixture broke the path
+`get_session_secret` reads and left the adapter path `ensure_session_secret`
+reads fully working. Run against the code with the probe already removed, the
+"broken" store happily served the existing secret row through
+`_session_secret_row` and the test's own claim (no cookie issued) went red:
+a cookie WAS issued. Fixed by patching `SQLiteAdapter._query_index` instead —
+the one primitive both `Settings.getProperty` (via `db.get`) and
+`_session_secret_row` (via `db.query`) resolve to for the `property` index, so
+one fault now genuinely breaks both real read paths, the way an unreadable
+store actually would. The equivalent fixture in
+`tests/unit/test_session_secret_recovery.py` had the identical defect and got
+the identical fix. A new test,
+`test_login_against_a_raising_store_creates_no_secret`, pins the half that
+mattered most and had no test of its own: that a raising store is not written
+to, independent of whether a cookie was issued.
 
 ## Known intermittent: `tests/e2e/suggestions.spec.ts:99`
 

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -521,7 +521,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       Do it with a working harness: assert first that a SUCCESSFUL save
       rotates, then that a failing one does not.
 
-- [ ] T13: `session_secret_store_is_readable()` cannot detect an unreadable store — state: queued (no deps)
+- [x] T13: `session_secret_store_is_readable()` cannot detect an unreadable store — state: **probe removed** (2026-08-11, option 2)
 
       Review Medium on #229, confirmed by execution and then **attempted and
       reverted**, which is why it is a task rather than a fix.
@@ -562,6 +562,37 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
 
       Option 2 is smaller and matches what already happens. Either way it is
       its own change on the authentication path, with its own review.
+
+      **Done, option 2.** The probe is gone; `ensure_session_secret`'s own
+      propagation is documented as the AC-SEC-33 enforcement point, at the
+      function and at `login_post`'s `except`, and the call-site comment no
+      longer describes a condition that does not exist. Recorded as D17 in
+      `specs/PR2B-SESSION-COOKIE.md`.
+
+      Behaviour-preserving under a REAL fault, and that was checked rather
+      than asserted: `SQLiteAdapter.get` and `.query` both route through
+      `_query_index`, so a store that cannot be read fails BOTH the
+      `getProperty` path and `_session_secret_row`, and no cookie is issued
+      with or without the probe.
+
+      **The test carrying the property was itself vacuous, which is the find
+      worth keeping.** `broken_store` patched `Settings.getProperty` to
+      raise — a fault that cannot occur, since that method's own blanket
+      `except` swallows what the layer beneath throws. It therefore never
+      exercised `ensure_session_secret`'s read at all. Proof it mattered:
+      with the old fixture retained, removing the probe made
+      `test_login_issues_no_cookie_when_the_secret_cannot_be_read` FAIL,
+      because the synthetic fault left the adapter read working, so a secret
+      was created and a cookie issued. The fixture now breaks
+      `_query_index`, the layer both real paths share.
+
+      A second test pins the other half independently: a login against a
+      raising store must write NO secret. No cookie is necessary but not
+      sufficient — writing a fresh secret over a row nobody could read signs
+      every OTHER device out, and inferring that from the cookie assertion
+      would leave it unguarded. Confirmed distinct: a mutation that mints an
+      in-memory fallback secret fails the cookie test and leaves the
+      no-write test green.
 
 - [ ] T11: a focus move that fails entirely tells only the developer console — state: queued (no deps)
 

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -586,6 +586,26 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       was created and a cookie issued. The fixture now breaks
       `_query_index`, the layer both real paths share.
 
+      **Spec bug, same as T17.** T13 shipped with no `AC-<LENS>-<n>`
+      criteria of its own, so review had only the task prose to check
+      against. Tasks added mid-plan skip the planning cycle where criteria
+      are written; that is the gap, not this task.
+
+      **A claim of mine in the first draft was false, and the adversarial
+      reviewer caught it as unproven before I disproved it.** I wrote that
+      `Env.prop` NEVER raises in production and that the probe answered
+      `True` unconditionally. Measured:
+
+          getProperty RAISED: RuntimeError: store down on the retry
+
+      `Settings.getProperty`'s `except ValueError:` recovery branch makes
+      its own `db.get` call outside any handler, so a corrupt-document read
+      followed by a failing retry propagates. The T13 conclusion is
+      unchanged — the probe was blind to the ordinary raising-store fault,
+      which is the one it existed to catch — but "unfalsified" is not
+      "true", and §7 says assert only what the repo proves. Corrected in
+      the code, in D17, and here.
+
       A second test pins the other half independently: a login against a
       raising store must write NO secret. No cookie is necessary but not
       sufficient — writing a fresh secret over a row nobody could read signs

--- a/tests/unit/test_login_page_messages.py
+++ b/tests/unit/test_login_page_messages.py
@@ -130,6 +130,12 @@ def _session_not_created_page(client, settings):
     `render_login_page` directly: the point of this guard is that some real
     path produces the message, and a direct call would prove only that the
     constant exists.
+
+    `ensure_session_secret` is patched to raise rather than the store itself,
+    because this test is about the MESSAGE the 503 page carries once secret
+    creation has failed, not about which real fault fails it -- that guard
+    lives in `test_session_secret_store.py::TestFailClosedWhenTheSecretIsUnavailable`,
+    against a genuinely broken `SQLiteAdapter`.
     """
     import couchpotato
     from couchpotato.core.helpers.variable import md5
@@ -137,14 +143,15 @@ def _session_not_created_page(client, settings):
     settings['password'] = md5(PASSWORD)
 
     original_get = couchpotato.get_session_secret
-    original_readable = couchpotato.session_secret_store_is_readable
+    original_ensure = couchpotato.ensure_session_secret
     couchpotato.get_session_secret = lambda: None
-    couchpotato.session_secret_store_is_readable = lambda: False
+    couchpotato.ensure_session_secret = lambda *args, **kwargs: (
+        (_ for _ in ()).throw(RuntimeError('store down')))
     try:
         response = client.post('/login/', data={'username': '', 'password': PASSWORD})
     finally:
         couchpotato.get_session_secret = original_get
-        couchpotato.session_secret_store_is_readable = original_readable
+        couchpotato.ensure_session_secret = original_ensure
 
     assert response.status_code == 503, response.status_code
     return response
@@ -649,13 +656,19 @@ class TestACorrectPasswordThatCannotStartASessionSaysSo:
     """
 
     def _login_with_a_broken_store(self, client, monkeypatch, settings):
+        """`ensure_session_secret` is patched to raise rather than the store
+        itself: these tests are about what the PAGE says once creation has
+        failed, not about which fault fails it (that is
+        `test_session_secret_store.py::TestFailClosedWhenTheSecretIsUnavailable`,
+        against a genuinely broken `SQLiteAdapter`)."""
         from couchpotato.core.helpers.variable import md5
         settings['password'] = md5(PASSWORD)
 
         import couchpotato
         monkeypatch.setattr(couchpotato, 'get_session_secret', lambda: None)
-        monkeypatch.setattr(couchpotato, 'session_secret_store_is_readable',
-                            lambda: False)
+        monkeypatch.setattr(
+            couchpotato, 'ensure_session_secret',
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError('store down')))
 
         return client.post('/login/', data={'username': '', 'password': PASSWORD})
 

--- a/tests/unit/test_session_secret_recovery.py
+++ b/tests/unit/test_session_secret_recovery.py
@@ -407,54 +407,53 @@ class TestAnUnreadableStoreIsNotAnAbsentSecret:
     The first version of the D14 change conflated them and turned
     `test_session_secret_store.py::test_login_issues_no_cookie_when_the_secret_
     cannot_be_read` red, which is the only reason this class exists.
+
+    Both tests below break the read at `SQLiteAdapter._query_index`, not at
+    `Settings.getProperty`. `getProperty` swallows whatever `_query_index`
+    raises in its own `except Exception:` and returns None, so patching
+    `getProperty` to raise bypasses that handler -- a fault a real store never
+    produces -- and never reaches `ensure_session_secret`'s read
+    (`_session_secret_row`, straight against the adapter), which is the one
+    that has to fail for either assertion below to mean anything. T13 deleted
+    `session_secret_store_is_readable()` for exactly this reason: it read via
+    `getProperty` too, and answered "readable" for a store whose real reads
+    raised.
     """
 
     def test_a_login_against_a_raising_store_issues_no_cookie(self, env, monkeypatch):
-        monkeypatch.setattr(
-            Settings, 'getProperty',
-            lambda self, identifier: (_ for _ in ()).throw(RuntimeError('store down')))
+        with monkeypatch.context() as m:
+            m.setattr(
+                SQLiteAdapter, '_query_index',
+                lambda self, *args, **kwargs: (_ for _ in ()).throw(RuntimeError('store down')))
 
-        session = TestClient(env.app, follow_redirects=False)
-        response = session.post('/login/', data={'username': '', 'password': PASSWORD})
+            session = TestClient(env.app, follow_redirects=False)
+            response = session.post('/login/', data={'username': '', 'password': PASSWORD})
 
         assert 'set-cookie' not in {k.lower() for k in response.headers}
 
     def test_a_login_against_a_raising_store_writes_nothing(self, env, monkeypatch):
-        """The dangerous half: a blind write over a row we cannot see."""
+        """The dangerous half: a blind write over a row we cannot see.
+
+        `secret_rows` reads through `_query_index` itself, so it is called
+        before the patch is applied and again after the `with` block has
+        undone it -- evaluating it while the patch is live would raise
+        instead of comparing.
+        """
         before = secret_rows(env.db)
         assert before, 'no secret to overwrite, so this proves nothing'
 
-        monkeypatch.setattr(
-            Settings, 'getProperty',
-            lambda self, identifier: (_ for _ in ()).throw(RuntimeError('store down')))
+        with monkeypatch.context() as m:
+            m.setattr(
+                SQLiteAdapter, '_query_index',
+                lambda self, *args, **kwargs: (_ for _ in ()).throw(RuntimeError('store down')))
 
-        TestClient(env.app, follow_redirects=False).post(
-            '/login/', data={'username': '', 'password': PASSWORD})
+            TestClient(env.app, follow_redirects=False).post(
+                '/login/', data={'username': '', 'password': PASSWORD})
 
         assert secret_rows(env.db) == before, (
             'a login rewrote the signing secret while the property store was '
             'raising, so a transient fault signs every device out'
         )
-
-    def test_the_probe_reports_a_raising_store_as_unreadable(self, env, monkeypatch):
-        from couchpotato import session_secret_store_is_readable
-
-        assert session_secret_store_is_readable() is True
-
-        monkeypatch.setattr(
-            Settings, 'getProperty',
-            lambda self, identifier: (_ for _ in ()).throw(RuntimeError('store down')))
-
-        assert session_secret_store_is_readable() is False
-
-    def test_an_absent_secret_still_reads_as_readable(self, env):
-        """Both directions: absent must NOT look like broken, or D14's whole
-        recovery never fires."""
-        from couchpotato import session_secret_store_is_readable
-
-        delete_the_secret(env.db)
-
-        assert session_secret_store_is_readable() is True
 
 
 class TestAFailedRecoveryDoesNotPretendToSucceed:

--- a/tests/unit/test_session_secret_store.py
+++ b/tests/unit/test_session_secret_store.py
@@ -1,11 +1,23 @@
 """The signing secret: where it lives, who may write it, and what happens
 when it is not there.
 
-Driven against a REAL `SQLiteAdapter` and the REAL `Settings.getProperty`, not
-a dict double. The defects this file exists to catch all live in the seam
-between the two: a stub that tolerated raw bytes would hide the fact that
-`setProperty` mangles them, and a stub with no `_rev` would hide the
+Driven against a REAL `SQLiteAdapter`, not a dict double. The defects this
+file exists to catch all live in the seam between the adapter and
+`Settings.getProperty`: a stub that tolerated raw bytes would hide the fact
+that `setProperty` mangles them, and a stub with no `_rev` would hide the
 compare-and-swap that turns a lost race into a duplicate row.
+
+Two read paths reach that adapter, and a broken-store test has to name the
+one it means (T13/D17): `get_current_user`'s verification reads through the
+REAL `Settings.getProperty`, so breaking THAT is the correct fault for the
+verification-path tests below. `ensure_session_secret`'s bootstrap
+(`_session_secret_row`) reads the adapter directly and never touches
+`getProperty` -- breaking `getProperty` alone leaves that read working and
+proves nothing about it, which is exactly how
+`test_login_issues_no_cookie_when_the_secret_cannot_be_read` passed once
+while a raising store issued a cookie. Those tests break
+`SQLiteAdapter._query_index` instead, the layer both paths resolve to for the
+`property` index.
 
 Companion to `test_session_token.py`, which covers the pure sign/verify seam.
 """
@@ -525,6 +537,13 @@ class TestVerificationNeverWrites:
         writes = []
         monkeypatch.setattr('couchpotato._write_session_secret',
                             lambda *args, **kwargs: writes.append(args))
+        # `Settings.getProperty` is the RIGHT fault here, not the discredited
+        # one: `get_current_user` reads via `Env.prop` -> `getProperty`, so
+        # this breaks the actual path being exercised. It is only the wrong
+        # fault for `ensure_session_secret`'s bootstrap read
+        # (`_session_secret_row`, straight against the adapter), which is why
+        # the login-creation tests in `TestFailClosedWhenTheSecretIsUnavailable`
+        # break `SQLiteAdapter._query_index` instead (T13/D17).
         monkeypatch.setattr(Settings, 'getProperty',
                             lambda self, identifier: (_ for _ in ()).throw(RuntimeError('store down')))
 
@@ -712,12 +731,21 @@ class TestFailClosedWhenTheSecretIsUnavailable:
         assert 'set-cookie' not in response.headers
 
     def test_login_against_a_raising_store_creates_no_secret(self, env, monkeypatch):
-        """The other half of AC-SEC-33: no cookie is necessary but not
-        sufficient. Writing a fresh secret over a row that could not be read
-        would invalidate every OTHER live session on the strength of a
-        transient fault, even though this particular login gets no cookie --
-        so this is pinned independently rather than inferred from the cookie
-        assertion above.
+        """The other half of AC-SEC-33 for the CREATE-on-unreadable-store case:
+        no cookie is necessary but not sufficient. There is no pre-existing
+        secret here (asserted below) -- a store that raises on read must not
+        be treated as merely absent and bootstrapped into, because the next
+        successful login could then find EITHER row non-deterministically,
+        and because a login that "succeeded" against a store it could not
+        actually read is not a login anyone should trust. So this is pinned
+        independently rather than inferred from the cookie assertion above.
+
+        The OVERWRITE case -- a secret already exists and a raising store
+        must not have it replaced under it, which would invalidate every
+        OTHER live session on the strength of a transient fault -- is covered
+        separately by
+        `test_session_secret_recovery.py::TestAnUnreadableStoreIsNotAnAbsentSecret::test_a_login_against_a_raising_store_writes_nothing`,
+        whose fixture requires a pre-existing row for exactly that reason.
 
         Checks `secret_rows` before patching `_query_index` and again after
         undoing the patch, deliberately: `secret_rows` itself reads through
@@ -749,6 +777,11 @@ class TestFailClosedWhenTheSecretIsUnavailable:
         token = mint_session_token(secret, SESSION_LIFETIME)
         assert get_current_user(_request(token)) is True
 
+        # `Settings.getProperty` is the real path this assertion drives:
+        # `get_current_user` -> `get_session_secret` -> `Env.prop` ->
+        # `getProperty`. Not the discredited pattern (T13/D17) -- that applies
+        # to `ensure_session_secret`'s bootstrap read, which never calls
+        # `getProperty` at all.
         monkeypatch.setattr(Settings, 'getProperty',
                             lambda self, identifier: (_ for _ in ()).throw(RuntimeError('store down')))
 

--- a/tests/unit/test_session_secret_store.py
+++ b/tests/unit/test_session_secret_store.py
@@ -675,8 +675,28 @@ class TestFailClosedWhenTheSecretIsUnavailable:
 
     @pytest.fixture
     def broken_store(self, env, monkeypatch):
-        monkeypatch.setattr(Settings, 'getProperty',
-                            lambda self, identifier: (_ for _ in ()).throw(RuntimeError('store down')))
+        """Breaks the read at the ADAPTER, the level every consumer shares.
+
+        `Settings.getProperty` calls `db.get('property', ...)`, and
+        `ensure_session_secret`'s `_session_secret_row` calls `db.query('property',
+        ...)` directly -- both end up in `SQLiteAdapter._query_index` for a
+        named index. Patching `_query_index` therefore breaks both real read
+        paths from one fault, the way a genuinely unreadable store would.
+
+        This is deliberately NOT a patch of `Settings.getProperty` itself:
+        that method's own `except Exception:` swallows whatever `_query_index`
+        raises and returns None, so patching `getProperty` to raise bypasses
+        that handler and never gets exercised by a real fault -- which is
+        exactly the defect T13 removed `session_secret_store_is_readable()`
+        for. A version of this fixture that patched `getProperty` let
+        `test_login_issues_no_cookie_when_the_secret_cannot_be_read` below pass
+        while a login against a raising store actually issued a cookie: proven
+        by running it after T13's other changes landed, before this fixture
+        was fixed.
+        """
+        monkeypatch.setattr(
+            SQLiteAdapter, '_query_index',
+            lambda self, *args, **kwargs: (_ for _ in ()).throw(RuntimeError('store down')))
         return env
 
     def test_login_issues_no_cookie_when_the_secret_cannot_be_read(self, broken_store):
@@ -690,6 +710,39 @@ class TestFailClosedWhenTheSecretIsUnavailable:
             'unreadable, so it was signed with something that is not a secret'
         )
         assert 'set-cookie' not in response.headers
+
+    def test_login_against_a_raising_store_creates_no_secret(self, env, monkeypatch):
+        """The other half of AC-SEC-33: no cookie is necessary but not
+        sufficient. Writing a fresh secret over a row that could not be read
+        would invalidate every OTHER live session on the strength of a
+        transient fault, even though this particular login gets no cookie --
+        so this is pinned independently rather than inferred from the cookie
+        assertion above.
+
+        Checks `secret_rows` before patching `_query_index` and again after
+        undoing the patch, deliberately: `secret_rows` itself reads through
+        `_query_index`, so evaluating it while the patch is still active would
+        raise instead of asserting.
+        """
+        from couchpotato.core.helpers.variable import md5
+        env.data['password'] = md5('hunter2')
+
+        assert secret_rows(env.db) == [], (
+            'a secret already existed before the login attempt, so this test '
+            'cannot tell a write from a pre-existing row'
+        )
+
+        monkeypatch.setattr(
+            SQLiteAdapter, '_query_index',
+            lambda self, *args, **kwargs: (_ for _ in ()).throw(RuntimeError('store down')))
+
+        client().post('/login/', data={'username': 'admin', 'password': 'hunter2'})
+
+        monkeypatch.undo()
+        assert secret_rows(env.db) == [], (
+            'a login against a store that cannot be READ wrote a secret to it '
+            '-- signing every device out on the strength of a transient fault'
+        )
 
     def test_a_previously_valid_cookie_is_refused_when_the_secret_cannot_be_read(self, env, monkeypatch):
         secret = ensure_session_secret(env.db)


### PR DESCRIPTION
T13. Removes `session_secret_store_is_readable()`, a guard that could not
do its job, and documents where the protection actually lives.

## The defect

The probe existed to tell "this install has no secret" from "the store
cannot be read", because D14's login bootstrap must create in the first
case and refuse in the second. It could not tell them apart. Measured
against a store whose reads raise:

    getProperty returned: None   <-- did NOT raise
    session_secret_store_is_readable() -> True

It read through `Env.prop` → `Settings.getProperty`, whose blanket
`except Exception:` logs at DEBUG and returns `None`, so the probe's own
`except` was unreachable for the fault it existed to catch, and it
answered "readable" for a store that was on fire.

Its test passed only by monkeypatching `Settings.getProperty` wholesale,
which bypasses the very handler a real fault goes through.

## The fix, and why it is behaviour-preserving

The real protection was always `ensure_session_secret`'s propagation:
`_session_secret_row` queries the adapter directly and raises, and
`login_post`'s `except` around it is where fail-closed happens. That is
now documented at the function, at the `except`, and as D17 in
`specs/PR2B-SESSION-COOKIE.md`. The call-site comment no longer
describes a condition that does not exist.

Behaviour is unchanged under a REAL fault, and that was checked rather
than asserted: `SQLiteAdapter.get` and `.query` both route through
`_query_index`, so an unreadable store fails BOTH read paths and no
cookie is issued with or without the probe. Two review lenses
independently ran the new hostile tests against the pre-change source
and got a full pass.

## The test carrying the property was itself vacuous

`broken_store` patched `Settings.getProperty` to raise — a fault that
cannot occur, since that method's own `except` swallows what the layer
beneath throws. Proof it mattered: keeping the old fixture and removing
the probe made `test_login_issues_no_cookie_when_the_secret_cannot_be_read`
FAIL, with a cookie actually issued, because the synthetic fault left
the adapter read working. The fixture now breaks `_query_index`, the
layer both real paths share.

A second test pins the other half independently: a login against a
raising store must write NO secret. No cookie is necessary but not
sufficient — writing a fresh secret over a row nobody could read signs
every OTHER device out. Confirmed distinct: a mutation minting an
in-memory fallback fails the cookie test and leaves the no-write test
green.

## Review findings, including two of mine

- **AC-SEC-33 still prescribed the disproven proof method.** The first
  draft amended D14/D15 and added D17 but left the criterion itself
  telling the next person to monkeypatch `getProperty`. Two lenses
  reinstated exactly that fixture and the test failed. The AC is the
  durable artefact; it now names the adapter-level fault and requires
  both halves.
- **A claim of mine was false.** The first draft said `Env.prop` NEVER
  raises in production. `getProperty`'s `except ValueError:` recovery
  branch makes its own `db.get` call outside any handler, so a
  corrupt-document read followed by a failing retry propagates:

      getProperty RAISED: RuntimeError: store down on the retry

  The conclusion is unchanged — the probe was blind to the *ordinary*
  raising-store fault — but "unfalsified" is not "true". Corrected in
  the code, in D17, and in the plan.
- On a **read** fault the operator was told to check the database was
  **writable**. Fixed in all three places; the review found two and the
  third was flagged by the implementer rather than silently widened.
- `if secret:` at the end of `login_post` could never be False, inside
  the very block whose comments this change rewrote — which contradicts
  D17's own argument. Removed and dedented, with the diff checked line
  by line because a mis-indented block on the cookie-issuing path would
  be far worse than the tidiness it buys.
- Two tests kept their `getProperty` patch after checking what they
  need: both drive `get_current_user`, whose real path IS
  `getProperty`. Left unconverted with comments saying why, rather than
  converted mechanically.

## Verification

`make verify` green (`GATE_RC=0`). Guards mutation-proven: neutralising
the fail-closed early return fails both new tests; minting a fallback
secret fails the cookie test. Mutations hash-confirmed to have landed,
files byte-identical after restore.

**Recorded as a spec bug:** T13 shipped with no acceptance criteria of
its own, because tasks added mid-plan skip the planning cycle where
criteria are written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
