### PR TITLE
T27: hadouken's TorrentItem subclasses shadow the base class's properties

### DIFF
--- a/couchpotato/core/downloaders/hadouken.py
+++ b/couchpotato/core/downloaders/hadouken.py
@@ -386,15 +386,19 @@ class TorrentItemv5(TorrentItem):
     def __init__(self, obj):
         self.obj = obj
 
+    @property
     def info_hash(self):
         return self.obj[0]
 
+    @property
     def save_path(self):
         return self.obj[26]
 
+    @property
     def name(self):
         return self.obj[2]
 
+    @property
     def state(self):
         return self.obj[1]
 
@@ -469,15 +473,19 @@ class TorrentItemv4(TorrentItem):
     def __init__(self, obj):
         self.obj = obj
 
+    @property
     def info_hash(self):
         return self.obj['InfoHash']
 
+    @property
     def save_path(self):
         return self.obj['SavePath']
 
+    @property
     def name(self):
         return self.obj['Name']
 
+    @property
     def state(self):
         return self.obj['State']
 

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -1044,7 +1044,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       `verify` and not in CI: it is reporting, not a gate, and the runners
       cannot reach the server.
 
-- [ ] T27: hadouken's `TorrentItem` subclasses shadow the base class's properties — state: queued (no deps)
+- [x] T27: hadouken's `TorrentItem` subclasses shadow the base class's properties — state: **fixed** (2026-08-12)
 
       Found by the implementer while fixing T24, flagged rather than folded
       in, and it is the bigger of the two.
@@ -1081,7 +1081,51 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       `TorrentItemv4` and `TorrentItemv5` built from representative API
       payloads, not a fake — a fake torrent is exactly what let this survive.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T27 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale twice by enumeration alone. T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list.)
+- [ ] T28: hadouken's user_pass auth cannot connect — `b64encode` is handed a str — state: queued (no deps)
+
+      Third guaranteed crash found in this one file, flagged by the T27
+      implementer rather than folded in. `hadouken.py:57`:
+
+          header = 'Basic ' + b64encode(self.conf('auth_user') + ':' + self.conf('auth_pass'))
+
+      `b64encode` requires bytes. Driven:
+
+          b64encode('user:pass') -> TypeError: a bytes-like object is
+                                    required, not 'str'
+
+      Fires in `connect()` for any v5 Hadouken configured with
+      `auth_type = 'user_pass'`, so that authentication mode has never
+      worked. `api_key` auth is unaffected and takes a different branch.
+
+      Fix is `.encode()` on the joined string and `.decode()` on the result
+      (the header must be a str), but **do not fix it blind**: this is a
+      credential-carrying line, so check the encoding matches what Hadouken
+      actually expects rather than what makes the TypeError go away, and
+      keep the credentials out of any log added while testing.
+
+      **What this file's record says about scope.** Three separate
+      guaranteed crashes have now come out of `hadouken.py` (T24's `len()`
+      on a boolean, T27's property shadowing, and this). That is the
+      "question the frame" signal, so the frame was questioned before
+      writing this entry, and the answer was measured rather than assumed:
+
+      - `download()` does NOT use the broken attributes — it computes the
+        info hash itself and calls `add_magnet_link`/`add_file`. It works.
+      - `connect()` works under `api_key` auth.
+      - `getAllDownloadStatus()` was the broken half, and T24 + T27 fixed it.
+
+      So this downloader was **partially** functional, not dead: an operator
+      on `api_key` auth could add torrents and simply never see them
+      complete. That rules out the tempting conclusion — deleting it under
+      T18 as obviously-dead code — because someone may have it configured
+      and working to that extent. Fix T28, do not remove the module.
+
+      The real lesson is the test gap, not any one bug: nothing constructed
+      a real `TorrentItemv4`/`v5` or exercised `connect()`, which is how
+      three crashes shipped. T24 and T27 added coverage for their own lines;
+      `connect()` still has none.
+
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T28 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale twice by enumeration alone. T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list.)
 
       **Runs LAST, and it is not a duplicate of T7 even though it sounds like
       one.** T7 is a scoped pass over the specific items this plan's reviews

