### PR TITLE
T14: rotate the session secret after the password save commits

### DIFF
--- a/couchpotato/core/_base/_core.py
+++ b/couchpotato/core/_base/_core.py
@@ -50,6 +50,18 @@ class Core(Plugin):
     #    to exercise `md5Password` in isolation (`test_password_storage.py`,
     #    `test_auth_required_gate.py`) -- an instance attribute set only in
     #    `__init__` would make those raise `AttributeError` on first use.
+    #
+    # The trade that buys, stated so a future test does not trip on it:
+    # being class-scoped, every `Core` shares this, so the flag a bare
+    # `Core.__new__(Core)` leaves behind sits on that thread's slot until
+    # something consumes it -- `__init__`'s reset below only runs for real
+    # `Core()` construction. Harmless in production, where the only writer
+    # is `md5Password` and it assigns unconditionally on every save. It
+    # matters for a TEST that calls `rotateSessionSecretAfterSave()` without
+    # first calling `md5Password` on the same thread: it would inherit
+    # whatever an unrelated earlier test left, and become order-dependent.
+    # Set the intent explicitly in such a test rather than relying on the
+    # flag being false.
     _pending_rotation = threading.local()
 
     def __init__(self):

--- a/couchpotato/core/_base/_core.py
+++ b/couchpotato/core/_base/_core.py
@@ -28,7 +28,32 @@ class Core(Plugin):
     ]
     shutdown_started = False
 
+    # Set by `md5Password`, consumed by `rotateSessionSecretAfterSave`. A
+    # CLASS attribute, not one assigned in `__init__`, for two reasons:
+    #
+    # 1. Thread-local, not instance state. `Settings.saveView` dispatches
+    #    through FastAPI's `run_in_threadpool` (REG-002), so one password-save
+    #    request runs value-hook -> write -> after-hook on a single thread, but
+    #    two concurrent requests land on two different threadpool threads.
+    #    Plain instance state would let a slower request's after-hook read a
+    #    flag a faster, unrelated request had just overwritten -- rotating for
+    #    the wrong save, or silently skipping its own. `threading.local()`
+    #    removes that interleaving: each thread sees only what it wrote.
+    # 2. Declared at class scope so it exists without `__init__` running.
+    #    Plenty of this project's own tests build a bare `Core.__new__(Core)`
+    #    to exercise `md5Password` in isolation (`test_password_storage.py`,
+    #    `test_auth_required_gate.py`) -- an instance attribute set only in
+    #    `__init__` would make those raise `AttributeError` on first use.
+    _pending_rotation = threading.local()
+
     def __init__(self):
