### PR TITLE
T24: hadouken calls len() on a boolean — a guaranteed crash with no test to catch it

### DIFF
--- a/couchpotato/core/downloaders/hadouken.py
+++ b/couchpotato/core/downloaders/hadouken.py
@@ -183,7 +183,7 @@ class Hadouken(DownloaderBase):
                 'seed_ratio': torrent.get_seed_ratio(),
                 'original_status': torrent.state,
                 'timeleft': -1,
-                'folder': sp(torrent.save_path if len(torrent_files == 1) else os.path.join(torrent.save_path, torrent.name)),
+                'folder': sp(torrent.save_path if len(torrent_files) == 1 else os.path.join(torrent.save_path, torrent.name)),
                 'files': torrent_files
             })
 

--- a/couchpotato/core/downloaders/putio/main.py
+++ b/couchpotato/core/downloaders/putio/main.py
@@ -22,7 +22,7 @@ class PutIO(DownloaderBase):
         })
         addEvent('putio.download', self.putioDownloader)
 
-        return super().__init__()
+        super().__init__()
 
     # This is a recusive function to check for the folders
     def recursionFolder(self, client, folder = 0, tfolder = ''):

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -965,7 +965,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       error handling for a condition that cannot occur, and repairing
       unreachable code was exactly the trap T15 fell into.
 
-- [ ] T24: `hadouken.py` calls `len()` on a boolean — state: queued (no deps)
+- [x] T24: `hadouken.py` calls `len()` on a boolean — state: **fixed** (2026-08-12), but see T27 — the downloader is still broken upstream of it
 
       `couchpotato/core/downloaders/hadouken.py:186`:
 
@@ -1044,7 +1044,44 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       `verify` and not in CI: it is reporting, not a gate, and the runners
       cannot reach the server.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T24, T25 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale twice by enumeration alone. T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list.)
+- [ ] T27: hadouken's `TorrentItem` subclasses shadow the base class's properties — state: queued (no deps)
+
+      Found by the implementer while fixing T24, flagged rather than folded
+      in, and it is the bigger of the two.
+
+      `TorrentItem` (`couchpotato/core/downloaders/hadouken.py:359`) declares
+      `info_hash`, `save_path`, `name` and `state` as `@property`.
+      `TorrentItemv4` (`:468`) and `TorrentItemv5` (`:385`) redefine all four
+      as **plain methods with no decorator**. The subclass wins in the MRO,
+      so on a real instance the attribute is a bound method, not a value.
+      Driven on a minimal repro of the same shape:
+
+          type(v.info_hash)   -> method
+          v.info_hash.upper() -> AttributeError: 'function' object has no
+                                 attribute 'upper'
+          v.info_hash()       -> 'abc123'      (the value, only if CALLED)
+
+      `getAllDownloadStatus` does `torrent.info_hash.upper()` at `:180` and
+      passes `torrent.info_hash` into `get_files_by_hash` at `:173`, both
+      BEFORE the `len()` line T24 repaired. So the function raises earlier
+      than the bug T24 fixed, and **T24 alone does not make this downloader
+      work** — that is why T24 is ticked with a pointer here rather than as
+      "hadouken status fixed".
+
+      Same root cause as T24, one layer up: this downloader has no test that
+      constructs a real `TorrentItemv4`/`v5`, so two guaranteed crashes have
+      sat in it undisturbed. T24 added coverage for the one line in its
+      scope using a plain fake torrent, which is deliberately narrow and
+      does NOT exercise these classes.
+
+      Fix shape: decide whether the base class's `@property` declarations or
+      the subclasses' plain methods are the intended interface, make both
+      subclasses match, and update the four call sites in
+      `getAllDownloadStatus` accordingly. Then test against a real
+      `TorrentItemv4` and `TorrentItemv5` built from representative API
+      payloads, not a fake — a fake torrent is exactly what let this survive.
+
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T27 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale twice by enumeration alone. T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list.)
 
       **Runs LAST, and it is not a duplicate of T7 even though it sounds like
       one.** T7 is a scoped pass over the specific items this plan's reviews

--- a/tests/unit/test_downloaders.py
+++ b/tests/unit/test_downloaders.py
@@ -2799,3 +2799,86 @@ class TestHadoukenDownloadFile:
         mock_api.add_file.assert_not_called()
         assert mock_log_error.call_count == 1
         assert 'Invalid/corrupt torrent file' in mock_log_error.call_args[0][0]