--- a/tests/unit/test_downloaders.py
+++ b/tests/unit/test_downloaders.py
@@ -2882,3 +2882,197 @@ class TestHadoukenGetAllDownloadStatus:
         assert sorted(result[0]['files']) == sorted([
             os.path.join(save_path, 'a.mkv'), os.path.join(save_path, 'b.srt'),
         ])
+
+
+class TestTorrentItemProperties:
+    """T27: TorrentItem declares info_hash/save_path/name/state as
+    @property on the base class, but TorrentItemv4 and TorrentItemv5 both
+    redefine all four as plain methods with no decorator. The subclass wins
+    the MRO, so on a real instance `torrent.info_hash` is a bound method,
+    not a value -- getAllDownloadStatus dereferences it as a value at six
+    call sites (hadouken.py:173-186) and crashes (or silently passes a
+    method where a string was expected) before it ever reaches the T24
+    len() fix. FakeHadoukenTorrent (above) is a plain-attribute stub and
+    can never catch this -- these tests build the REAL classes instead.
+    """
+
+    def _make_v4_payload(self):
+        # Realistic Hadouken v4 torrents.getByInfoHashList() dict payload.
+        return {
+            'InfoHash': 'ABCDEF0123456789ABCDEF0123456789ABCDEF01',
+            'SavePath': '/downloads/complete',
+            'Name': 'Some.Movie.2026.1080p',
+            'State': 'Seeding',
+            'IsSeeding': True,
+            'IsFinished': True,
+            'Paused': True,
+            'TotalUploadedBytes': 200,
+            'TotalDownloadedBytes': 100,
+        }
+
+    def _make_v5_payload(self):
+        # Realistic Hadouken v5 webui.list() torrent row: a flat indexable
+        # sequence, not a dict. Only indices 0 (info_hash), 1 (state),
+        # 2 (name), 5 (down bytes), 6 (up bytes) and 26 (save_path) are
+        # read by TorrentItemv5 / getAllDownloadStatus, so the list must be
+        # at least 27 long to cover index 26; the untouched slots are
+        # padded with 0 as harmless placeholders matching Hadouken's
+        # numeric-only row shape.
+        row = [0] * 27
+        row[0] = 'FEDCBA9876543210FEDCBA9876543210FEDCBA98'  # info_hash
+        row[1] = 32                                          # state (completed)
+        row[2] = 'Another.Movie.2026.1080p'                  # name
+        row[5] = 100                                         # down bytes
+        row[6] = 200                                         # up bytes
+        row[26] = '/downloads/complete'                      # save_path
+        return row
+
+    # -- TorrentItemv4 -----------------------------------------------------
+
+    def test_torrentitemv4_info_hash_is_not_callable(self):
+        """The exact defect: on the unfixed class, info_hash is a bound
+        method (callable), not a string. This is what turns line 180's
+        `torrent.info_hash.upper()` into an AttributeError in production."""
+        from couchpotato.core.downloaders.hadouken import TorrentItemv4
+        torrent = TorrentItemv4(self._make_v4_payload())
+
+        assert not callable(torrent.info_hash), (
+            'TorrentItemv4.info_hash must be a @property returning a value, '
+            'not a bound method -- shadowing TorrentItem.info_hash'
+        )
+        assert torrent.info_hash == 'ABCDEF0123456789ABCDEF0123456789ABCDEF01'
+
+    def test_torrentitemv4_save_path_name_state_are_not_callable_and_correct(self):
+        from couchpotato.core.downloaders.hadouken import TorrentItemv4
+        torrent = TorrentItemv4(self._make_v4_payload())
+
+        assert not callable(torrent.save_path)
+        assert not callable(torrent.name)
+        assert not callable(torrent.state)
+
+        assert torrent.save_path == '/downloads/complete'
+        assert torrent.name == 'Some.Movie.2026.1080p'
+        assert torrent.state == 'Seeding'
+
+    def test_torrentitemv4_get_status_and_get_seed_ratio_remain_plain_methods(self):
+        """get_status/get_seed_ratio must stay plain methods on every class
+        -- @property must not bleed onto them as a side effect of this fix."""
+        from couchpotato.core.downloaders.hadouken import TorrentItemv4
+        torrent = TorrentItemv4(self._make_v4_payload())
+
+        assert callable(torrent.get_status)
+        assert callable(torrent.get_seed_ratio)
+        assert torrent.get_status() == 'completed'
+        assert torrent.get_seed_ratio() == 2.0
+
+    # -- TorrentItemv5 -----------------------------------------------------
+
+    def test_torrentitemv5_info_hash_is_not_callable(self):
+        """Same defect, the v5 class -- a fix applied to only v4 would leave
+        this one broken, so it is pinned separately."""
+        from couchpotato.core.downloaders.hadouken import TorrentItemv5
+        torrent = TorrentItemv5(self._make_v5_payload())
+
+        assert not callable(torrent.info_hash), (
+            'TorrentItemv5.info_hash must be a @property returning a value, '
+            'not a bound method -- shadowing TorrentItem.info_hash'
+        )
+        assert torrent.info_hash == 'FEDCBA9876543210FEDCBA9876543210FEDCBA98'
+
+    def test_torrentitemv5_save_path_name_state_are_not_callable_and_correct(self):
+        from couchpotato.core.downloaders.hadouken import TorrentItemv5
+        torrent = TorrentItemv5(self._make_v5_payload())
+
+        assert not callable(torrent.save_path)
+        assert not callable(torrent.name)
+        assert not callable(torrent.state)
+
+        assert torrent.save_path == '/downloads/complete'
+        assert torrent.name == 'Another.Movie.2026.1080p'
+        assert torrent.state == 32
+
+    def test_torrentitemv5_get_status_and_get_seed_ratio_remain_plain_methods(self):
+        from couchpotato.core.downloaders.hadouken import TorrentItemv5
+        torrent = TorrentItemv5(self._make_v5_payload())
+
+        assert callable(torrent.get_status)
+        assert callable(torrent.get_seed_ratio)
+        assert torrent.get_status() == 'completed'
+        assert torrent.get_seed_ratio() == 2.0
+
+
+class TestHadoukenGetAllDownloadStatusWithRealTorrentItems:
+    """T27: drives getAllDownloadStatus end to end against the REAL
+    TorrentItemv4/TorrentItemv5 classes (not FakeHadoukenTorrent, not a bare
+    MagicMock standing in for the torrent) -- proving the property fix
+    actually closes the gap between the (already correct) call sites and
+    the (previously shadowed) class attributes."""
+
+    def _make_hadouken(self, conf_values = None):
+        from couchpotato.core.downloaders.hadouken import Hadouken
+        conf_values = conf_values or {}
+        hd = Hadouken.__new__(Hadouken)
+
+        def conf(key, **kw):
+            return conf_values.get(key, kw.get('default', ''))
+
+        hd.conf = conf
+        return hd
+
+    def test_getAllDownloadStatus_with_real_torrentitemv4(self, tmp_path):
+        from couchpotato.core.downloaders.hadouken import TorrentItemv4
+        save_path = str(tmp_path)
+        payload = {
+            'InfoHash': 'abc123def456',
+            'SavePath': save_path,
+            'Name': 'Real.Movie.2026',
+            'State': 'Seeding',
+            'IsSeeding': True,
+            'IsFinished': True,
+            'Paused': True,
+            'TotalUploadedBytes': 10,
+            'TotalDownloadedBytes': 5,
+        }
+        real_torrent = TorrentItemv4(payload)
+
+        hd = self._make_hadouken()
+        mock_api = MagicMock()
+        hd.hadouken_api = mock_api
+        mock_api.get_by_hash_list.return_value = [real_torrent]
+        mock_api.get_files_by_hash.return_value = ['Real.Movie.2026.mkv']
+
+        with patch.object(hd, 'connect', return_value = True):
+            result = hd.getAllDownloadStatus(['ABC123DEF456'])
+
+        assert len(result) == 1
+        assert result[0]['id'] == 'ABC123DEF456'
+        assert result[0]['name'] == 'Real.Movie.2026'
+        assert result[0]['original_status'] == 'Seeding'
+        assert result[0]['folder'] == save_path
+
+    def test_getAllDownloadStatus_with_real_torrentitemv5(self, tmp_path):
+        from couchpotato.core.downloaders.hadouken import TorrentItemv5
+        save_path = str(tmp_path)
+        row = [0] * 27
+        row[0] = 'fedcba987654'
+        row[1] = 32
+        row[2] = 'Real.MovieSet.2026'
+        row[5] = 5
+        row[6] = 10
+        row[26] = save_path
+        real_torrent = TorrentItemv5(row)
+
+        hd = self._make_hadouken()
+        mock_api = MagicMock()
+        hd.hadouken_api = mock_api
+        mock_api.get_by_hash_list.return_value = [real_torrent]
+        mock_api.get_files_by_hash.return_value = ['a.mkv', 'b.srt']
+
+        with patch.object(hd, 'connect', return_value = True):
+            result = hd.getAllDownloadStatus(['FEDCBA987654'])
+
+        assert len(result) == 1
+        assert result[0]['id'] == 'FEDCBA987654'
+        assert result[0]['name'] == 'Real.MovieSet.2026'
+        assert result[0]['original_status'] == 32
+        assert result[0]['folder'] == os.path.join(save_path, 'Real.MovieSet.2026')


