### PR TITLE
T26: coverage has been published as 0% on every scan — generate it, and make that unforgettable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,8 @@ persona from memory; `AGENTS.md` is the review rubric they apply.
 | `make mutation-changed` | Mutation testing on changed files only — use this per-change |
 | `make check-traps` | False-green guard (jsdom layout reads, exit-code-eating pipes, weak shell gates) |
 | `make check-secrets` | Secret scan of the working tree (same command CI runs) |
+| `make coverage` | Generate the Python + JS coverage reports SonarQube ingests |
+| `make sonar` | Scan into self-hosted SonarQube after a merge that changed analysed code. Reporting only — **never a gate, never in CI**. Runs `coverage` first so the reports cannot be forgotten |
 | `./scripts/backup.sh` | Snapshot prod SQLite DB + settings — run before every deploy |
 
 ## Hard rules — never break these

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,11 @@ sonar-token-check: ## Fail fast if the analysis token is missing or empty
 	@# passes `test -r` and then fails inside the scanner AFTER coverage has
 	@# run, which is precisely the waste this check exists to prevent. Assert
 	@# the assignment exists AND has a value.
-	@grep -qE '^SONAR_TOKEN=.+' "$(SONAR_TOKEN_FILE)" || { \
+	@# `[^[:space:]]`, not `.+`: `.+` matches a value of pure whitespace, which
+	@# sources cleanly and then fails deep inside the scanner AFTER coverage --
+	@# the same late failure this check exists to prevent. POSIX class rather
+	@# than `\S`, which is a GNU extension BSD grep does not honour.
+	@grep -qE '^SONAR_TOKEN=[^[:space:]]' "$(SONAR_TOKEN_FILE)" || { \
 		echo "$(SONAR_TOKEN_FILE) does not define a non-empty SONAR_TOKEN=..."; \
 		exit 1; }
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 # it is the target that CREATES the environment.
 PYTHON ?= $(shell if [ -x .venv/bin/python ]; then echo .venv/bin/python; else echo python3; fi)
 
-.PHONY: help setup verify verify-fast test-py test-ui test-e2e lint security-lint check-traps check-secrets check-secrets-history mutation mutation-py mutation-js mutation-changed backup
+.PHONY: help setup verify verify-fast test-py test-ui test-e2e lint security-lint check-traps check-secrets check-secrets-history mutation mutation-py mutation-js mutation-changed backup coverage sonar sonar-token-check
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -87,6 +87,44 @@ check-traps: ## False-green guard (jsdom layout reads, exit-code-eating pipes, w
 # Pinned version: an unpinned :latest changes the ruleset under you, so a clean
 # scan today can fail tomorrow with no code change. Bump deliberately.
 GITLEAKS_IMAGE ?= zricethezav/gitleaks:v8.30.1
+
+# Self-hosted SonarQube. Reporting only -- NOT a gate, and deliberately not in
+# CI: the runners cannot reach the server, and the answer to that is not to
+# expose it. See specs/REMEDIATION-2026-08.md, "Scanning discipline".
+SONAR_HOST_URL ?= http://172.16.11.10:9000
+SONAR_TOKEN_FILE ?= $(HOME)/.sonar-token
+
+coverage: ## Generate the coverage reports SonarQube ingests (Python + JS)
+	@# Both, not one. Sonar blends them, and a MISSING report is silent -- it
+	@# lands as a plausible-looking 0%, not an error. That is exactly how this
+	@# project published 0.0% coverage on every scan until 2026-08-11.
+	$(PYTHON) -m pytest tests/unit/ tests/integration/ -q \
+		--cov=couchpotato --cov=scripts --cov-report=xml:coverage.xml
+	npx vitest run --coverage
+	@test -s coverage.xml || { echo "coverage.xml missing or empty"; exit 1; }
+	@test -s coverage/lcov.info || { echo "coverage/lcov.info missing or empty"; exit 1; }
+
+sonar-token-check: ## Fail fast if the analysis token is missing
+	@# FIRST prerequisite of `sonar`, deliberately: `coverage` takes minutes,
+	@# and discovering a missing token after it has run is the sort of thing
+	@# that gets a target abandoned rather than fixed.
+	@test -r "$(SONAR_TOKEN_FILE)" || { \
+		echo "No token at $(SONAR_TOKEN_FILE). Use the ANALYSIS token (sqa_/sqp_),"; \
+		echo "never the admin token -- that one can rewrite issue history."; exit 1; }
+
+sonar: sonar-token-check coverage ## Scan into self-hosted SonarQube (reporting only, never a gate)
+	@# Depends on `coverage` so the reports cannot be forgotten -- forgetting
+	@# them is the whole defect this target exists to prevent (T26).
+	@# Token via the environment only, so it stays out of the process list and
+	@# shell history. Never pass -Dsonar.token= on the command line.
+	@set -a; . "$(SONAR_TOKEN_FILE)"; set +a; \
+		npx --yes sonarqube-scanner -Dsonar.host.url=$(SONAR_HOST_URL)
+	@echo ""
+	@echo "Scan uploaded. It is a MEASUREMENT, not a verdict:"
+	@echo "  * read findings at the call site before believing them;"
+	@echo "  * never resolve or dismiss one to move a number;"
+	@echo "  * check coverage actually arrived -- a false 0% looks like data."
+	@echo "  $(SONAR_HOST_URL)/dashboard?id=couchpotato"
 
 check-secrets: ## Secret scan of the working tree (same command CI runs)
 	docker run --rm -v "$(PWD):/repo" -w /repo $(GITLEAKS_IMAGE) \

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,15 @@ GITLEAKS_IMAGE ?= zricethezav/gitleaks:v8.30.1
 SONAR_HOST_URL ?= http://172.16.11.10:9000
 SONAR_TOKEN_FILE ?= $(HOME)/.sonar-token
 
+# PINNED, for the same reason GITLEAKS_IMAGE above is pinned -- and one more.
+# `npx --yes` with no version fetches whatever npm currently publishes and
+# executes it, and this package is in neither package.json nor the lockfile,
+# so nothing here has ever been reviewed. That code runs with SONAR_TOKEN
+# already in its environment and the repository on disk: an unpinned fetch
+# immediately after loading a credential is a dependency-confusion vector,
+# not just a reproducibility problem. Bump deliberately.
+SONAR_SCANNER_VERSION ?= 5.0.0
+
 coverage: ## Generate the coverage reports SonarQube ingests (Python + JS)
 	@# Both, not one. Sonar blends them, and a MISSING report is silent -- it
 	@# lands as a plausible-looking 0%, not an error. That is exactly how this
@@ -104,21 +113,33 @@ coverage: ## Generate the coverage reports SonarQube ingests (Python + JS)
 	@test -s coverage.xml || { echo "coverage.xml missing or empty"; exit 1; }
 	@test -s coverage/lcov.info || { echo "coverage/lcov.info missing or empty"; exit 1; }
 
-sonar-token-check: ## Fail fast if the analysis token is missing
-	@# FIRST prerequisite of `sonar`, deliberately: `coverage` takes minutes,
-	@# and discovering a missing token after it has run is the sort of thing
-	@# that gets a target abandoned rather than fixed.
+sonar-token-check: ## Fail fast if the analysis token is missing or empty
+	@# Runs before `coverage`, deliberately: that takes minutes, and
+	@# discovering a bad token after it has run is the sort of thing that gets
+	@# a target abandoned rather than fixed.
 	@test -r "$(SONAR_TOKEN_FILE)" || { \
 		echo "No token at $(SONAR_TOKEN_FILE). Use the ANALYSIS token (sqa_/sqp_),"; \
 		echo "never the admin token -- that one can rewrite issue history."; exit 1; }
+	@# Readability is not enough: an empty, truncated or wrongly-named file
+	@# passes `test -r` and then fails inside the scanner AFTER coverage has
+	@# run, which is precisely the waste this check exists to prevent. Assert
+	@# the assignment exists AND has a value.
+	@grep -qE '^SONAR_TOKEN=.+' "$(SONAR_TOKEN_FILE)" || { \
+		echo "$(SONAR_TOKEN_FILE) does not define a non-empty SONAR_TOKEN=..."; \
+		exit 1; }
 
-sonar: sonar-token-check coverage ## Scan into self-hosted SonarQube (reporting only, never a gate)
-	@# Depends on `coverage` so the reports cannot be forgotten -- forgetting
-	@# them is the whole defect this target exists to prevent (T26).
+sonar: sonar-token-check ## Scan into self-hosted SonarQube (reporting only, never a gate)
+	@# `coverage` is invoked HERE rather than declared as a prerequisite.
+	@# Under `make -j` (or a global parallel MAKEFLAGS) independent
+	@# prerequisites run concurrently, so `sonar-token-check coverage` would
+	@# start the multi-minute coverage run alongside the check instead of
+	@# after it -- silently voiding the fail-fast guarantee above. A recipe
+	@# line is ordered under every mode.
+	$(MAKE) coverage
 	@# Token via the environment only, so it stays out of the process list and
 	@# shell history. Never pass -Dsonar.token= on the command line.
 	@set -a; . "$(SONAR_TOKEN_FILE)"; set +a; \
-		npx --yes sonarqube-scanner -Dsonar.host.url=$(SONAR_HOST_URL)
+		npx --yes sonarqube-scanner@$(SONAR_SCANNER_VERSION) -Dsonar.host.url=$(SONAR_HOST_URL)
 	@echo ""
 	@echo "Scan uploaded. It is a MEASUREMENT, not a verdict:"
 	@echo "  * read findings at the call site before believing them;"

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -1001,7 +1001,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       Do not add labels and call it done while the gate still cannot see
       the page.
 
-- [ ] T26: the analyser has never had coverage data, so the trend it exists for is blank — state: queued (no deps)
+- [x] T26: the analyser has never had coverage data, so the trend it exists for is blank — state: **fixed** (2026-08-11), 0.0 → 53.3%
 
       `sonar-project.properties` sets `sonar.python.coverage.reportPaths=coverage.xml`,
       but the first re-scan reported `coverage 0.0` because no `coverage.xml`
@@ -1018,7 +1018,33 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       plugin loading are exercised by integration tests), so decide what to
       include before publishing a number people will read as the truth.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T24, T25, T26 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale twice by enumeration alone. T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list.)