+
+
+class FakeHadoukenTorrent:
+    """Minimal stand-in for TorrentItem[v4|v5] -- plain attributes plus the
+    two computed-status methods, matching exactly what getAllDownloadStatus
+    reads off a torrent. Not a MagicMock: a MagicMock tolerates the
+    `len(torrent_files == 1)` bug silently (its `.upper()`/comparisons never
+    raise), which would hide the exact defect this test exists to catch."""
+
+    def __init__(self, info_hash, name, save_path, state = 1):
+        self.info_hash = info_hash
+        self.name = name
+        self.save_path = save_path
+        self.state = state
+
+    def get_status(self):
+        return 'busy'
+
+    def get_seed_ratio(self):
+        return 0
+
+
+class TestHadoukenGetAllDownloadStatus:
+    """T24: hadouken.py:186 transposed `len(torrent_files == 1)` for
+    `len(torrent_files) == 1` -- comparing a list to an int is always False,
+    and len(False) raises TypeError, so getAllDownloadStatus crashed on the
+    first torrent in the queue, every time."""
+
+    def _make_hadouken(self, conf_values = None):
+        from couchpotato.core.downloaders.hadouken import Hadouken
+        conf_values = conf_values or {}
+        hd = Hadouken.__new__(Hadouken)
+
+        def conf(key, **kw):
+            return conf_values.get(key, kw.get('default', ''))
+
+        hd.conf = conf
+        return hd
+
+    def test_getAllDownloadStatus_single_file_torrent_folder_is_save_path(self, tmp_path):
+        """A single-file torrent's folder is just save_path -- not
+        save_path/name."""
+        save_path = str(tmp_path)
+        hd = self._make_hadouken()
+        mock_api = MagicMock()
+        hd.hadouken_api = mock_api
+
+        torrent = FakeHadoukenTorrent(
+            info_hash = 'abc123', name = 'Movie.mkv', save_path = save_path,
+        )
+        mock_api.get_by_hash_list.return_value = [torrent]
+        mock_api.get_files_by_hash.return_value = ['Movie.mkv']
+
+        with patch.object(hd, 'connect', return_value = True):
+            result = hd.getAllDownloadStatus(['ABC123'])
+
+        assert len(result) == 1
+        assert result[0]['folder'] == save_path
+        assert result[0]['files'] == [os.path.join(save_path, 'Movie.mkv')]
+
+    def test_getAllDownloadStatus_multi_file_torrent_folder_is_save_path_plus_name(self, tmp_path):
+        """A multi-file torrent's folder is save_path/name -- the files sit
+        in a subfolder named after the torrent, not directly under
+        save_path."""
+        save_path = str(tmp_path)
+        hd = self._make_hadouken()
+        mock_api = MagicMock()
+        hd.hadouken_api = mock_api
+
+        torrent = FakeHadoukenTorrent(
+            info_hash = 'def456', name = 'MovieSet', save_path = save_path,
+        )
+        mock_api.get_by_hash_list.return_value = [torrent]
+        mock_api.get_files_by_hash.return_value = ['a.mkv', 'b.srt']
+
+        with patch.object(hd, 'connect', return_value = True):
+            result = hd.getAllDownloadStatus(['DEF456'])
+
+        assert len(result) == 1
+        assert result[0]['folder'] == os.path.join(save_path, 'MovieSet')
+        assert sorted(result[0]['files']) == sorted([
+            os.path.join(save_path, 'a.mkv'), os.path.join(save_path, 'b.srt'),
+        ])


### PR DESCRIPTION
`hadouken.py:186` called `len()` on a boolean. SonarQube BLOCKER
`python:S2159`, found by the first re-scan after T17.

```python
'folder': sp(torrent.save_path if len(torrent_files == 1) else ...)
```

`torrent_files == 1` compares a list to an int, so it is always `False`,
and `len(False)` raises. It is a transposition of
`len(torrent_files) == 1`. Driven:

    TypeError: object of type 'bool' has no len()   <-- for ANY value

Not conditional on data: it raises on the first torrent in the queue,
every time.

## Why it survived

There is no hadouken test file. A guaranteed, unconditional crash sat in
a shipped downloader because nothing ever called it. So the fix is one
character and the test is the deliverable — driving `getAllDownloadStatus`
and asserting the resulting `folder` for both the single-file and
multi-file branches, on actual paths rather than "it did not raise". A
no-exception assertion would pass against `len(torrent_files) != 1` too
and leave the fix half-guarded.

Mutation-proven both ways: reverting to the original bug fails both
tests with the original `TypeError`; flipping to `!=` fails them on the
**assertions** instead, with the paths swapped. So the tests pin which
branch produces which path, not merely that the call completes.

`grep -rnE "len\([^)]*[=!]="` across the tree returns only this line, so
the transposition is isolated.

## This does NOT make the downloader work — see T27

While adding coverage, the implementer found a second crash **upstream**
of this one, and flagged it rather than folding it in.

`TorrentItem` declares `info_hash`, `save_path`, `name` and `state` as
`@property`. `TorrentItemv4` and `TorrentItemv5` redefine all four as
plain methods with no decorator, so the subclass wins in the MRO and the
attribute is a bound method rather than a value:

    type(v.info_hash)   -> method
    v.info_hash.upper() -> AttributeError: 'function' object has no
                           attribute 'upper'

`getAllDownloadStatus` does `torrent.info_hash.upper()` at `:180`, before
the line this PR repairs. So the function still raises, earlier.

T24 is ticked with a pointer to **T27** rather than as "hadouken status
fixed", because it is not. The new tests use a plain fake torrent and
deliberately do not exercise those classes — that is a narrow test of the
line in scope, not a claim the downloader works end to end. Same root
cause as T24 one layer up: nothing constructs a real `TorrentItemv4`/`v5`,
which is how two guaranteed crashes sat undisturbed.

## Also

`python:S2734` at `putio/main.py:25` — `return super().__init__()`.
**Cosmetic, not a crash**: `object.__init__` returns `None` and returning
`None` from `__init__` is legal. Stated explicitly so nobody later reads
this commit as having fixed a bug there.

## Verification

`make verify` green (`GATE_RC=0`), 3401 unit tests, `ruff` clean.
Mutations hash-confirmed to have landed, byte-identical restores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
