### PR TITLE
T33: take five dependency bumps, completing the three-way ruff pin (and record two security findings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         python-version: '3.14'
 
     - name: Install ruff
-      run: pip install 'ruff==0.16.1'
+      run: pip install 'ruff==0.16.2'
 
     - name: Run ruff
       run: ruff check .
@@ -231,7 +231,7 @@ jobs:
         python-version: '3.14'
 
     - name: Install ruff
-      run: pip install 'ruff==0.16.1'
+      run: pip install 'ruff==0.16.2'
 
     - name: ruff security lint (bandit S rules)
       continue-on-error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ source_paths = ["couchpotato/core/db/sqlite_adapter.py"]
 # every bump, and a wrong one reads as precision.
 tests_dir = ["tests/unit/"]
 # `runner`, by contrast, is INERT on mutmut 3.x (re-verified on 3.7.0) —
-# config loading never reads it
+# `_load_config()` never reads it
 # and __main__.py hardcodes `runner = PytestRunner()` under a `# TODO:
 # config/option for runner`. It is kept only as documentation of which tests
 # cover the mutated module; editing it changes nothing, so if you need to narrow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,16 +129,23 @@ ignore = [
 # keep the runner pointed at the tests that actually cover the mutated paths
 # so each run stays fast enough to be useful.
 #
-# `source_paths` is the modern key — mutmut 3.6 warns that the old
+# `source_paths` is the modern key — mutmut 3.x warns that the old
 # `paths_to_mutate` name is deprecated. scripts/mutation_changed.py reads this
 # list rather than keeping its own copy, and accepts either name.
 source_paths = ["couchpotato/core/db/sqlite_adapter.py"]
-# `tests_dir` is LOAD-BEARING despite the deprecation warning: mutmut 3.6 folds it
-# into `pytest_add_cli_args_test_selection` (configuration.py:110) and uses it to
-# select tests (__main__.py:424, :475). Migrate the key when convenient, but do
-# not simply delete it.
+# `tests_dir` is LOAD-BEARING despite the deprecation warning: mutmut 3.x folds it
+# into `pytest_add_cli_args_test_selection` (in `configuration.py`) and uses it to
+# select tests (`__main__.py`, the pytest-arg assembly and the --collect-only
+# call). Migrate the key when convenient, but do not simply delete it.
+#
+# Cited by SYMBOL, not by line. This comment previously carried three exact
+# line numbers and ALL THREE moved between 3.6.0 and 3.7.0 — caught in review
+# of the 3.7.0 bump, along with a claim in that bump's own commit message that
+# they had not gone stale. Line citations into a third-party package rot on
+# every bump, and a wrong one reads as precision.
 tests_dir = ["tests/unit/"]
-# `runner`, by contrast, is INERT on mutmut 3.6 — `_load_config()` never reads it
+# `runner`, by contrast, is INERT on mutmut 3.x (re-verified on 3.7.0) —
+# config loading never reads it
 # and __main__.py hardcodes `runner = PytestRunner()` under a `# TODO:
 # config/option for runner`. It is kept only as documentation of which tests
 # cover the mutated module; editing it changes nothing, so if you need to narrow

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,9 +5,9 @@ pytest==9.1.1
 pytest-cov>=7.1.0
 coverage==7.15.2
 httpx>=0.28.1
-ruff==0.16.1
+ruff==0.16.2
 pytest-timeout>=2.4.0
-mutmut>=3.6.0
+mutmut>=3.7.0
 # Used by scripts/check_test_traps.py to parse GitHub workflows with a real
 # parser instead of a hand-rolled one (two rounds of review found edge cases in
 # the hand-rolled version: `- ` inside a block scalar, comments in a shell: value).

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,15 @@ click-option-group==0.5.9
 defusedxml==0.7.1
 trakit==0.2.5
 decorator==5.3.1
+# 4.5 is a SECURITY fix, not a routine minor: GHSA-94vx-95fq-wwvp (High),
+# unbounded read with comments, published 2026-08-02. No CVE was assigned,
+# which is why it arrived looking routine. It also truncates filenames at the
+# first NUL byte. This is the library that parses a .rar arriving from a
+# hostile torrent, so it sits inside the threat model rather than beside it.
+#
+# NOTE for the next bump: rarfile 5.0 removes root-level config, so
+# `rarfile.UNRAR_TOOL = ...` (renamer/extractor.py) stops working and becomes
+# `rarfile.config.UNRAR_TOOL` — SILENTLY. Hold 5.0 until that is ported.
 rarfile==4.5
 
 # Downloaders

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # Web Framework
 fastapi==0.141.1
 starlette==1.3.1
-uvicorn==0.51.0
+uvicorn==0.52.1
 Jinja2==3.1.6
 python-multipart==0.0.32
 
@@ -43,12 +43,12 @@ click-option-group==0.5.9
 defusedxml==0.7.1
 trakit==0.2.5
 decorator==5.3.1
-rarfile==4.4
+rarfile==4.5
 
 # Downloaders
 deluge-client==1.10.2
 putio.py==8.8.0
-qbittorrent-api==2026.7.0
+qbittorrent-api==2026.8.0
 rtorrent-rpc==0.9.7
 
 # Notifications

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -1134,7 +1134,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       three crashes shipped. T24 and T27 added coverage for their own lines;
       `connect()` still has none.
 
-- [ ] T29: `HadoukenAPIv4` cannot be constructed, so the entire v4 protocol is unusable — state: pr-open #261 (owner approved removal 2026-08-12; the box is ticked only when #261 merges, not when the decision was made)
+- [x] T29: `HadoukenAPIv4` cannot be constructed, so the entire v4 protocol is unusable — state: **merged #261** (`e433ceba`, 2026-08-18) — closed by REMOVAL, not by a fix; verified from `gh pr view` and by `git ls-files` on master showing no hadouken file tracked
 
       Fourth guaranteed crash from this file, found by the T28 implementer
       driving `connect()`'s v4 branch for real instead of mocking the API
@@ -1195,7 +1195,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       test (`test_connect_v4_raises_typeerror_pre_existing_unrelated_bug`)
       no longer exist to fix or invert.
 
-- [ ] T30: no hadouken RPC can succeed — `invoke` posts a str body — state: pr-open #261 (owner approved removal 2026-08-12; the box is ticked only when #261 merges, not when the decision was made)
+- [x] T30: no hadouken RPC can succeed — `invoke` posts a str body — state: **merged #261** (`e433ceba`, 2026-08-18) — closed by REMOVAL, not by a fix; verified from `gh pr view` and by `git ls-files` on master showing no hadouken file tracked
 
       Fifth guaranteed crash in this file, raised in review of #259 and
       confirmed by driving it:
@@ -1247,7 +1247,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       `couchpotato/core/downloaders/hadouken.py` is deleted, nothing was
       patched.
 
-- [ ] T31: `getValues()` returns an unregistered section's secrets UNMASKED — state: building, in #261 (was: queued, no deps)
+- [x] T31: `getValues()` returns an unregistered section's secrets UNMASKED — state: **merged #261** (`e433ceba`, 2026-08-18) — masking by registration, verified present on master after merge
 
       Found while removing hadouken, by an implementer driving the orphan
       `[hadouken]` config section rather than reasoning about it. General,
@@ -1486,7 +1486,88 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       rating D -> A, BLOCKER bugs 2 -> 0, coverage 0.0 -> 53.5%) so the trend
       is visible rather than just the current state.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T31, T32, T33, T34, T35 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale twice by enumeration alone. T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too.)