+      **Done.** The config was never wrong — `sonar.python.coverage.reportPaths`
+      and `sonar.javascript.lcov.reportPaths` were both already set, and the
+      properties file even documented the two commands. The reports simply
+      were not generated before scanning, every time. Measured after
+      generating both and re-scanning master:
+
+          coverage        0.0  ->  53.3
+          line_coverage        ->  52.8
+          lines_to_cover       ->  20917
+          uncovered_lines      ->  9872
+
+      Plausibility checked rather than assumed, which is what that file asks
+      for: Python alone measures 56.74%, the properties file records a
+      previous scan at 51.8%, and 53.3% is the expected blend once the
+      untested legacy JS is included.
+
+      **Mechanised, because a remembered step is exactly what failed.**
+      `make coverage` generates both reports and fails if either is empty;
+      `make sonar` depends on it so they cannot be skipped, and reads the
+      token from a file into the environment so it never reaches the process
+      list. `make sonar-token-check` runs FIRST, so a missing token fails in
+      0.04s instead of after the four-minute coverage run — a target that
+      wastes an evening gets abandoned rather than fixed. Not wired into
+      `verify` and not in CI: it is reporting, not a gate, and the runners
+      cannot reach the server.
+
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T24, T25 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale twice by enumeration alone. T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list.)
 
       **Runs LAST, and it is not a duplicate of T7 even though it sounds like
       one.** T7 is a scoped pass over the specific items this plan's reviews