+        # Defensive reset: a prior password-save on THIS thread that never
+        # reached `rotateSessionSecretAfterSave` (e.g. a test harness that
+        # called `md5Password` directly, or a process that never got the
+        # matching `.committed` event) must not leak into the next real save
+        # this instance handles.
+        self._pending_rotation.rotate = False
+
         addApiView('app.shutdown', self.shutdown, docs = {
             'desc': 'Shutdown the app.',
             'return': {'type': 'string: shutdown'}
@@ -55,6 +80,7 @@ class Core(Plugin):
         addEvent('app.load.after', self.dependencies)
 
         addEvent('setting.save.core.password', self.md5Password)
+        addEvent('setting.save.core.password.committed', self.rotateSessionSecretAfterSave)
         addEvent('setting.save.core.auth_required', self.guardAuthRequired)
         addEvent('setting.save.core.api_key', self.checkApikey)
 
@@ -163,7 +189,8 @@ class Core(Plugin):
                       'Check Settings > Server > Require login. %s',
                       traceback.format_exc())
 
-        # End every existing session (D6/AC-SEC-38).
+        # End every existing session (D6/AC-SEC-38) -- but only once the new
+        # password has actually COMMITTED, not merely been submitted.
         #
         # Changing a password is usually a RESPONSE to something -- a shared
         # laptop, a screenshot, a suspicion. Before this, every cookie issued
@@ -172,29 +199,87 @@ class Core(Plugin):
         # whoever prompted it. Rotating the signing secret is what makes the
         # change mean something, and the field's own description now says so.
         #
-        # Only when a password is actually SET. Clearing it turns
-        # `auth_required` off two lines above, so every request is already
-        # served without a session and there is nothing to revoke -- and
-        # writing a secret row anyway would put one on installs that never
-        # enabled authentication, which AC-QA-21 and AC-SEC-46 both forbid.
+        # This hook cannot do the rotation itself. It is the VALUE hook, which
+        # `Settings.saveView` calls BEFORE `self.save()` writes config.ini
+        # (settings.py:507-512). Rotating here would sign every device out for
+        # a password change that a subsequent failed save -- read-only config
+        # directory, a permissions change, a full volume, any I/O error --
+        # then never persists. After a restart the OLD password is still
+        # authoritative, and every session opened under it is already gone:
+        # nothing changed, and everyone is logged out. So this only RECORDS
+        # the intent; `rotateSessionSecretAfterSave`, wired to
+        # `setting.save.core.password.committed`, does the rotation once
+        # `saveView` reaches that event -- which it only does after `save()`
+        # returned without raising.
         #
-        # Guarded, and the guard direction matters: this method's RETURN VALUE
-        # is the stored password hash. An exception escaping here would abort
-        # the settings save after the `auth_required = 1` above had already
-        # been set in the parser, which is the "authentication on, no password
-        # stored" lockout that the rest of this file exists to prevent. A stale
-        # signing secret is recoverable by signing out; that state is not.
-        if value:
-            try:
-                from couchpotato import rotate_session_secret
-                rotate_session_secret()
-            except Exception:
-                log.error('Password saved, but the session signing secret '
-                          'could not be rotated -- sessions opened with the '
-                          'OLD password are still valid. Sign out to force a '
-                          'rotation, or restart. %s', traceback.format_exc())
+        # NOT wired to `.after`, despite the name suggesting exactly this.
+        # `fireEvent` auto-fires `'<name>.after'` for EVERY dispatch, including
+        # the value-hook call itself (`event.py`) -- so a handler on
+        # `setting.save.core.password.after` runs BEFORE `self.save()` too, as
+        # a side effect of firing THIS hook, defeating the whole point.
+        # Measured: rotation happened even when `self.save()` was made to
+        # raise. `.committed`, fired explicitly by `saveView` after `self.save()`
+        # succeeds, is not a name `fireEvent` auto-derives from anything, so it
+        # is the one signal here guaranteed to fire exactly once and only
+        # post-commit. See the comment at that `fireEvent` call in settings.py.
+        #
+        # Assigned UNCONDITIONALLY (`bool(value)`, never `if value: ... =
+        # True`). `self.save()` raising means `saveView` never reaches the
+        # `.committed` event, so a failed save leaves this thread's flag
+        # exactly as this call set it. Only an unconditional assignment
+        # guarantees the NEXT call to this hook on this thread -- whatever
+        # value it carries, including a clear -- overwrites that leftover
+        # before `.committed` is ever reached again, rather than a stale True
+        # from a failed SET surviving to make a later CLEAR rotate.
+        #
+        # Only SET should rotate. Clearing the password turns `auth_required`
+        # off two lines above, so every request is already served without a
+        # session and there is nothing to revoke -- and rotating anyway would
+        # put a secret row on installs that never enabled authentication,
+        # which AC-QA-21 and AC-SEC-46 both forbid.
+        self._pending_rotation.rotate = bool(value)
 
         return hash_password(md5(value)) if value else ''
+
+    def rotateSessionSecretAfterSave(self):
+        """Rotate the session secret once the password change has committed.
+
+        Wired to `setting.save.core.password.committed`, which `Settings.saveView`
+        fires only after `self.save()` has written config.ini without raising
+        -- so a save that fails never reaches this, and the operator is never
+        signed out for a password change that was not actually persisted.
+        Deliberately NOT `.after`: `fireEvent` auto-fires that name for every
+        dispatch, including the value hook's OWN call, so it actually runs
+        before `self.save()` too. See the comment on `md5Password`'s rotation
+        block and the `fireEvent('...committed', ...)` call in settings.py.
+        `md5Password` is the value hook that records intent, in a thread-local
+        rather than instance attribute; see the class-level `_pending_rotation`
+        comment for why.
+
+        Consume-and-clear: read the flag, reset it, THEN act on the value read
+        -- so an exception raised while rotating cannot leave the flag set for
+        a later, unrelated `.committed` firing on this thread to pick up.
+
+        Guarded, and the guard direction is now the OPPOSITE of what it was
+        when rotation lived in the value hook: this runs entirely after the
+        password write has already succeeded, so nothing here can abort that
+        save. A rotation failure here only leaves the OLD signing secret live
+        -- recoverable by signing out (which itself rotates) or a restart --
+        never "authentication on, no password stored".
+        """
+        pending = getattr(self._pending_rotation, 'rotate', False)
+        self._pending_rotation.rotate = False
+        if not pending:
+            return
+
+        try:
+            from couchpotato import rotate_session_secret
+            rotate_session_secret()
+        except Exception:
+            log.error('Password saved, but the session signing secret '
+                      'could not be rotated -- sessions opened with the '
+                      'OLD password are still valid. Sign out to force a '
+                      'rotation, or restart. %s', traceback.format_exc())
 
     def guardAuthRequired(self, value):
         """Refuse to turn "Require login" on while no password is stored.

--- a/couchpotato/core/_base/_core.py
+++ b/couchpotato/core/_base/_core.py
@@ -31,14 +31,20 @@ class Core(Plugin):
     # Set by `md5Password`, consumed by `rotateSessionSecretAfterSave`. A
     # CLASS attribute, not one assigned in `__init__`, for two reasons:
     #
-    # 1. Thread-local, not instance state. `Settings.saveView` dispatches
-    #    through FastAPI's `run_in_threadpool` (REG-002), so one password-save
-    #    request runs value-hook -> write -> after-hook on a single thread, but
-    #    two concurrent requests land on two different threadpool threads.
-    #    Plain instance state would let a slower request's after-hook read a
-    #    flag a faster, unrelated request had just overwritten -- rotating for
-    #    the wrong save, or silently skipping its own. `threading.local()`
-    #    removes that interleaving: each thread sees only what it wrote.
+    # 1. Thread-local, not instance state -- defence-in-depth, NOT closing a
+    #    reachable race today. `Settings.saveView` runs value-hook -> write ->
+    #    `.committed` on one thread per call, and TWO calls cannot interleave
+    #    through the shipped HTTP path: `callApiHandler` (`couchpotato/api.py`)
+    #    holds `api_locks['settings.save']` -- one lock per ROUTE, shared by
+    #    every settings save -- across the whole handler, and `saveView` is
+    #    reached nowhere else in this tree. So plain instance state would be
+    #    safe under the current wiring; it is thread-local anyway because that
+    #    safety depends entirely on the lock staying exactly as it is, and on
+    #    nothing ever calling `saveView` a second way. `threading.local()`
+    #    removes the interleaving unconditionally rather than via that lock,
+    #    at no cost. Proven with a real two-thread probe (bypassing the lock
+    #    entirely, since the lock is what makes the race unreachable via HTTP):
+    #    `test_password_rotation_after_commit.py::TestThePendingRotationFlagIsPerThreadNotShared`.
     # 2. Declared at class scope so it exists without `__init__` running.
     #    Plenty of this project's own tests build a bare `Core.__new__(Core)`
     #    to exercise `md5Password` in isolation (`test_password_storage.py`,
@@ -236,7 +242,8 @@ class Core(Plugin):
         # off two lines above, so every request is already served without a
         # session and there is nothing to revoke -- and rotating anyway would
         # put a secret row on installs that never enabled authentication,
-        # which AC-QA-21 and AC-SEC-46 both forbid.
+        # which AC-QA-21 and AC-SEC-46 (`specs/PR2B-SESSION-COOKIE.md`) both
+        # forbid.
         self._pending_rotation.rotate = bool(value)
 
         return hash_password(md5(value)) if value else ''

--- a/couchpotato/core/settings.py
+++ b/couchpotato/core/settings.py
@@ -514,6 +514,25 @@ class Settings:
         fireEvent('setting.save.%s.%s.after' % (section, option), single=True)
         fireEvent('setting.save.%s.*.after' % section, single=True)
 
+        # `.after`, above, is NOT "runs once, after the save" -- despite the
+        # name and despite running on this line after `self.save()`.
+        # `fireEvent`'s own tail (`event.py`: `if not options['is_after_event']:
+        # fireEvent('%s.after' % name, is_after_event=True)`) auto-derives and
+        # fires `'<name>.after'` for EVERY dispatch, including the value-hook
+        # call three lines up -- so a handler on
+        # `'setting.save.<section>.<option>.after'` actually runs TWICE per
+        # save: once immediately after the value hook (BEFORE `self.set()` and
+        # `self.save()` above), and once again here. A hook that reacts once
+        # and consumes state (T14: `Core.rotateSessionSecretAfterSave`,
+        # rotating the session secret only once a password change has
+        # committed) sees the premature firing and never the real one --
+        # measured: the secret rotated even when `self.save()` was made to
+        # raise, because rotation had already happened before that line ran.
+        # `.committed` is a name `fireEvent` has never auto-derived from
+        # anything, so it is the only signal here guaranteed to fire exactly
+        # once, and only after `self.save()` has returned without raising.
+        fireEvent('setting.save.%s.%s.committed' % (section, option), single=True)
+
         # Report what was ACTUALLY STORED, not merely that a write happened.
         #
         # A hook may rewrite the submitted value -- `Core.guardAuthRequired`

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -531,12 +531,28 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       so a failed SET cannot leave a stale True for a later CLEAR to inherit.
 
       Existing `.after` consumers elsewhere (`automation.py`, `manage.py`,
-      `rtorrent_.py`, `updater/main.py`, `searcher/base.py` -- all
-      cron-recompute hooks) are double-fired by the same `fireEvent` quirk and
-      were deliberately left alone: recomputing an idempotent cron schedule
-      twice is wasteful, not incorrect, and touching five unrelated plugins was
-      out of this task's scope. Worth a pass if `.after` semantics are ever
-      revisited generally.
+      `updater/main.py`, `searcher/base.py` -- all cron-recompute hooks
+      registered on a specific `<section>.<option>.after`) are double-fired by
+      the same `fireEvent` quirk and were deliberately left alone: recomputing
+      an idempotent cron schedule twice is wasteful, not incorrect, and
+      touching four unrelated plugins was out of this task's scope. Worth a
+      pass if `.after` semantics are ever revisited generally.
+
+      **`rtorrent_.py` does NOT belong on that list**, measured after an
+      earlier draft of this entry put it there. `rtorrent_.settingsChanged`
+      registers on the literal wildcard `setting.save.rtorrent.*.after`
+      (closing the active rTorrent connection, not a cron recompute), and
+      `fireEvent`'s auto-derivation only ever produces `'%s.after' % name` for
+      the CONCRETE name it was called with -- `saveView`'s value hook fires
+      `'setting.save.rtorrent.<option>'`, never the literal string
+      `'setting.save.rtorrent.*'`, so nothing auto-derives the wildcard early.
+      It is reached only once, by `saveView`'s own explicit
+      `fireEvent('setting.save.%s.*.after' % section, single=True)` (settings.py:515),
+      genuinely after the save. Instrumenting a real `saveView` call
+      confirmed the counts directly: `{'per_option_after': 2, 'wildcard_after':
+      1, 'committed': 1}`. The distinction is the useful part for whoever next
+      touches `.after` generally: a per-option `.after` double-fires, a
+      wildcard `*.after` does not.
 
       Tests: `tests/unit/test_password_rotation_after_commit.py` (new -- a
       working rotation instrument proven first per this entry's own

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -485,41 +485,68 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       risks a regression in the one function that must not lose a write. Its
       own small change, with its own review.
 
-- [ ] T14: the password-change rotation commits before the save does — state: queued (no deps)
+- [x] T14: the password-change rotation commits before the save does — state: **fixed** (2026-08-11), rotation moved off `Core.md5Password` onto a new `.committed` event `Settings.saveView` fires only after `self.save()` succeeds
 
-      P2 review finding on #229, **attempted and withdrawn**, so it is a task
-      rather than a fix.
+      P2 review finding on #229, **attempted and withdrawn twice** before this
+      pass, so it was a task rather than a fix.
 
-      `Core.md5Password` is the VALUE hook: it runs while the settings save is
-      still in progress, before `Settings.save()` writes `config.ini`. Rotating
-      there means a save that then fails -- read-only config directory, a
-      permissions change, an I/O error -- has already signed the operator out
+      `Core.md5Password` was the VALUE hook: it ran while the settings save was
+      still in progress, before `Settings.save()` wrote `config.ini`. Rotating
+      there meant a save that then failed -- read-only config directory, a
+      permissions change, an I/O error -- had already signed the operator out
       of every device for a change that was never persisted, and after a
-      restart the OLD password is still authoritative.
+      restart the OLD password was still authoritative.
 
-      **The fix is available and clean.**
-      `fireEvent('setting.save.<section>.<option>.after')` fires AFTER
-      `self.save()` (`core/settings.py:514`), so a save that raises never
-      reaches it. Moving the rotation there couples it to the commit rather
-      than the attempt, and takes the rotation out of the value hook where an
-      exception risks the auth_required lockout that T-M6 is also about.
+      **The fix this entry originally proposed does not work, and that is very
+      likely why the first two attempts produced nothing usable.**
+      `fireEvent()` auto-fires `'<name>.after'` as an intrinsic side effect of
+      EVERY dispatch (`couchpotato/core/event.py`), including the value-hook
+      call itself -- so a handler wired to `setting.save.core.password.after`
+      runs a FIRST time immediately after the value hook, before
+      `self.set()`/`self.save()` in `saveView`, and only a second time for
+      real afterwards. A consume-and-clear rotation hook acts on the first,
+      premature firing and never sees the second. Measured directly against
+      this branch's own harness: wiring the rotation to `.after` still rotated
+      the secret when `self.save()` was made to raise -- the exact defect this
+      task exists to close, reproduced by the fix this entry described as
+      "available and clean".
 
-      One wrinkle to design around: the `.after` hook receives no value, so it
-      cannot tell a password being SET from one being CLEARED, and D10 says
-      clearing must not rotate. A flag set in `md5Password` and consumed by the
-      after-hook works, but must be assigned unconditionally so a failed save
-      cannot leave it set for the next one.
+      **The actual fix** adds a new event, `setting.save.<section>.<option>.committed`,
+      which `Settings.saveView` (`core/settings.py`) fires explicitly, once,
+      only after `self.save()` returns without raising. `fireEvent` never
+      auto-derives that name from anything else, so it is the one signal in
+      `saveView` guaranteed to fire exactly once and only post-commit.
+      `Core.rotateSessionSecretAfterSave` is wired to it instead of `.after`.
 
-      **Why it is deferred.** Three attempts to measure in this area produced
-      nothing usable: the ordering test passes on the current code, and I could
-      not prove it is non-vacuous -- a successful save through the same harness
-      would not demonstrably rotate either, so the test may be asserting
-      nothing. Shipping a guard that looks like coverage and is not is worse
-      than shipping none. Project rule 11 already applies to this function on
-      this branch.
+      The wrinkle this entry flagged held: the `.committed` event receives no
+      value, so it cannot tell a password being SET from one being CLEARED,
+      and D10 says clearing must not rotate. `Core.md5Password` sets a flag,
+      consumed by the new hook. It is a per-thread `threading.local()`
+      declared as a CLASS attribute rather than instance state: thread-local
+      because `saveView` dispatches through `run_in_threadpool`, so two
+      concurrent password-change requests must not read or clear each other's
+      flag; class-scoped so it exists without `__init__` running, which
+      several of this project's own tests rely on (`Core.__new__(Core)`).
+      Assigned unconditionally (`bool(value)`, never `if value: ... = True`),
+      so a failed SET cannot leave a stale True for a later CLEAR to inherit.
 
-      Do it with a working harness: assert first that a SUCCESSFUL save
-      rotates, then that a failing one does not.
+      Existing `.after` consumers elsewhere (`automation.py`, `manage.py`,
+      `rtorrent_.py`, `updater/main.py`, `searcher/base.py` -- all
+      cron-recompute hooks) are double-fired by the same `fireEvent` quirk and
+      were deliberately left alone: recomputing an idempotent cron schedule
+      twice is wasteful, not incorrect, and touching five unrelated plugins was
+      out of this task's scope. Worth a pass if `.after` semantics are ever
+      revisited generally.
+
+      Tests: `tests/unit/test_password_rotation_after_commit.py` (new -- a
+      working rotation instrument proven first per this entry's own
+      instruction, exactly-once-per-save as a regression guard against the
+      "looks green for the wrong reason" shape above, failure injected at the
+      real `self.save()` commit point, the flag's leak-across-attempts guard,
+      and clearing never rotating or creating a secret row on a fresh
+      install), plus `tests/unit/test_session_revocation.py` updated where it
+      drove the password-change event directly and so needed the `.committed`
+      event fired alongside it to still exercise real behaviour.
 
 - [x] T13: `session_secret_store_is_readable()` cannot detect an unreadable store — state: **probe removed** (2026-08-11, option 2)
 

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -530,6 +530,14 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       Assigned unconditionally (`bool(value)`, never `if value: ... = True`),
       so a failed SET cannot leave a stale True for a later CLEAR to inherit.
 
+      **Residual window, recorded not fixed: T21.** A kill between the
+      atomic `save()` and the rotation's database write leaves the new
+      password live and the old signing secret intact, so a password change
+      that DID persist revokes nothing until the cookie's own expiry. Much
+      narrower than what this task fixed (a precise instant, versus any I/O
+      error) and nothing is lost or locked out, but it is silent. Design and
+      severity in T21.
+
       Existing `.after` consumers elsewhere (`automation.py`, `manage.py`,
       `updater/main.py`, `searcher/base.py` -- all cron-recompute hooks
       registered on a specific `<section>.<option>.after`) are double-fired by
@@ -756,6 +764,49 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       cleanup), so a third adjacent change to the same file, altering what
       `notify` returns, is exactly the shape that keeps going wrong. It
       gets its own task and its own tests.
+
+- [ ] T21: a kill between the password save and the rotation loses the revocation — state: queued (no deps)
+
+      Raised on #248 (T14) by two reviewers independently, one rating it P1
+      and one Low. Recorded rather than folded in, because T14's diff already
+      reshapes the auth path and this needs a startup reconciliation of its
+      own.
+
+      T14 moved the rotation AFTER `self.save()` commits, which fixes the
+      common case: any I/O error on the save no longer signs every device out
+      for a password change that was never persisted. The residual window is
+      narrower and the opposite way round. If the process is killed between
+      `save()` returning (`settings.py:512`, `config.ini` now holds the NEW
+      password) and `rotate_session_secret()` completing its database write,
+      a restart finds the new password live and the OLD signing secret
+      intact. `ensure_session_secret` reuses it, so a cookie captured before
+      the change stays valid until its own expiry — 24 hours, or 30 days with
+      "remember me". A password change that DID persist silently revoked
+      nothing, which is the AC-SEC-38 guarantee the feature exists to provide.
+
+      Severity, honestly: much smaller than what T14 fixed. That fired on any
+      save failure; this needs a kill inside a specific instant between two
+      writes. Nobody is locked out and nothing is lost. But it is silent, and
+      the operator's belief that they revoked access is exactly what they
+      acted on.
+
+      **Fix shape, and the reason this is tractable rather than a
+      two-phase-commit rabbit hole:** `Settings.save` is already atomic
+      (temp file, fsync, rename — `settings.py:268`), and `md5Password`
+      already writes a second key (`auth_required`) into the in-memory parser
+      specifically so the caller's single `save()` persists both together or
+      neither. A rotation marker can ride the same write: set
+      `session_rotation_pending` in the parser next to `auth_required`, so
+      the one atomic save persists the new password AND the intent to
+      rotate. `rotateSessionSecretAfterSave` clears it after rotating.
+      Startup reconciles: marker present means the rotation did not complete,
+      so rotate now.
+
+      That does not eliminate a window so much as move it somewhere
+      recoverable — a kill before the atomic save leaves neither the password
+      nor the marker, which is correct. Prove it by killing between the two
+      writes, not by reasoning about it: the previous three attempts in this
+      area all failed on harnesses that could not distinguish the states.
 
 - [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: T6, T7, T8, T11, T13, T14, T15, T17, T19 — every other open task, because each adds residue and several rewrite the code this would sweep. T19 was added in the same commit that wrote this line and was omitted from it, which is the ordinary way such a list goes stale)
 

--- a/tests/unit/test_password_rotation_after_commit.py
+++ b/tests/unit/test_password_rotation_after_commit.py
@@ -133,7 +133,8 @@ def env(tmp_path):
 
 @pytest.fixture
 def fresh_env(tmp_path):
-    """An install that has never had a session secret at all (D12/AC-SEC-46)."""
+    """An install that has never had a session secret at all
+    (D12/AC-SEC-46, `specs/PR2B-SESSION-COOKIE.md`)."""
     yield from _build_env(tmp_path, bootstrap_secret=False)
 
 
@@ -177,37 +178,58 @@ class TestASuccessfulSaveActuallyRotates:
 
 class TestARealSaveFiresTheRotationExactlyOnce:
     """Regression guard for the specific way the FIRST version of this file
-    passed for the wrong reason.
+    passed for the wrong reason -- and, per review (M1, 2026-08-11), the
+    specific way a NAIVE version of THIS guard also passes for the wrong
+    reason, which is why it is written the way it now is.
 
-    Wired to `.after` instead of `.committed`, `TestASuccessfulSaveActuallyRotates`
-    above still went green -- `fireEvent` auto-fires `'<name>.after'` for every
-    dispatch (`event.py`), including the value hook's own call, so the handler
-    ran once BEFORE `self.set()`/`self.save()` and once again after. A
-    consume-and-clear hook only acts on the first of those, so the save
-    "rotated" -- just at the same premature moment as the original defect --
-    and nothing about that first pass distinguished it from the correct
-    behaviour. Counting calls is what tells them apart.
+    The first attempt at this class counted calls to `rotate_session_secret`
+    and asserted exactly one. That does not distinguish the two wirings at
+    all: `rotateSessionSecretAfterSave` consumes and clears the flag on its
+    FIRST firing (`_core.py`), so under `.after` -- fired once BEFORE
+    `self.set()`/`self.save()` and once again after, per the module docstring
+    -- the premature firing consumes the flag, rotates, and the second firing
+    then finds nothing pending and returns early. The call COUNT is 1 under
+    both the correct wiring and the `.after` regression; only the ORDER
+    differs (rotate-then-save under the regression, save-then-rotate when
+    correct). Measured directly: rewiring `.committed` back to `.after` left
+    the original, count-based version of this test GREEN.
+
+    The tests that DO catch the `.after` regression are
+    `TestAFailedSaveDoesNotRotate::test_a_save_that_raises_at_self_save_does_not_rotate`
+    (rotation has already happened by the time the injected failure would
+    have mattered) and
+    `TestThePendingFlagCannotLeakAcrossAttempts::test_a_failed_set_does_not_make_the_next_clear_rotate`.
+    Both need a failure injected to notice the reordering. This class exists
+    so there is a THIRD, more direct guard that asserts the ordering itself,
+    without needing to inject anything failing.
     """
 
-    def test_one_password_save_calls_rotate_session_secret_once(self, env, monkeypatch):
+    def test_the_save_commits_before_the_rotation_runs(self, env, monkeypatch):
         import couchpotato
 
-        calls = []
+        sequence = []
+        real_save = env.settings.save
         real_rotate = couchpotato.rotate_session_secret
 
-        def spy(*args, **kwargs):
-            calls.append(1)
+        def spy_save():
+            sequence.append('save')
+            return real_save()
+
+        def spy_rotate(*args, **kwargs):
+            sequence.append('rotate')
             return real_rotate(*args, **kwargs)
 
-        monkeypatch.setattr(couchpotato, 'rotate_session_secret', spy)
+        monkeypatch.setattr(env.settings, 'save', spy_save)
+        monkeypatch.setattr(couchpotato, 'rotate_session_secret', spy_rotate)
 
         env.settings.saveView(section='core', name='password', value='hunter3')
 
-        assert len(calls) == 1, (
-            'a single password save called rotate_session_secret %d times; '
-            'this is the exact double-firing shape (`.after` firing once '
-            'before the commit and once after it) that made the previous '
-            'wiring look correct while rotating at the wrong time' % len(calls)
+        assert sequence == ['save', 'rotate'], (
+            'config.ini was written and the secret was rotated in the order '
+            '%r, not save-then-rotate. Rotating before (or without) the save '
+            'that actually commits is the exact defect this task fixes -- a '
+            'save that then failed would already have signed every device '
+            'out for a password change that was never persisted.' % sequence
         )
 
 
@@ -260,6 +282,55 @@ class TestAFailedSaveDoesNotRotate:
         assert on_disk.get('password') == original_stored, (
             'config.ini on disk changed even though Settings.save() raised -- '
             'the failure was not actually happening at the commit point'
+        )
+
+
+class TestARotationFailureDoesNotEscapeTheHook:
+    """M2 (review): the `try/except` inside `rotateSessionSecretAfterSave`,
+    exercised directly rather than through `fireEvent`.
+
+    Every OTHER test in this file that patches `rotate_session_secret` to
+    raise reaches `rotateSessionSecretAfterSave` through `fireEvent`, whose
+    own dispatch loop already catches every handler exception
+    (`couchpotato/core/event.py`, `runHandler` / `createHandle`'s
+    `try/except Exception: log.error(...)`). Through that path alone, the
+    `try/except` inside the hook itself is unobservable: deleting it there
+    still leaves the exception caught one frame up, by `fireEvent`. Verified
+    by review measurement: 41 tests stayed green with the inner `try/except`
+    deleted.
+
+    Kept anyway, as deliberate defence-in-depth: `rotateSessionSecretAfterSave`
+    is a plain public method, exactly like `md5Password` -- which several of
+    this project's own tests already call directly, bypassing `fireEvent`
+    entirely (`test_password_storage.py`, `test_auth_required_gate.py`). Any
+    future caller that reaches this method the same way -- a different
+    dispatch mechanism, a migration script, a test -- gets no protection from
+    `fireEvent`'s catch, and the guarantee the method's own docstring makes
+    ("a rotation failure here only leaves the OLD signing secret live... never
+    'authentication on, no password stored'") would silently stop holding for
+    that caller. This test is what makes deleting the `try/except` a red
+    build again, by calling the method directly.
+    """
+
+    def test_a_rotation_failure_does_not_raise_out_of_the_hook_called_directly(self, monkeypatch, caplog):
+        import logging
+
+        from couchpotato.core._base._core import Core
+
+        core = Core.__new__(Core)
+        core.md5Password('a-new-password')  # records intent on the real thread-local
+
+        def explode():
+            raise RuntimeError('store down')
+
+        monkeypatch.setattr('couchpotato.rotate_session_secret', explode)
+
+        with caplog.at_level(logging.ERROR):
+            core.rotateSessionSecretAfterSave()  # must not raise
+
+        assert any('rotat' in record.getMessage().lower() for record in caplog.records), (
+            'a rotation failure was swallowed with no trace -- nothing tells '
+            'the operator they are still signed in under the OLD secret'
         )
 
 
@@ -322,7 +393,9 @@ class TestClearingNeverRotates:
     """D10: clearing turns `auth_required` off, so every request is already
     served without a session -- there is nothing to revoke, and rotating
     anyway risks the other half of D10, a secret row on an install that never
-    enabled authentication (AC-QA-21, AC-SEC-46)."""
+    enabled authentication (AC-QA-21, AC-SEC-46 -- both
+    `specs/PR2B-SESSION-COOKIE.md`; AC-QA-21 is a different requirement in
+    `specs/FEAT-009B-UPGRADE-REPLACEMENT.md`)."""
 
     def test_clearing_does_not_rotate_an_existing_secret(self, env):
         before = env.settings.getProperty(SESSION_SECRET_PROPERTY)
@@ -344,6 +417,94 @@ class TestClearingNeverRotates:
         assert result.get('success') is not False, result
         assert _secret_rows(fresh_env.db) == [], (
             'clearing a password on an install that never enabled '
-            'authentication wrote a session_secret row -- D12/AC-SEC-46 both '
-            'forbid this'
+            'authentication wrote a session_secret row -- D12 and AC-SEC-46 '
+            '(`specs/PR2B-SESSION-COOKIE.md`) both forbid this'
+        )
+
+
+class TestThePendingRotationFlagIsPerThreadNotShared:
+    """L1 (review): the `_pending_rotation` class comment's own claim, made
+    testable -- and qualified, because review measurement showed the claim
+    was overstated as first written.
+
+    `_pending_rotation` is `threading.local()` specifically so two threads
+    handling DIFFERENT password saves at once cannot read or clear each
+    other's intent. **Through the real HTTP path today, that interleaving is
+    NOT reachable**: `callApiHandler` (`couchpotato/api.py`) holds
+    `api_locks['settings.save']` -- a single lock keyed by ROUTE name, shared
+    by every settings save regardless of section/option -- across the WHOLE
+    handler call, and `saveView` is registered and reached nowhere else in
+    this tree (`grep -rn "saveView(" couchpotato/` outside `tests/` returns
+    only its own definition). So two `settings.save` requests cannot execute
+    `saveView` concurrently at all right now; the lock already serialises
+    them before the thread-local would ever matter.
+
+    Kept anyway, deliberately claiming less than "this closes a live
+    production race": it is free, correct regardless, and does not depend on
+    `api_locks` staying exactly as it is -- a future per-section lock (rather
+    than per-route), or any code that reaches `saveView` other than through
+    `callApiHandler` (a migration script, a different dispatch mechanism),
+    would silently reopen this exact interleaving with nothing here to catch
+    it if the flag were shared state instead.
+
+    This test bypasses `api_locks` entirely -- it calls `md5Password` /
+    `rotateSessionSecretAfterSave` directly on two real OS threads with no
+    lock at all -- because that is the only way to exercise the property the
+    class comment claims, given the lock closes off the real path today.
+    """
+
+    def test_a_concurrent_clear_on_another_thread_does_not_steal_a_sets_rotation(self, monkeypatch):
+        import threading as _threading
+
+        from couchpotato.core._base._core import Core
+
+        # Bare instance, like several existing tests in this suite
+        # (`test_password_storage.py`, `test_auth_required_gate.py`): no
+        # `__init__`, so `core._pending_rotation` resolves to the shared
+        # CLASS attribute -- which is the point, since that attribute is what
+        # is under test here.
+        core = Core.__new__(Core)
+
+        calls = []
+        monkeypatch.setattr('couchpotato.rotate_session_secret', lambda: calls.append('SET') or 'fake-secret')
+
+        # Two Events, not one Barrier: a Barrier only guarantees both threads
+        # have REACHED a point, not that the CLEAR's write has landed before
+        # the SET's read afterwards -- a single barrier here left the two
+        # post-barrier statements racing each other with no ordering
+        # guarantee at all, which made an earlier version of this test pass
+        # by luck under BOTH the correct code and a shared-flag mutant.
+        # `clear_done` forces a strict happens-before: the CLEAR's write is
+        # guaranteed complete before the SET thread ever reads the flag.
+        clear_may_proceed = _threading.Event()
+        clear_done = _threading.Event()
+        errors = []
+
+        def set_password():
+            core.md5Password('a-new-password')  # this thread's intent: True
+            clear_may_proceed.set()
+            assert clear_done.wait(timeout=5), 'the CLEAR thread never finished'
+            try:
+                core.rotateSessionSecretAfterSave()
+            except Exception as exc:  # pragma: no cover - surfaced via `errors`
+                errors.append(exc)
+
+        def clear_password_on_another_thread():
+            assert clear_may_proceed.wait(timeout=5), 'the SET thread never signalled'
+            core.md5Password('')  # a DIFFERENT thread's intent: False
+            clear_done.set()
+
+        t_set = _threading.Thread(target=set_password)
+        t_clear = _threading.Thread(target=clear_password_on_another_thread)
+        t_set.start()
+        t_clear.start()
+        t_set.join(timeout=5)
+        t_clear.join(timeout=5)
+
+        assert not errors, errors
+        assert calls == ['SET'], (
+            'a password SET on one thread lost its own rotation to an '
+            'unrelated CLEAR that ran on a different thread (%r) -- the '
+            'password changed but no session was revoked, which is exactly '
+            'the interleaving `threading.local()` exists to prevent' % calls
         )

--- a/tests/unit/test_password_rotation_after_commit.py
+++ b/tests/unit/test_password_rotation_after_commit.py
@@ -1,0 +1,349 @@
+"""T14: the password-change rotation must commit AFTER the save, not before.
+
+`Core.md5Password` is registered as the VALUE hook for `setting.save.core.password`
+(`_core.py:57`), which `Settings.saveView` calls BEFORE `self.save()` writes
+`config.ini` (`settings.py:507-514`):
+
+    new_value = fireEvent('setting.save.%s.%s' % (section, option), value, single=True)  # <- md5Password ran HERE
+    self.set(section, option, stored)
+    self.save()                                                                          # <- config.ini written HERE
+    fireEvent('setting.save.%s.%s.after' % (section, option), single=True)               # <- and HERE
+
+Rotating the session signing secret from the value hook meant a save that then
+failed -- a read-only config directory, a permissions change, a full volume, any
+I/O error -- had already signed the operator out of every device for a password
+change that was never persisted. After a restart the OLD password is still
+authoritative, so every session opened under it is already gone: nothing
+changed, and everyone is logged out. The fix moves rotation to a NEW event,
+`setting.save.core.password.committed`, fired by `saveView` only after
+`self.save()` has returned without raising.
+
+**NOT `.after`, despite that reading as the obvious name.** `fireEvent`'s own
+tail (`couchpotato/core/event.py`) auto-fires `'<name>.after'` for EVERY
+dispatch, including the value-hook call itself three lines above -- so a
+handler on `setting.save.core.password.after` runs a first time immediately
+after the value hook, BEFORE `self.set()`/`self.save()`, and only a second
+time for real afterwards. A consume-and-clear hook (which this is; see
+`_core.py`'s `rotateSessionSecretAfterSave`) sees the premature firing and
+never the real one -- measured directly against this file's own harness before
+`.committed` existed: the secret rotated even when `self.save()` was made to
+raise. `.committed` is a name `fireEvent` never auto-derives from anything
+else, so it is the only signal in `saveView` guaranteed to fire exactly once,
+and only post-commit.
+
+**This was attempted once and withdrawn**, and this rediscovered why on the
+first real run: three attempts to measure T14 produced nothing usable, because
+the harness fired only the value hook
+(`fireEvent('setting.save.core.password', value, single=True)`) and never the
+write or an `.after`-shaped event that real production traffic always fires
+around it. Against a harness like that, "a failing save does not rotate" would
+pass for a harness in which NOTHING rotates under ANY circumstance -- an
+assertion that cannot fail is not coverage. So this file drives the REAL
+`Settings.saveView`, backed by a REAL `Settings` object writing to a REAL
+config.ini on disk, not `FakeSettings` (whose `save()` is `pass` and so cannot
+be made to fail at the actual commit point). `TestASuccessfulSaveActuallyRotates`
+below is deliberately the first class in the file and is treated as the
+precondition for every other class: if it does not pass, nothing below it means
+anything. Its FIRST version passed while wired to `.after` -- for the wrong
+reason, because of the double-firing above -- which is exactly the "looks like
+coverage and isn't" failure mode this task exists to avoid; `TestARealSaveFiresTheRotationExactlyOnce`
+is the guard against a regression back to that shape.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from couchpotato import SESSION_SECRET_PROPERTY, ensure_session_secret  # noqa: E402
+from couchpotato.api import api, api_docs, api_docs_missing, api_locks, api_nonblock  # noqa: E402
+from couchpotato.core import event as event_module  # noqa: E402
+from couchpotato.core.db.sqlite_adapter import SQLiteAdapter  # noqa: E402
+from couchpotato.core.settings import Settings  # noqa: E402
+from couchpotato.environment import Env  # noqa: E402
+from env_helper import env_restored  # noqa: E402
+
+
+def _secret_rows(db):
+    return [row for row in db._query_index('property', key=SESSION_SECRET_PROPERTY)
+            if row.get('identifier') == SESSION_SECRET_PROPERTY]
+
+
+def _build_env(tmp_path, bootstrap_secret=True):
+    """A real `Core`, a real `Settings` writing a real `config.ini`, a real
+    `SQLiteAdapter` -- the whole `setting.save.core.password` chain as
+    production runs it, through `Settings.saveView` directly.
+
+    Real `Settings` rather than `test_session_revocation.py`'s `FakeSettings`
+    on purpose: `FakeSettings.save()` is `pass`, so nothing could ever inject a
+    failure at the actual commit point, which is exactly what
+    `TestAFailedSaveDoesNotRotate` needs to do.
+    """
+    old_api = dict(api)
+    old_locks = dict(api_locks)
+    old_nonblock = dict(api_nonblock)
+    old_docs = dict(api_docs)
+    old_missing = list(api_docs_missing)
+    old_events = {name: list(handlers) for name, handlers in event_module.events.items()}
+
+    db = SQLiteAdapter()
+    db.create(str(tmp_path / 'db'))
+
+    settings = Settings()
+    settings.setFile(str(tmp_path / 'config.ini'))
+
+    with env_restored():
+        Env.set('db', db)
+        Env.set('settings', settings)
+        # Skips `Core.signalHandler`, which would otherwise replace this
+        # process's SIGINT/SIGTERM handlers for the rest of the pytest run.
+        Env.set('desktop', True)
+
+        from couchpotato.core._base._core import Core
+        Core()
+
+        secret_before = ensure_session_secret(db) if bootstrap_secret else None
+
+        yield type('EnvHandle', (), {
+            'db': db, 'settings': settings, 'secret_before': secret_before,
+        })()
+
+        Env.set('desktop', False)
+        db.close()
+        api.clear()
+        api.update(old_api)
+        api_locks.clear()
+        api_locks.update(old_locks)
+        api_nonblock.clear()
+        api_nonblock.update(old_nonblock)
+        api_docs.clear()
+        api_docs.update(old_docs)
+        api_docs_missing.clear()
+        api_docs_missing.extend(old_missing)
+        event_module.events.clear()
+        event_module.events.update(old_events)
+
+
+@pytest.fixture
+def env(tmp_path):
+    """The protected install: a session secret already exists."""
+    yield from _build_env(tmp_path)
+
+
+@pytest.fixture
+def fresh_env(tmp_path):
+    """An install that has never had a session secret at all (D12/AC-SEC-46)."""
+    yield from _build_env(tmp_path, bootstrap_secret=False)
+
+
+class TestASuccessfulSaveActuallyRotates:
+    """Step 1: the instrument. Nothing below this class means anything until
+    it passes -- see the module docstring for why the previous attempt at
+    T14 could not tell a working guard from a harness that never rotates."""
+
+    def test_setting_a_password_through_the_real_save_path_changes_the_secret(self, env):
+        before = env.settings.getProperty(SESSION_SECRET_PROPERTY)
+        assert before == env.secret_before, (
+            'sanity check failed before the real assertion even runs: the '
+            'property store is not returning what ensure_session_secret wrote'
+        )
+
+        result = env.settings.saveView(section='core', name='password', value='hunter3')
+
+        assert result.get('success') is not False, (
+            'the save itself was refused, so nothing below is testing what it '
+            'claims to: %r' % result
+        )
+
+        after = env.settings.getProperty(SESSION_SECRET_PROPERTY)
+        assert after != before, (
+            'a successful password change through the REAL Settings.saveView '
+            'path did not rotate the session secret. This harness cannot '
+            'detect rotation under any circumstance, so a "failing save does '
+            'not rotate" assertion built on it would be vacuous.'
+        )
+        assert len(bytes.fromhex(after)) == 32, after
+
+    def test_the_rows_do_not_accumulate(self, env):
+        """Same instrument, the other failure shape a stub could hide:
+        rotation that inserts a second row instead of updating the one row."""
+        env.settings.saveView(section='core', name='password', value='hunter3')
+        env.settings.saveView(section='core', name='password', value='hunter4')
+
+        rows = _secret_rows(env.db)
+        assert len(rows) == 1, 'password changes accumulated %d secret rows' % len(rows)
+
+
+class TestARealSaveFiresTheRotationExactlyOnce:
+    """Regression guard for the specific way the FIRST version of this file
+    passed for the wrong reason.
+
+    Wired to `.after` instead of `.committed`, `TestASuccessfulSaveActuallyRotates`
+    above still went green -- `fireEvent` auto-fires `'<name>.after'` for every
+    dispatch (`event.py`), including the value hook's own call, so the handler
+    ran once BEFORE `self.set()`/`self.save()` and once again after. A
+    consume-and-clear hook only acts on the first of those, so the save
+    "rotated" -- just at the same premature moment as the original defect --
+    and nothing about that first pass distinguished it from the correct
+    behaviour. Counting calls is what tells them apart.
+    """
+
+    def test_one_password_save_calls_rotate_session_secret_once(self, env, monkeypatch):
+        import couchpotato
+
+        calls = []
+        real_rotate = couchpotato.rotate_session_secret
+
+        def spy(*args, **kwargs):
+            calls.append(1)
+            return real_rotate(*args, **kwargs)
+
+        monkeypatch.setattr(couchpotato, 'rotate_session_secret', spy)
+
+        env.settings.saveView(section='core', name='password', value='hunter3')
+
+        assert len(calls) == 1, (
+            'a single password save called rotate_session_secret %d times; '
+            'this is the exact double-firing shape (`.after` firing once '
+            'before the commit and once after it) that made the previous '
+            'wiring look correct while rotating at the wrong time' % len(calls)
+        )
+
+
+class TestAFailedSaveDoesNotRotate:
+    """Step 2: the failure is injected at `self.save()` -- the real commit
+    point `Settings.saveView` calls at settings.py:512 -- not at anything
+    upstream of it (not `rotate_session_secret`, not the value hook)."""
+
+    def test_a_save_that_raises_at_self_save_does_not_rotate(self, env, monkeypatch):
+        before = env.settings.getProperty(SESSION_SECRET_PROPERTY)
+
+        def explode():
+            raise OSError('config directory is read-only')
+
+        monkeypatch.setattr(env.settings, 'save', explode)
+
+        with pytest.raises(OSError):
+            env.settings.saveView(section='core', name='password', value='hunter3')
+
+        after = env.settings.getProperty(SESSION_SECRET_PROPERTY)
+        assert after == before, (
+            'the session secret rotated even though Settings.save() raised. '
+            'Every existing session was ended for a password change that was '
+            'never persisted -- after a restart the OLD password is still '
+            'authoritative and there is no session left that can sign in '
+            'under it either.'
+        )
+
+    def test_a_failed_save_leaves_config_ini_holding_the_old_password(self, env, monkeypatch):
+        """The paired half: confirms the failure really is at the commit
+        point -- config.ini on disk (what a restart reads) keeps the OLD
+        password, not merely that this test asserts on the in-memory secret."""
+        baseline = env.settings.saveView(section='core', name='password', value='original-pw')
+        assert baseline.get('success') is not False, baseline
+        original_stored = env.settings.get('password')
+        assert original_stored, 'baseline save did not actually store a password'
+
+        def explode():
+            raise OSError('config directory is read-only')
+
+        monkeypatch.setattr(env.settings, 'save', explode)
+
+        with pytest.raises(OSError):
+            env.settings.saveView(section='core', name='password', value='hunter3')
+
+        # in-memory parser was updated by saveView before save() ran, but the
+        # file on disk (what a restart actually reads) was never written
+        on_disk = Settings()
+        on_disk.setFile(str(env.settings.file))
+        assert on_disk.get('password') == original_stored, (
+            'config.ini on disk changed even though Settings.save() raised -- '
+            'the failure was not actually happening at the commit point'
+        )
+
+
+class TestThePendingFlagCannotLeakAcrossAttempts:
+    """The unconditional `bool(value)` assignment in `md5Password`.
+
+    If the flag were only ever set truthy (`if value: flag = True`), a SET
+    whose `save()` then raises leaves it stuck at True -- nothing before the
+    NEXT save on this option would ever clear it back to False. The very next
+    save, even a CLEAR, which must never rotate, would inherit that stale
+    True and rotate anyway.
+    """
+
+    def test_a_failed_set_does_not_make_the_next_clear_rotate(self, env, monkeypatch):
+        before = env.settings.getProperty(SESSION_SECRET_PROPERTY)
+
+        def explode():
+            raise OSError('disk full')
+
+        monkeypatch.setattr(env.settings, 'save', explode)
+        with pytest.raises(OSError):
+            env.settings.saveView(section='core', name='password', value='attempted-new-password')
+        monkeypatch.undo()
+
+        result = env.settings.saveView(section='core', name='password', value='')
+        assert result.get('success') is not False, result
+
+        after = env.settings.getProperty(SESSION_SECRET_PROPERTY)
+        assert after == before, (
+            'a failed password SET left a stale rotation flag that a later, '
+            'successful CLEAR then acted on. Clearing must never rotate: it '
+            'turns auth_required off, so there is nothing left to revoke.'
+        )
+
+    def test_a_failed_set_still_rotates_on_a_later_successful_set(self, env, monkeypatch):
+        """The recovery half: the flag must not get stuck refusing to fire
+        either. An operator who retries after a transient failure needs the
+        retry to actually revoke the old sessions."""
+        before = env.settings.getProperty(SESSION_SECRET_PROPERTY)
+
+        def explode():
+            raise OSError('disk full')
+
+        monkeypatch.setattr(env.settings, 'save', explode)
+        with pytest.raises(OSError):
+            env.settings.saveView(section='core', name='password', value='attempted-new-password')
+        monkeypatch.undo()
+
+        env.settings.saveView(section='core', name='password', value='hunter5')
+
+        after = env.settings.getProperty(SESSION_SECRET_PROPERTY)
+        assert after != before, (
+            'after a failed attempt, a retried SET that actually succeeded '
+            'did not rotate -- the operator has no way left to revoke old '
+            'sessions for a password that DID change'
+        )
+
+
+class TestClearingNeverRotates:
+    """D10: clearing turns `auth_required` off, so every request is already
+    served without a session -- there is nothing to revoke, and rotating
+    anyway risks the other half of D10, a secret row on an install that never
+    enabled authentication (AC-QA-21, AC-SEC-46)."""
+
+    def test_clearing_does_not_rotate_an_existing_secret(self, env):
+        before = env.settings.getProperty(SESSION_SECRET_PROPERTY)
+
+        result = env.settings.saveView(section='core', name='password', value='')
+
+        assert result.get('success') is not False, result
+        after = env.settings.getProperty(SESSION_SECRET_PROPERTY)
+        assert after == before, (
+            'clearing the password rotated the session secret, which the '
+            'field only promises for SETTING one'
+        )
+
+    def test_clearing_creates_no_secret_row_on_an_install_that_never_had_one(self, fresh_env):
+        assert _secret_rows(fresh_env.db) == [], 'fixture is not actually fresh'
+
+        result = fresh_env.settings.saveView(section='core', name='password', value='')
+
+        assert result.get('success') is not False, result
+        assert _secret_rows(fresh_env.db) == [], (
+            'clearing a password on an install that never enabled '
+            'authentication wrote a session_secret row -- D12/AC-SEC-46 both '
+            'forbid this'
+        )

--- a/tests/unit/test_session_revocation.py
+++ b/tests/unit/test_session_revocation.py
@@ -233,6 +233,26 @@ def is_signed_in(session) -> bool:
     return False
 
 
+def change_password(value):
+    """Mirror `Settings.saveView`'s real event sequence for `core.password`
+    (settings.py), rather than `env.settings.saveView(...)` -- `FakeSettings`
+    has no real `self.p` (ConfigParser), which `saveView`'s own
+    `isOptionWritable` needs, so calling it directly raises `AttributeError`.
+
+    Firing only the value hook, as every test here used to, is no longer
+    enough. T14 moved rotation to `setting.save.core.password.committed`,
+    fired by `saveView` only once `self.save()` has returned without raising
+    -- deliberately NOT `.after`, which `fireEvent` auto-fires as an
+    intrinsic side effect of firing the value-hook event itself, before any
+    save happens at all (`couchpotato/core/event.py`). So the two calls below
+    are not interchangeable with one: the first alone reproduces exactly the
+    "rotates before the commit" defect T14 fixes.
+    """
+    stored = fireEvent('setting.save.core.password', value, single=True)
+    fireEvent('setting.save.core.password.committed', single=True)
+    return stored
+
+
 class TestLogoutRevokesRatherThanForgets:
     """AC-SEC-36 / D1."""
 
@@ -569,7 +589,11 @@ class TestChangingThePasswordEndsEverySession:
         thief = replay(env, token)
         assert is_signed_in(thief)
 
-        fireEvent('setting.save.core.password', 'a-new-password', single=True)
+        # Driven through the real `Settings.saveView` (T14: rotation lives on
+        # `setting.save.core.password.committed`, fired only after the save
+        # commits -- firing the value hook alone, as this test used to,
+        # no longer triggers it).
+        change_password('a-new-password')
 
         assert not is_signed_in(thief), (
             'changing the password left every existing session valid. Someone '
@@ -594,7 +618,7 @@ class TestChangingThePasswordEndsEverySession:
         description = password['description'].lower()
 
         owner, token = log_in(env)
-        fireEvent('setting.save.core.password', 'a-new-password', single=True)
+        change_password('a-new-password')
         assert not verify_session_token(token, env.settings.getProperty(SESSION_SECRET_PROPERTY))
 
         assert 'sign' in description or 'log' in description, description
@@ -616,7 +640,7 @@ class TestChangingThePasswordEndsEverySession:
         empty.create(str(tmp_path / 'empty-db'))
         Env.set('db', empty)
         try:
-            fireEvent('setting.save.core.password', '', single=True)
+            change_password('')
 
             rows = [row for row in empty._query_index('property', key=SESSION_SECRET_PROPERTY)
                     if row.get('identifier') == SESSION_SECRET_PROPERTY]
@@ -628,16 +652,15 @@ class TestChangingThePasswordEndsEverySession:
     def test_a_failure_to_rotate_does_not_stop_the_password_being_hashed(self, env):
         """Precedence: losing the password write is worse than a stale secret.
 
-        `md5Password` returns the stored hash. If rotation raised through it,
-        the settings save would fail and -- because the same hook writes
-        `auth_required` -- the operator could be left with authentication on
-        and no password stored, which is the recorded unrecoverable lockout.
+        T14 moved rotation to `rotateSessionSecretAfterSave`
+        (`setting.save.core.password.committed`), which runs AFTER the
+        password is already hashed and stored -- so a rotation failure there
+        can no longer abort the save the way it could when rotation lived in
+        the value hook, and this now has to be proven through the real save
+        path rather than by calling `md5Password` alone.
         """
-        from couchpotato.core._base._core import Core
-
-        core = Core.__new__(Core)
         with patch('couchpotato.rotate_session_secret', side_effect=RuntimeError('store down')):
-            stored = core.md5Password('a-new-password')
+            stored = change_password('a-new-password')  # must not raise
 
         assert stored.startswith(('$2a$', '$2b$', '$2y$')), stored
 
@@ -705,7 +728,7 @@ class TestExactlyOneFunctionWritesTheSecret:
             owner.post('/logout/')
             assert len(calls) == 2, 'logout did not use the writer'
 
-            fireEvent('setting.save.core.password', 'a-new-password', single=True)
+            change_password('a-new-password')
             assert len(calls) == 3, 'the password change did not use the writer'
         finally:
             fresh.close()

--- a/tests/unit/test_session_revocation.py
+++ b/tests/unit/test_session_revocation.py
@@ -247,6 +247,23 @@ def change_password(value):
     save happens at all (`couchpotato/core/event.py`). So the two calls below
     are not interchangeable with one: the first alone reproduces exactly the
     "rotates before the commit" defect T14 fixes.
+
+    **This is a COPY of `saveView`'s event sequence, not `saveView` itself**
+    (review L3, 2026-08-11). If `Settings.saveView` ever stopped firing
+    `.committed` -- a typo, a refactor, a merge conflict -- every test built
+    on this helper would keep passing while real password changes silently
+    stopped revoking sessions, because this function would still fire it
+    regardless. The only place that verifies `saveView` ITSELF still fires
+    `.committed` is `test_password_rotation_after_commit.py`, which drives the
+    real method end to end (`TestASuccessfulSaveActuallyRotates`,
+    `TestARealSaveFiresTheRotationExactlyOnce`). Do not trim those as
+    "redundant with this file": they are the only guard standing between a
+    drifted `saveView` and a false-green AC-SEC-38 suite here. (`FakeSettings`
+    in this module has no real `self.p` ConfigParser, which `saveView`'s
+    `isOptionWritable` needs, so pointing these tests at the real method
+    directly is not a small change -- see the class docstring above
+    `TestChangingThePasswordEndsEverySession` for the trade this file makes
+    instead.)
     """
     stored = fireEvent('setting.save.core.password', value, single=True)
     fireEvent('setting.save.core.password.committed', single=True)
@@ -582,7 +599,16 @@ class TestLogoutWritesNothingWhenAuthenticationIsOff:
 
 
 class TestChangingThePasswordEndsEverySession:
-    """AC-SEC-38 / D6."""
+    """AC-SEC-38 / D6.
+
+    Driven through `change_password()`, a hand-rolled copy of `saveView`'s
+    event sequence -- `FakeSettings` here has no real `self.p` (ConfigParser),
+    which `saveView`'s own `isOptionWritable` needs, so calling the real
+    method directly raises `AttributeError` (measured). See `change_password`'s
+    docstring for the resulting trade: this file proves the session-revocation
+    BEHAVIOUR against the copied sequence; `test_password_rotation_after_commit.py`
+    is what proves `saveView` itself still produces that sequence.
+    """
 
     def test_a_cookie_issued_before_a_password_change_is_refused_after_it(self, env):
         owner, token = log_in(env)
@@ -649,15 +675,24 @@ class TestChangingThePasswordEndsEverySession:
             empty.close()
             Env.set('db', env.db)
 
-    def test_a_failure_to_rotate_does_not_stop_the_password_being_hashed(self, env):
-        """Precedence: losing the password write is worse than a stale secret.
+    def test_a_rotation_failure_does_not_raise_out_of_the_save_sequence(self, env):
+        """The save-SEQUENCE-level guarantee, not the hook's own guard.
 
-        T14 moved rotation to `rotateSessionSecretAfterSave`
-        (`setting.save.core.password.committed`), which runs AFTER the
-        password is already hashed and stored -- so a rotation failure there
-        can no longer abort the save the way it could when rotation lived in
-        the value hook, and this now has to be proven through the real save
-        path rather than by calling `md5Password` alone.
+        Renamed from `test_a_failure_to_rotate_does_not_stop_the_password_being_hashed`
+        (review M2, 2026-08-11): that name promised a test of the `try/except`
+        inside `rotateSessionSecretAfterSave`, but `change_password` reaches
+        that hook only through `fireEvent`, whose OWN dispatch loop already
+        catches every handler exception (`couchpotato/core/event.py`). So this
+        passes -- and always would -- regardless of whether the hook's own
+        `try/except` exists; it is observing `fireEvent`'s catch-all, not the
+        hook's. What it still legitimately pins: a rotation failure does not
+        surface as an error on the request that changed the password, and the
+        value hook's own return (the stored hash) is unaffected by what
+        happens to rotation afterwards.
+
+        The hook's OWN `try/except` -- reached by calling it directly, the way
+        `fireEvent` does not have to be involved -- is tested in
+        `test_password_rotation_after_commit.py::TestARotationFailureDoesNotEscapeTheHook`.
         """
         with patch('couchpotato.rotate_session_secret', side_effect=RuntimeError('store down')):
             stored = change_password('a-new-password')  # must not raise


### PR DESCRIPTION
T14. The session-secret rotation on a password change now happens after
the save COMMITS, not before it is attempted.

## The defect

`Core.md5Password` is the **value** hook. `Settings.saveView` calls it at
`settings.py:507`, then writes `config.ini` at `:512`. The rotation lived
in the value hook, so a save that then failed — read-only config
directory, a permissions change, a full volume, any I/O error — had
already signed the operator out of every device for a password change
that was never persisted. After a restart the OLD password is still
authoritative and every session opened under it is gone: nothing
changed, and everyone is logged out.

## Why the obvious fix does not work, and this task failed twice before

The plan called for wiring the rotation to
`setting.save.core.password.after`, which `saveView` fires after
`self.save()`. That does not work, and finding out why is most of this
change.

`fireEvent` auto-derives and fires `'<name>.after'` as a side effect of
**every** dispatch (`event.py`: `if not options['is_after_event']:
fireEvent('%s.after' % name, is_after_event=True)`) — including the
value-hook call itself. Measured:

    after firing ONLY the value hook: ['value-hook', 'after']
    -> .after already fired BEFORE save()? True

So a handler on `.after` runs **twice**: once immediately after the
value hook, before `self.set()` and `self.save()`, and once again
afterwards. A consume-and-clear hook acts on the premature firing and
never sees the real one. Wiring the rotation there still rotated the
secret when `self.save()` was made to raise — the original defect,
reproduced by its own fix.

This is almost certainly why the two previous attempts produced nothing
usable.

## The fix

A new event, `setting.save.<section>.<option>.committed`, fired
explicitly by `saveView` once, only after `self.save()` returns without
raising. `fireEvent` never auto-derives that name from anything.

`md5Password` now only records intent in a flag; `rotateSessionSecretAfterSave`
consumes it and rotates. The flag is assigned unconditionally
(`bool(value)`, never `if value:`) so a failed save cannot leave it set
for the next save of some other setting.

## Building the instrument before trusting it

The previous attempts failed because their tests passed against the
unfixed code. So the success path was proven first: a test driving the
real `saveView` against a real `Settings` writing a real `config.ini`,
asserting the stored secret actually changed. Only then were the
failure-injection tests written. Without that order, "a failing save
does not rotate" passes in a harness where nothing rotates at all.

## Two vacuous guards found in review, in a change about a vacuous guard

- **The test named as the guard for the `.after` regression passed under
  that regression.** It counted calls and asserted one — but the hook
  consumes and clears the flag on its first firing, so under `.after`
  the premature firing rotates and the second returns early. The count
  is 1 under *both* wirings; only the ORDER differs. It now spies on
  `Settings.save` and `rotate_session_secret` and asserts the sequence
  is `['save', 'rotate']`. Rewiring to `.after` now fails three tests
  where it previously failed two.
- **The rotation-failure `try/except` could not fail any test.**
  `fireEvent` already catches every handler exception, and that was the
  only path reaching it, so deleting it left 41 tests green. Kept as
  defence-in-depth — the method is public and this project's own tests
  already call its sibling `md5Password` directly — and now exercised
  directly rather than through `fireEvent`, so deleting it fails.

Also corrected: the thread-local flag's rationale claimed a race that
cannot occur (`callApiHandler` holds a per-route lock across the whole
handler and `saveView` is reached nowhere else), so it now says
defence-in-depth rather than claiming a live threat. `rtorrent_.py` was
wrongly listed as double-fired — it registers on the literal wildcard
`setting.save.rtorrent.*.after`, which `fireEvent` never derives. And
bare `AC-QA-21` citations now name their spec, because that number means
two different things in two different specs.

## Recorded, not fixed

Four plugins (`automation.py`, `manage.py`, `updater/main.py`,
`searcher/base.py`) genuinely are double-fired by the same quirk. All
are idempotent recompute hooks, so it is harmless today — but it is a
live trap for whoever next writes a non-idempotent `.after` handler.

**Spec bug:** T14 shipped with zero acceptance criteria of its own, the
third instance on this plan. Tasks added mid-plan skip the planning
cycle where criteria are written.

## Verification

`make verify` green (`GATE_RC=0`). Guards mutation-proven: rewiring
`.committed` to `.after` fails three tests; deleting the `.committed`
fire fails three including the success-path test; every variant of a
conditional flag assignment fails the leak test; deleting the
`try/except` fails its direct test. Mutations hash-confirmed to have
landed, files byte-identical after restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