### PR DESCRIPTION
The follow-on to T24 (#257), and the reason that PR was ticked with a
pointer rather than as "hadouken status fixed".

## The bug

`TorrentItem` declares `info_hash`, `save_path`, `name` and `state` as
`@property`. `TorrentItemv4` and `TorrentItemv5` redefine all four as
plain methods with no decorator. The subclass wins in the MRO, so on a
real instance the attribute is a bound method, not a value:

    type(v.info_hash)   -> method
    v.info_hash.upper() -> AttributeError: 'function' object has no
                           attribute 'upper'

`getAllDownloadStatus` uses them as values at six sites. Line 173 passes
a bound method into the API client and line 180 raises — both **before**
the `len()` line T24 repaired.

## The fix, and why this direction

`@property` added to the eight subclass methods. The alternative — strip
`@property` from the base and rewrite six call sites — was rejected: the
call sites already dereference these as values, the base class already
declares the contract, and nothing outside this file constructs these
classes, so there was no external caller pulling the other way.
`get_status()` and `get_seed_ratio()` were already consistent plain
methods on all three classes and are untouched.

Eight lines of source. 194 lines of test.

## The test is the deliverable

T24's lesson was that **nothing in this repo constructs a real
`TorrentItemv4` or `v5`** — which is how two guaranteed crashes shipped.
Its own tests used a plain fake torrent and deliberately did not exercise
these classes.

So this builds real instances from representative payloads (v5 indexes
element 26, so the fixture is long enough to be honest), asserts each
attribute returns a **value rather than a callable**, and drives
`getAllDownloadStatus` end to end against them.

Mutation-proven per class, not once: stripping `@property` from v4 alone
fails named v4 tests, and likewise for v5. They are independent classes,
so fixing one is a plausible half-fix that would otherwise look complete.
Hash-confirmed the mutation landed where intended, byte-identical restore.

## A third crash found — recorded as T28, not fixed here

`hadouken.py:57` passes a `str` to `b64encode`, which requires bytes:

    b64encode('user:pass') -> TypeError: a bytes-like object is required

So `user_pass` auth has never been able to connect. `api_key` auth takes
a different branch and is unaffected.

**Three guaranteed crashes from one file is the question-the-frame
signal, so the frame was questioned — and the answer was measured rather
than assumed.** The tempting conclusion was that this downloader is
obviously-dead code to be swept under T18. It is not:

- `download()` never touches the broken attributes — it computes the info
  hash itself and calls `add_magnet_link`/`add_file`. It works.
- `connect()` works under `api_key` auth.
- `getAllDownloadStatus()` was the broken half, now fixed by T24 + T27.

So an operator on `api_key` auth could add torrents and simply never see
them complete. That is partial function, not death, and it rules out
removal — someone may have this configured and working to that extent.

The real lesson is the test gap rather than any single bug. `connect()`
still has no coverage at all.

## Verification

`make verify` green (`GATE_RC=0`), 3409 unit tests, `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