### PR DESCRIPTION
SonarQube has published **0.0% coverage on every scan**. Now 53.3%, and
the step that was being skipped is now a make target that cannot be
skipped.

## What was wrong

Nothing in the configuration. `sonar.python.coverage.reportPaths` and
`sonar.javascript.lcov.reportPaths` were both already set, and
`sonar-project.properties` even documented the two commands that produce
them. The reports were simply never generated before scanning.

That file also warns why this is worse than an ordinary omission: *"An
unmatched report is SILENT — it shows as a false 0%, which looks like a
measurement rather than an error."* A flat zero is indistinguishable
from genuinely zero coverage, so the one metric that would show the test
suite improving has been reading as a catastrophe instead of as absent.

## What it actually is

    coverage          0.0  ->  53.3
    line_coverage          ->  52.8
    lines_to_cover         ->  20917
    uncovered_lines        ->  9872

Plausibility checked rather than assumed, which is what the properties
file asks for: Python alone measures 56.74%, the file records an earlier
scan at 51.8%, and 53.3% is the expected blend once the untested legacy
JS is included.

## Mechanised, because a remembered step is exactly what failed

- `make coverage` generates both reports and **fails if either is empty**,
  so a silent false zero cannot reach the server.
- `make sonar` depends on it, so the reports cannot be forgotten. It reads
  the token from a file into the environment, never onto the command
  line, so it stays out of the process list and shell history.
- `make sonar-token-check` runs **first**. A missing token now fails in
  0.04s instead of after the four-minute coverage run — a target that
  wastes an evening gets abandoned rather than fixed.
- The success output restates that a scan is a measurement, not a
  verdict, and that nothing is resolved to move a number.

Deliberately **not** wired into `verify` and **not** in CI: it is
reporting, not a gate, and the runners cannot reach the self-hosted
server. The answer to that is not to expose it.

## Context

This came out of the owner asking whether scans were being uploaded
during merges. They were not — four PRs merged after T17 with no scan,
so the dashboard still showed all three fixed vulnerabilities as open.
The first re-scan confirmed T17 (`vulnerabilities 3 -> 0`, `security
rating D -> A`) and surfaced three findings nothing else had, recorded
as T24 (a BLOCKER `len()`-on-a-boolean crash), T25 (39 unlabelled inputs
behind a green a11y gate) and this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