+- [ ] T36: a hostile archive entry escapes the extraction directory via BACKSLASHES — state: queued (no deps) — **security, attacker-reachable**
+
+      Found by the security lens while reviewing the rarfile 4.5 bump, and
+      confirmed independently by driving the real `sp()` rather than reading it:
+
+          entry name                             -> resolved target
+          ../../../evil.txt                      -> /tmp/extract_here/evil.txt   contained
+          ..\..\..\CP_PWNED_BACKSLASH.txt        -> /CP_PWNED_BACKSLASH.txt      *** ESCAPES ***
+          /etc/passwd                            -> /tmp/extract_here/passwd     contained
+          ....//....//evil.txt                   -> /tmp/extract_here/evil.txt   contained
+
+      `extractor.py` flattens each entry with
+      `os.path.basename(info.filename)`, which defeats `../`, absolute paths
+      and `....//`. But on POSIX a BACKSLASH is not a separator, so
+      `..\..\..\x` survives `basename` intact. `sp()`
+      (`helpers/encoding.py`) then does the damage in its Windows-path
+      conversion: it replaces `\` with `/` **and prepends `/`**, anchoring the
+      result at root, after which `normpath` walks straight out of
+      `extr_path`. The reviewer drove the full `extractArchive` and the file
+      was written to disk outside the extraction directory.
+
+      **Reachable from an ordinary automated download.** This is the library
+      that parses a `.rar` from a torrent, i.e. exactly the hostile-input path
+      the project's threat model names.
+
+      **Bounded, and the bound matters for ranking.** `extractor.py` skips
+      extraction when the destination already exists, so this is arbitrary
+      NEW-FILE creation, not overwrite — measured against a stand-in
+      `couchpotato.db` three levels up, the target resolved onto it and the
+      bytes were unchanged. It cannot destroy the database, `config.ini` or
+      media, which keeps it off the top of the loss hierarchy but does not make
+      it acceptable.
+
+      **Taking rarfile 4.5 does NOT close it.** 4.5 ships a realpath escape
+      guard in `RarFile._extract_one`, but CouchPotato never calls
+      `extract()`/`extractall()` — it rolls its own loop over `open(info)`, so
+      it bypasses the guard entirely. That is worth stating plainly, because
+      "we took the security bump" would otherwise read as coverage.
+
+      Fix belongs in `extractArchive`: reject or sanitise the entry name before
+      `sp()`, and assert the resolved target is under
+      `os.path.realpath(extr_path)`. The test must feed the BACKSLASH form —
+      a `../` fixture passes today and would guard nothing (§11: feed it
+      hostile inputs, not polite ones).
+
+      Symlink following is genuinely safe and needs no work: rarfile returns
+      `io.BytesIO(redir_name)` for a symlink entry, so CP writes a regular file
+      containing the link target as text and never creates a link.
+
+- [ ] T37: the login throttle is bypassable by rotating `X-Forwarded-For` — state: queued (no deps) — **security**
+
+      `rate_limit.py` rests on a premise that is the exact inverse of the
+      truth. Its comment says "nothing here configures uvicorn's
+      `proxy_headers` or `forwarded_allow_ips`, so `request.client.host` is the
+      TCP peer". Not configuring them is precisely WHY
+      `ProxyHeadersMiddleware` is active — verified against the installed
+      uvicorn:
+
+          proxy_headers        -> proxy_headers: bool = True
+          forwarded_allow_ips  -> defaults to 127.0.0.1
+
+      So on the deployment shape this project documents (nginx/Caddy/Traefik on
+      the same host, or a proxy container talking to a port-mapped app) the
+      peer IS 127.0.0.1, the middleware trusts it, and the client IP becomes
+      whatever the request claims. Reviewer's measurement, real middleware
+      wrapping the real limiter at `max_requests=5`, 12 x `POST /login/`:
+
+          A  no XFF                    -> 7 x 429
+          B  rotating X-Forwarded-For  -> 0 x 429   (all 12 accepted)
+          C  fixed X-Forwarded-For     -> 7 x 429
+
+      That is AC-SEC-42's protection removed entirely, leaving bcrypt's ~166ms
+      as the only brake on credential stuffing.
+
+      Not caused by the uvicorn 0.51->0.52 bump: the default is identical at
+      0.51.0, and neither release touched proxy headers.
+
+      Whatever the fix, the COMMENT must be corrected too — a comment asserting
+      the inverse of the runtime default is how this survived review the first
+      time.
+
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T33, T34, T35, T36, T37 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale twice by enumeration alone. T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too.)
 
       **Runs LAST, and it is not a duplicate of T7 even though it sounds like
       one.** T7 is a scoped pass over the specific items this plan's reviews

--- a/tests/unit/test_downloaders.py
+++ b/tests/unit/test_downloaders.py
@@ -5,6 +5,7 @@ VENDORED-02: Put.io downloader tests (maintained putiopy client).
 Uses unittest.mock to avoid real network calls.
 """
 import datetime
+import inspect
 import json
 import os
 import sys
@@ -2703,3 +2704,76 @@ class TestDelugeCheckTorrent:
         # from the outer except Exception in add_torrent_file.
         assert mock_log_error.call_count == 1
         assert 'Invalid/corrupt torrent file' in mock_log_error.call_args[0][0]
+
+
+class TestQbittorrentApiSignatureGuard:
+    """Pins the REAL installed qbittorrent-api surface the downloader depends
+    on, so a future bump that drifts it fails here (loudly) instead of
+    silently passing every mocked test in this file.
+
+    Modelled on `TestRarfileApiSignatureGuard` in `test_extractor.py`, and
+    written for the same reason: every other qBittorrent test in this file
+    mocks the client, which bakes in assumptions about an API nothing checks.
+
+    It exists because of how the 2026.7.0 -> 2026.8.0 bump was verified: by
+    probing this surface by hand, once, in a review. Hand-probing catches the
+    bump in front of you and nothing after it -- the next bump would have
+    landed unguarded. §9: a check that can be a test should be one.
+
+    Signature-level only, deliberately. Behavioural drift inside these calls
+    needs a live qBittorrent instance, which CI does not have; that gap is
+    stated rather than papered over. `is_skip_checking`/`seedMode` are NOT
+    pinned here because the downloader does not pass them -- pinning a surface
+    we do not use would be decoration that fails on someone else's change.
+    """
+
+    def test_the_client_exposes_the_api_the_downloader_relies_on(self):
+        qba = pytest.importorskip('qbittorrentapi')
+
+        # Constructor kwargs the downloader passes (connect()).
+        params = inspect.signature(qba.Client.__init__).parameters
+        accepts_kwargs = any(
+            p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+        )
+        for kwarg in ('host', 'username', 'password'):
+            assert kwarg in params or accepts_kwargs, (
+                'qbittorrentapi.Client no longer accepts %r; '
+                'couchpotato/core/downloaders/qbittorrent_.py passes it' % kwarg
+            )
+
+        # Methods the downloader calls, and the one property it reads.
+        for name in (
+            'auth_log_in', 'auth_log_out',
+            'torrents_add', 'torrents_info', 'torrents_files',
+            'torrents_pause', 'torrents_resume', 'torrents_delete',
+        ):
+            assert callable(getattr(qba.Client, name, None)), (
+                'qbittorrentapi.Client.%s is gone or is no longer callable' % name
+            )
+        assert hasattr(qba.Client, 'is_logged_in')
+
+        # The exception type every call site catches. If this stops being the
+        # base of the family, `except qbittorrentapi.APIError` silently stops
+        # catching and a transient blip becomes an unhandled traceback.
+        assert hasattr(qba, 'APIError')
+        assert issubclass(qba.APIError, Exception)
+        assert issubclass(qba.Conflict409Error, qba.APIError), (
+            'Conflict409Error is the add-failure the downloader relies on '
+            'being caught by `except qbittorrentapi.APIError`'
+        )
+
+    def test_torrents_add_still_accepts_the_kwargs_the_downloader_sends(self):
+        """`torrents_add` is called with keyword arguments only. A rename of
+        any of these is a silent behaviour change rather than a crash when the
+        method also takes **kwargs, which is exactly why this is pinned."""
+        qba = pytest.importorskip('qbittorrentapi')
+
+        params = inspect.signature(qba.Client.torrents_add).parameters
+        accepts_kwargs = any(
+            p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+        )
+        for kwarg in ('urls', 'torrent_files', 'category', 'is_stopped'):
+            assert kwarg in params or accepts_kwargs, (
+                'torrents_add no longer names %r; the downloader passes it as a '
+                'keyword, so a rename fails silently rather than loudly' % kwarg
+            )

--- a/tests/unit/test_extractor.py
+++ b/tests/unit/test_extractor.py
@@ -592,7 +592,7 @@ class TestNoExtractorToolMessage:
 
 class TestRarfileApiSignatureGuard:
     """Every other test mocks rarfile, baking in assumptions about its API.
-    This guard pins the REAL installed rarfile==4.2 surface CP's extractor
+    This guard pins the REAL installed rarfile surface CP's extractor
     depends on, so a future dependency bump that drifts the API fails here
     (loudly) instead of silently passing every mocked test.
 


### PR DESCRIPTION
T33. A decision recorded for every open Dependabot PR, per the standing dependency rule. All five taken.

| PR | bump | decision |
|---|---|---|
| #251 | qbittorrent-api 2026.7.0 → 2026.8.0 | take |
| #252 | ruff 0.16.1 → 0.16.2 | take, **completed** — see below |
| #253 | mutmut >=3.6.0 → >=3.7.0 | take, after verifying our config |
| #254 | uvicorn 0.51.0 → 0.52.1 | take |
| #255 | rarfile 4.4 → 4.5 | take — **security fix**, see below |

### #252 was red in CI, for a good reason

It failed `test_the_ruff_pin_agrees_across_requirements_dev_and_both_ci_jobs`. Ruff is pinned **three** ways — `requirements-dev.txt` plus the `lint` and `security-lint` jobs in `ci.yml` — and Dependabot only knows about the first. The duplication is deliberate (`AC-SIMP-9`: sourcing the lint job from `requirements-dev.txt` would install pytest, mutmut and coverage into a lint job for no benefit), and the guard exists so the copies cannot drift. Without it, `verify.sh` goes green locally on one ruff while both CI jobs lint on another, with no signal either way.

So the PR was **incomplete, not wrong**. This moves all three pins. Both reviewers swept the tree for a fourth copy and found none — `scripts/verify.sh` *derives* the pin from `requirements-dev.txt` and `mutation.yml` installs from it, so both track automatically. Both also independently mutated `ci.yml`'s `security-lint` line back to 0.16.1 and watched the guard fail with an accurate message, then restored and re-hashed.

### #255 is a security fix, and the triage nearly missed it

rarfile 4.5 is **GHSA-94vx-95fq-wwvp**, unbounded read with comments, severity **High**, published 2026-08-02. No CVE was assigned, which is why it arrived looking like a routine minor. It also truncates filenames at the first NUL byte. Both changes are inert-to-beneficial here: nothing reads `RarFile.comment`, and the extractor already applies `os.path.basename`, so NUL truncation strictly improves a path-handling line.

Recorded at the pin, along with a hold condition for 5.0, which removes root-level config and would break `rarfile.UNRAR_TOOL = ...` **silently**.

### #253 needed the changelog read, not relayed

`pyproject.toml` documents mutmut internals our config depends on, so a minor bump could have silently changed what it does. Verified against the installed 3.7.0: `source_paths` read, `tests_dir` read and still folded into pytest arg selection, `runner` still never read. Config behaviour unchanged.

A reviewer then caught that my *description* of those comments was wrong — they cite three exact line numbers and the bump moved all three, and my claim that config handling relocated between 3.6 and 3.7 was also wrong (it happened at 3.5→3.6). Corrected in `f90ddcd2`, now cited by symbol. Worth flagging because an assertion that comments are fine is worse than a stale comment: it tells the next reader not to check.

### Evidence

- `pip check` → **No broken requirements found** (exit 0), run immediately after install and before anything else
- full local gate green under ruff 0.16.2, no new rules firing: 3401 python unit / 42 integration / 202 UI unit / 138 E2E / 40 accessibility
- uvicorn's security-relevant defaults verified unchanged and unset by `runner.py`; a reviewer drove the real 0.52.1 server and confirmed the bind-conflict contract (`SystemExit(3)`) and the `access_log=False` privacy contract still hold — the existing test monkeypatches `uvicorn.run`, so it structurally cannot catch that class of drift
- 27 surface/signature probes across rarfile 4.5 and qbittorrent-api 2026.8.0, 0 failures

### Standing holds, unchanged

`stevedore` 5.9.0 (drops Python 3.10) and `rebulk` 6.0.1 (coupled to guessit 3.8.0; fails the suite). Both re-propose each cycle and get closed, not merged.

Not touched here: the npm side. `extract-zip` (alert #114) has no patched version, so its only correct outcome is hold; `nanoid` is a plain `npm audit fix` and belongs in its own change, where an unchanged `package.json` is the signal that only transitive versions moved.

### Two pre-existing security findings, recorded not fixed

Neither is caused by this branch and neither blocks it. Both are in the plan as **T36** and **T37**, and both were re-verified independently rather than taken from the review.

**T36 — a hostile archive entry escapes the extraction directory via backslashes.** `os.path.basename` defeats `../`, absolute paths and `....//`, but a backslash is not a POSIX separator, so `..\..\..\x` survives whole; `sp()` then replaces `\` with `/` **and prepends `/`**, anchoring at root.

```
../../../evil.txt                -> /tmp/extract_here/evil.txt   contained
..\..\..\CP_PWNED_BACKSLASH.txt  -> /CP_PWNED_BACKSLASH.txt      *** ESCAPES ***
```

Reachable from an ordinary automated download. Bounded to new-file creation, not overwrite, because the extractor skips an existing destination. **Taking rarfile 4.5 does not close it** — 4.5's realpath guard lives in `_extract_one`, and CouchPotato never calls `extract()`/`extractall()`.

**T37 — the login throttle is bypassable by rotating `X-Forwarded-For`.** `rate_limit.py` asserts that because nothing configures `proxy_headers`, `request.client.host` is the TCP peer. The inverse is true: not configuring it is why the middleware is active. Verified `proxy_headers: bool = True`, trust defaulting to `127.0.0.1`. Measured at `max_requests=5` over 12 login attempts: 7×429 with no header, **0×429 with a rotating one**.

Closes #251, closes #252, closes #253, closes #254, closes #255
