### PR TITLE
T42: stop gate fixtures inheriting GIT_DIR from a worktree push and corrupting the real repo

### DIFF
--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -1704,7 +1704,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       alternative rather than reasoning about it — the last two attempts in
       this area were both measured worse than what they replaced.
 
-- [x] T42: gate fixtures inherit GIT_DIR from a worktree push and corrupt the real repo — state: building (branch `fix/t42-gitdir-leak`)
+- [ ] T42: gate fixtures inherit GIT_DIR from a worktree push and corrupt the real repo — state: pr-open #264
 
       **Not a theory. It has now corrupted this repository TWICE in one day,**
       both times flipping `core.bare` to `true` so the main checkout stopped
@@ -1755,6 +1755,37 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       not the corruption assertion). Caught because the failure text did not
       name the behaviour being guarded, which is the whole reason for reading
       failure messages rather than counting reds.
+      **Reframed 2026-08-18, after the guard was wrong four times.** The first
+      fix sanitised each call site and added an AST guard to enforce it. That
+      guard missed aliased imports (`subprocess as sp` — 17 of 20 sites in the
+      file the incident happened in), missed subdirectories, accepted any
+      `env=` whether sanitised or not, and could not see argv built by an
+      `*args`-forwarding lambda — a shape with a LIVE unsanitised instance in
+      `test_next_beta_version.py` that the guard passed clean.
+
+      Four defects in one guard is the rule-11 signal, and the frame was
+      wrong: policing call SHAPES is a losing game, because every wrapper,
+      alias and lambda is a new spelling.
+
+      So the hazard is removed instead of the callers policed.
+      `tests/conftest.py` strips the six variables from `os.environ` once, for
+      the whole process, before collection. Every subprocess is then clean by
+      construction, whatever shape the call takes and whether or not its
+      author ever heard of the helper. Proven in isolation: with the scrub
+      removed, running `test_next_beta_version.py` (no sanitisation anywhere)
+      under a poisoned GIT_DIR moves the victim repo's HEAD.
+
+      Three layers, each failing on its own removal:
+
+          process scrub          -> victim HEAD moves
+          per-call sanitisation  -> 1 failed
+          containment assertion  -> 1 failed neutered, 55 affected inverted
+
+      The guard remains as defence in depth with its blind spot STATED rather
+      than implied, and the condition for revisiting recorded: prove any change
+      by planting an offender, never by reading — every defect in it was found
+      that way and none by inspection.
+
 
 - [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T36, T37, T38, T39, T40, T41 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale twice by enumeration alone. T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too.)
       **Add to its scope (2026-08-18):** citations that rot. This session

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -1757,6 +1757,27 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       failure messages rather than counting reds.
 
 - [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T36, T37, T38, T39, T40, T41 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale twice by enumeration alone. T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too.)
+      **Add to its scope (2026-08-18):** citations that rot. This session
+      converted three-line-number citations into a third-party package and
+      several stale line references into symbol citations, for one reason:
+      a wrong citation reads as precision and sends the next reader somewhere
+      specific and wrong.
+
+      One more class, raised by a peer session that hit it: a pinned COMMIT
+      HASH does not survive a history rewrite.
+      `tests/unit/test_check_test_traps.py` cites `git show f7f57b62` in a
+      docstring. It is prose, not executable — grepped, and NO test or script
+      in this repo shells out to a pinned SHA — so a rewrite would mislead a
+      reader rather than fail a gate. Resolve it by commit SUBJECT with an
+      assert-exactly-one-match, or drop the citation.
+
+      The peer's second-order finding is the one worth carrying even though it
+      does not bite us here: after a `filter-branch`, `refs/original/**` keeps
+      the old object reachable, so a test pinning the OLD hash stays GREEN
+      until `reflog expire && gc --prune=now`. A green suite run while the
+      rewrite backups still exist proves nothing about the rewritten repo.
+      Expire the backups first, then run the suite.
+
 
       **Runs LAST, and it is not a duplicate of T7 even though it sounds like
       one.** T7 is a scoped pass over the specific items this plan's reviews

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -1704,6 +1704,58 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       alternative rather than reasoning about it — the last two attempts in
       this area were both measured worse than what they replaced.
 
+- [x] T42: gate fixtures inherit GIT_DIR from a worktree push and corrupt the real repo — state: building (branch `fix/t42-gitdir-leak`)
+
+      **Not a theory. It has now corrupted this repository TWICE in one day,**
+      both times flipping `core.bare` to `true` so the main checkout stopped
+      being a work tree (`fatal: this operation must be run in a work tree`),
+      and the second time it also blocked T36's push.
+
+      Git exports `GIT_DIR` into hook subprocesses **only when the push comes
+      from a linked worktree** — measured: main checkout `GIT_DIR=[unset]`,
+      worktree `GIT_DIR=[.../.git/worktrees/<name>]`. `pre-push` runs
+      `make verify`, which runs this suite, so every git-invoking subprocess in
+      the gate-fixture tests inherited it. With `GIT_DIR` set, `git init` in a
+      fresh `tmp_path` does NOT create a repo there — it re-initialises the one
+      `GIT_DIR` already names, silently (`warning: re-init`). Every later
+      fixture `commit`/`checkout` then lands in the developer's real repo.
+
+      What it actually did, observed rather than predicted: a real checkout
+      left on a fixture branch, two fixture commits on a real feature branch,
+      and `core.bare = true`.
+
+      **Why it hid for so long:** the gate passes when run directly, because
+      nothing sets `GIT_DIR`. It fails ONLY through the hook, ONLY from a
+      worktree. So the standalone verdict and the push verdict disagree, and
+      the standalone one is the one people look at.
+
+      Fix: `sanitized_git_env()` in `tests/unit/conftest.py` strips `GIT_DIR`,
+      `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY`,
+      `GIT_COMMON_DIR` and `GIT_ALTERNATE_OBJECT_DIRECTORIES` before every
+      git-invoking subprocess call in both gate-fixture files — including the
+      `needs_e2e.sh`/`push_base_ref.sh` invocations, since those shell out to
+      git themselves. A plain function, deliberately NOT an autouse fixture, so
+      it carries none of the blast radius across this directory's other ~150
+      test files.
+
+      Defence in depth: the `repo` fixture now asserts, immediately after
+      `git init`, that `git rev-parse --absolute-git-dir` resolves inside the
+      throwaway `tmp_path`. That converts a future unsanitised call site from
+      silent corruption into a named assertion failure.
+
+      Verified under the real condition rather than by reasoning: with
+      `GIT_DIR` poisoned to the real repo, 75 gate-fixture tests pass,
+      `core.bare` stays `false` and HEAD is unchanged. Mutation-proven — with
+      the stripping removed, the defence-in-depth assertion fires and names the
+      leak:
+
+          assert PosixPath('.../victim/.git') == PosixPath('.../tmp_path/.git')
+
+      Note the first mutation attempt produced a FALSE RED (a collection error,
+      not the corruption assertion). Caught because the failure text did not
+      name the behaviour being guarded, which is the whole reason for reading
+      failure messages rather than counting reds.
+
 - [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T36, T37, T38, T39, T40, T41 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale twice by enumeration alone. T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too.)
 
       **Runs LAST, and it is not a duplicate of T7 even though it sounds like

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,44 @@
+import os as _os
+
+# ---------------------------------------------------------------------------
+# Remove git's location variables from the ENTIRE test process, once, before
+# anything is collected.
+#
+# This is the layer that actually closes the class, and it exists because
+# per-call sanitisation did not. Git exports GIT_DIR into hook subprocesses
+# launched from a linked worktree; pre-push runs the suite; and a test that
+# shells out to git then operates on the REAL repository instead of its cwd
+# -- `git init` in a tmp dir silently re-inits the repo GIT_DIR names. That
+# corrupted this repository twice on 2026-08-18.
+#
+# The first fix sanitised each call site and added an AST guard to enforce it.
+# That guard was then wrong FOUR times: it missed aliased imports
+# (`subprocess as sp`), it missed a subdirectory, it accepted any `env=`
+# whether sanitised or not, and it could not see argv built by an
+# `*args`-forwarding lambda -- a shape with a live unsanitised instance
+# sitting in `test_next_beta_version.py`. Policing call SHAPES is a losing
+# game: every wrapper, alias and lambda is a new spelling.
+#
+# So remove the hazard instead of policing the callers. With these unset in
+# `os.environ`, every subprocess inherits a clean environment by construction,
+# whatever shape the call takes and whether or not its author ever heard of
+# this module. `sanitized_git_env()` and the AST guard remain as defence in
+# depth, not as the primary protection.
+#
+# Safe to do unconditionally: nothing in this suite reads GIT_DIR, and git
+# falls back to discovery from `cwd`, which is what every call already
+# intends. Tests that mean to query the real repo pass `cwd=REPO_ROOT` and
+# keep working.
+for _var in (
+    'GIT_DIR',
+    'GIT_WORK_TREE',
+    'GIT_INDEX_FILE',
+    'GIT_OBJECT_DIRECTORY',
+    'GIT_COMMON_DIR',
+    'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+):
+    _os.environ.pop(_var, None)
+
 """Shared pytest fixtures for CouchPotatoServer test suite."""
 import json
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+"""Shared pytest fixtures for CouchPotatoServer test suite."""
 import os as _os
 
 # ---------------------------------------------------------------------------
@@ -39,7 +40,6 @@ for _var in (
 ):
     _os.environ.pop(_var, None)
 
-"""Shared pytest fixtures for CouchPotatoServer test suite."""
 import json
 import os
 import sys

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,9 +5,49 @@ On Python 3.10, `patch('couchpotato.api.addApiView', create=True)` fails because
 rather than the api module. This conftest ensures addApiView is patchable by replacing
 the problematic patch targets with direct module-level mocks.
 """
+import os
+
 import pytest
 
 from couchpotato.core.logger import reset_log_suppression
+
+# Git sets GIT_DIR (and its siblings below) in the environment of hook
+# subprocesses launched from a `git worktree` checkout -- but not from the
+# main checkout. `pre-push` runs `make verify`, which runs this suite, so a
+# push made from a worktree hands every test process a GIT_DIR naming that
+# worktree's real `.git`.
+#
+# Any test that shells out to `git init`/`commit`/`checkout -b` inside a
+# throwaway `tmp_path` MUST strip these first: with GIT_DIR set, `git init`
+# in a fresh directory does not create a repo there, it RE-INITIALISES the
+# repo GIT_DIR already points at, and every later commit/checkout in the
+# fixture lands there too. T31 follow-up: this is exactly how the real
+# developer checkout got a fixture branch, two fixture commits, and
+# `core.bare` flipped to true.
+#
+# Deliberately a plain function, not a fixture and not autouse: importing it
+# is each caller's explicit choice, so it carries none of the blast radius
+# the autouse fixtures above do across this file's ~150+ dependents. See
+# `tests/unit/test_fixtures_do_not_leak_gitdir.py`.
+GIT_LOCATION_ENV_VARS = (
+    'GIT_DIR',
+    'GIT_WORK_TREE',
+    'GIT_INDEX_FILE',
+    'GIT_OBJECT_DIRECTORY',
+    'GIT_COMMON_DIR',
+    'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+)
+
+
+def sanitized_git_env():
+    """A copy of the current environment with git's location variables
+    removed -- pass as `env=` to any subprocess `git` call (or any script
+    that itself shells out to `git`, e.g. `needs_e2e.sh`) that must operate
+    on an explicit `cwd` rather than wherever the ambient GIT_DIR points."""
+    env = os.environ.copy()
+    for var in GIT_LOCATION_ENV_VARS:
+        env.pop(var, None)
+    return env
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -39,6 +39,38 @@ GIT_LOCATION_ENV_VARS = (
 )
 
 
+def assert_git_dir_is(directory, env=None):
+    """Assert git, run in `directory`, resolves its git dir INSIDE `directory`.
+
+    Defence in depth for the GIT_DIR leak: verifies the EFFECT rather than
+    trusting that the input was sanitised. Extracted from the two `repo`
+    fixtures so it can be tested on its own -- inline, deleting it failed
+    nothing, because the per-call sanitisation already kept every test green.
+    Two layers where only one is proven look exactly like two working layers
+    from a green run.
+
+    Compares against the DIRECTORY, never against `directory/.git`, because in
+    the case this exists to catch that path was never created -- git
+    re-initialised the repo GIT_DIR named instead. Resolving through a child
+    that does not exist is how this assertion reports the wrong thing on the
+    one path that needs it.
+    """
+    import subprocess as _sp
+    absolute_git_dir = _sp.run(
+        ['git', 'rev-parse', '--absolute-git-dir'], cwd=str(directory),
+        check=True, capture_output=True, text=True,
+        env=sanitized_git_env() if env is None else env,
+    ).stdout.strip()
+    resolved = os.path.realpath(absolute_git_dir)
+    root = os.path.realpath(str(directory))
+    assert resolved == root or resolved.startswith(root + os.sep), (
+        'git operations here are not targeting the throwaway directory '
+        '(git dir resolved to %s, outside %s) -- refusing to continue rather '
+        'than risk running further git commands against a real repository'
+        % (absolute_git_dir, root)
+    )
+
+
 def sanitized_git_env():
     """A copy of the current environment with git's location variables
     removed -- pass as `env=` to any subprocess `git` call (or any script

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -54,6 +54,18 @@ def assert_git_dir_is(directory, env=None):
     re-initialised the repo GIT_DIR named instead. Resolving through a child
     that does not exist is how this assertion reports the wrong thing on the
     one path that needs it.
+
+    Proven by three mutations, not one, because they answer different
+    questions:
+
+        neuter this assertion    ->  1 failed              is it guarded?
+        make it reject anything  ->  2 failed, 53 errors   is it on the code path?
+        neuter the sanitisation  ->  1 failed              is the OTHER layer guarded?
+
+    The middle one is the check most easily skipped. A guard can be guarded
+    and still be dead code that is never reached; only forcing it to reject
+    everything shows it actually runs -- here, for every test that takes the
+    `repo` fixture.
     """
     import subprocess as _sp
     absolute_git_dir = _sp.run(

--- a/tests/unit/test_check_test_traps.py
+++ b/tests/unit/test_check_test_traps.py
@@ -56,6 +56,7 @@ import check_test_traps  # noqa: E402
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from rule6_guard_corpus import SHAPES as RULE6_SHAPES  # noqa: E402
+from tests.unit.conftest import sanitized_git_env
 
 
 def run_checker(*args):
@@ -756,11 +757,11 @@ def test_tracked_test_files_sees_both_pytest_naming_conventions(tmp_path):
     Asserting the exact list, not membership, so it also pins what must NOT
     be swept in: a helper module and a conftest are not tests.
     """
-    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True, env=sanitized_git_env())
     (tmp_path / "pkg").mkdir()
     for name in ("test_prefix.py", "suffix_test.py", "helpers.py", "conftest.py"):
         (tmp_path / "pkg" / name).write_text("", encoding="utf-8")
-    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True, env=sanitized_git_env())
 
     assert check_test_traps._tracked_test_files(tmp_path) == [
         "pkg/suffix_test.py",
@@ -882,14 +883,14 @@ def test_tracked_test_files_uses_git_ls_files_not_a_filesystem_walk(tmp_path):
     invisible to this rule, not merely filtered out by convention.
     """
     repo = tmp_path
-    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
-    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=repo, check=True)
-    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=sanitized_git_env())
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=repo, check=True, env=sanitized_git_env())
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True, env=sanitized_git_env())
 
     tracked = repo / "test_tracked.py"
     tracked.write_text("def test_x():\n    pass\n")
-    subprocess.run(["git", "add", "test_tracked.py"], cwd=repo, check=True)
-    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "test_tracked.py"], cwd=repo, check=True, env=sanitized_git_env())
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True, env=sanitized_git_env())
 
     # Untracked scratch file, same test_*.py naming pattern, sitting right
     # next to the tracked one on disk.
@@ -904,15 +905,15 @@ def test_tracked_test_files_uses_git_ls_files_not_a_filesystem_walk(tmp_path):
 def test_tracked_test_files_excludes_libs(tmp_path):
     """Vendored code under libs/ is not ours to flag."""
     repo = tmp_path
-    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
-    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=repo, check=True)
-    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True, env=sanitized_git_env())
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=repo, check=True, env=sanitized_git_env())
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True, env=sanitized_git_env())
 
     (repo / "libs").mkdir()
     (repo / "libs" / "test_vendored.py").write_text("def test_x():\n    pass\n")
     (repo / "test_ours.py").write_text("def test_y():\n    pass\n")
-    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
-    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, env=sanitized_git_env())
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=repo, check=True, env=sanitized_git_env())
 
     files = check_test_traps._tracked_test_files(repo)
     assert files == ["test_ours.py"], files

--- a/tests/unit/test_fixtures_do_not_leak_gitdir.py
+++ b/tests/unit/test_fixtures_do_not_leak_gitdir.py
@@ -38,8 +38,11 @@ audited unsanitised call sites between them:
 """
 import os
 import subprocess
+from tests.unit.conftest import sanitized_git_env
 import sys
 from pathlib import Path
+import re
+import ast
 
 REPO = Path(__file__).resolve().parents[2]
 
@@ -62,9 +65,15 @@ def _victim_repo(tmp_path):
     victim.mkdir()
 
     def git(*args):
+        # sanitized_git_env(), because THIS helper builds the victim. Under a
+        # real worktree push the parent pytest already carries the checkout's
+        # GIT_DIR, which this inherits -- so without stripping it, the fixture
+        # that exists to prove we do not corrupt the real repo would build its
+        # victim INSIDE the real repo. The regression test would carry the bug
+        # it tests for.
         return subprocess.run(
             ['git', *args], cwd=str(victim), check=True,
-            capture_output=True, text=True,
+            capture_output=True, text=True, env=sanitized_git_env(),
         )
 
     git('init', '-q', '-b', 'main')
@@ -81,9 +90,12 @@ def _victim_repo(tmp_path):
 
 def _snapshot(victim):
     def git(*args):
+        # Same reason as the builder above: a snapshot taken through an
+        # ambient GIT_DIR would describe the wrong repository, so the
+        # before/after comparison could pass while the victim was mangled.
         return subprocess.run(
             ['git', *args], cwd=str(victim['dir']),
-            capture_output=True, text=True,
+            capture_output=True, text=True, env=sanitized_git_env(),
         ).stdout.strip()
 
     return {
@@ -132,3 +144,63 @@ def test_the_real_fixtures_survive_a_poisoned_ambient_GIT_DIR(tmp_path):
         'fixture branches leaked into the victim repository'
     )
     assert after['wip_exists'], 'uncommitted work in the victim disappeared'
+
+
+def test_no_test_file_invokes_git_without_sanitizing_the_environment():
+    """The guard that makes the fix survive the next contributor.
+
+    The original fix audited two files and sanitised every git call in both.
+    That was true and insufficient: review then found the SAME pattern in
+    `test_check_test_traps.py` (12 sites), `test_mutation_changed.py`,
+    `test_gitleaks_config.py` -- and, worst of all, in the victim fixture of
+    THIS file, so the regression test for the corruption bug was itself
+    carrying the corruption bug.
+
+    A prose rule ("remember to pass env=") could not have caught that, because
+    forgetting is exactly the failure mode. This scans the tree instead, so a
+    new unsanitised call site fails by name at the next `make verify` rather
+    than the next time somebody pushes from a worktree.
+
+    Deliberately a source scan, not a runtime check: the damage happens inside
+    a subprocess in a test that may not run on this machine, so the only place
+    to catch it reliably is the source.
+
+    Deliberately AST, not a regex. The first version of this guard WAS a
+    regex, and it reported five false positives on calls that were correctly
+    sanitised -- because `[^)]*?` stops at the first `)`, and `cwd=str(tmp_path)`
+    closes the match before `env=` is ever reached. A guard that cries wolf on
+    correct code gets deleted by the next person in a hurry, which is a worse
+    outcome than not having it.
+    """
+    tests_dir = Path(__file__).parent
+    offenders = []
+
+    for path in sorted(tests_dir.glob('*.py')):
+        tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not (isinstance(func, ast.Attribute) and func.attr in ('run', 'check_output', 'Popen')):
+                continue
+            if not (isinstance(func.value, ast.Name) and func.value.id == 'subprocess'):
+                continue
+            if not node.args:
+                continue
+            argv = node.args[0]
+            if not (isinstance(argv, ast.List) and argv.elts):
+                continue
+            first = argv.elts[0]
+            if not (isinstance(first, ast.Constant) and first.value == 'git'):
+                continue
+            if any(kw.arg == 'env' for kw in node.keywords):
+                continue
+            offenders.append('%s:%d' % (path.name, node.lineno))
+
+    assert not offenders, (
+        'these git subprocess calls pass no env=, so an ambient GIT_DIR (which '
+        'git exports into pre-push hooks launched from a worktree) makes them '
+        'operate on the REAL repository instead of their cwd -- `git init` in a '
+        'tmp dir silently re-inits the repo GIT_DIR names. Pass '
+        'env=sanitized_git_env():\n  ' + '\n  '.join(offenders)
+    )

--- a/tests/unit/test_fixtures_do_not_leak_gitdir.py
+++ b/tests/unit/test_fixtures_do_not_leak_gitdir.py
@@ -48,7 +48,7 @@ import tempfile
 REPO = Path(__file__).resolve().parents[2]
 
 # Between them, exercises the repo fixture + classify()/needs_e2e.sh call in
-# BOTH files -- i.e. all five originally audited unsanitised call sites.
+# BOTH files -- i.e. TWO REPRESENTATIVE tests, one per fixture file.
 REPRESENTATIVE_NODE_IDS = (
     'tests/unit/test_hybrid_gate.py::TestTheScriptAnswersTheQuestion::'
     'test_non_browser_changes_do_not[README.md]',
@@ -122,6 +122,10 @@ def test_the_real_fixtures_survive_a_poisoned_ambient_GIT_DIR(tmp_path):
     result = subprocess.run(
         [sys.executable, '-B', '-m', 'pytest', *REPRESENTATIVE_NODE_IDS, '-q'],
         cwd=str(REPO), capture_output=True, text=True, env=poisoned_env,
+        # Generous, but bounded: an inner pytest that deadlocks on a fixture
+        # would otherwise hang the whole gate with no diagnosis, which is a
+        # worse failure than a red test.
+        timeout=600,
     )
 
     after = _snapshot(victim)
@@ -198,7 +202,11 @@ def test_no_test_file_invokes_git_without_sanitizing_the_environment():
     the guard's COVERAGE did not match its claim, which is the same
     looks-like-protection shape it exists to prevent.
     """
-    tests_dir = Path(__file__).parent
+    # tests/ ROOT, not tests/unit: a git call added under integration/,
+    # e2e/ or directly in tests/ would otherwise go unscanned. None exist
+    # today -- this is preventive, and cheap enough that waiting for the
+    # first one would be the wrong trade.
+    tests_dir = Path(__file__).parents[1]
     offenders = []
 
     def _is_sanitized(node):
@@ -399,6 +407,7 @@ def test_the_process_scrub_protects_a_file_that_never_heard_of_the_helper():
             [sys.executable, '-B', '-m', 'pytest',
              'tests/unit/test_next_beta_version.py', '-q'],
             cwd=str(REPO), capture_output=True, text=True, env=poisoned,
+            timeout=600,
         )
 
         after = subprocess.run(['git', 'rev-parse', 'HEAD'], cwd=str(victim),

--- a/tests/unit/test_fixtures_do_not_leak_gitdir.py
+++ b/tests/unit/test_fixtures_do_not_leak_gitdir.py
@@ -122,10 +122,21 @@ def test_the_real_fixtures_survive_a_poisoned_ambient_GIT_DIR(tmp_path):
     result = subprocess.run(
         [sys.executable, '-B', '-m', 'pytest', *REPRESENTATIVE_NODE_IDS, '-q'],
         cwd=str(REPO), capture_output=True, text=True, env=poisoned_env,
-        # Generous, but bounded: an inner pytest that deadlocks on a fixture
-        # would otherwise hang the whole gate with no diagnosis, which is a
-        # worse failure than a red test.
-        timeout=600,
+        # 45s, deliberately BELOW pytest.ini's ambient `--timeout=60`.
+        #
+        # The previous value here was 600, with a comment claiming it stopped
+        # the gate hanging indefinitely. Both halves were wrong: pytest-timeout
+        # already bounds every test at 60s, so nothing could hang forever, and
+        # 600 was unreachable dead code -- the outer kill always won first. A
+        # documented bound that is not the enforced one is the exact defect
+        # this branch keeps correcting elsewhere.
+        #
+        # Sitting below the ambient limit is what makes this useful: the inner
+        # run is killed HERE, naming the nested pytest, instead of the outer
+        # test being killed with a generic timeout that says nothing about
+        # which subprocess wedged. The healthy run takes ~7s, so 45 leaves
+        # ample headroom.
+        timeout=45,
     )
 
     after = _snapshot(victim)
@@ -407,7 +418,7 @@ def test_the_process_scrub_protects_a_file_that_never_heard_of_the_helper():
             [sys.executable, '-B', '-m', 'pytest',
              'tests/unit/test_next_beta_version.py', '-q'],
             cwd=str(REPO), capture_output=True, text=True, env=poisoned,
-            timeout=600,
+            timeout=45,  # below pytest.ini's --timeout=60; see the note above
         )
 
         after = subprocess.run(['git', 'rev-parse', 'HEAD'], cwd=str(victim),

--- a/tests/unit/test_fixtures_do_not_leak_gitdir.py
+++ b/tests/unit/test_fixtures_do_not_leak_gitdir.py
@@ -41,7 +41,6 @@ import subprocess
 from tests.unit.conftest import sanitized_git_env
 import sys
 from pathlib import Path
-import re
 import ast
 
 REPO = Path(__file__).resolve().parents[2]
@@ -167,23 +166,47 @@ def test_no_test_file_invokes_git_without_sanitizing_the_environment():
 
     Deliberately AST, not a regex. The first version of this guard WAS a
     regex, and it reported five false positives on calls that were correctly
-    sanitised -- because `[^)]*?` stops at the first `)`, and `cwd=str(tmp_path)`
-    closes the match before `env=` is ever reached. A guard that cries wolf on
-    correct code gets deleted by the next person in a hurry, which is a worse
-    outcome than not having it.
+    sanitised -- because `[^)]*?` stops at the first `)`, and
+    `cwd=str(tmp_path)` closes the match before `env=` is ever reached. A
+    guard that cries wolf on correct code gets deleted by the next person in a
+    hurry, which is worse than not having it.
+
+    ALIASES ARE RESOLVED PER FILE, and that is not a refinement. The second
+    version matched only `subprocess.run`, while `test_hybrid_gate.py` -- the
+    file the original incident happened in -- does `import subprocess as sp`
+    inside nearly every test method and calls `sp.run(...)`. Seventeen of its
+    twenty git calls were invisible to the guard. They happened to be
+    correctly sanitised already, so nothing was leaking; the defect was that
+    the guard's COVERAGE did not match its claim, which is the same
+    looks-like-protection shape it exists to prevent.
     """
     tests_dir = Path(__file__).parent
     offenders = []
 
-    for path in sorted(tests_dir.glob('*.py')):
+    def subprocess_aliases(tree):
+        """Every local name bound to the `subprocess` module in this file,
+        including imports nested inside functions and methods."""
+        names = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == 'subprocess':
+                        names.add(alias.asname or 'subprocess')
+        return names
+
+    for path in sorted(tests_dir.rglob('*.py')):
         tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
+        aliases = subprocess_aliases(tree)
+        if not aliases:
+            continue
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
             func = node.func
-            if not (isinstance(func, ast.Attribute) and func.attr in ('run', 'check_output', 'Popen')):
+            if not (isinstance(func, ast.Attribute)
+                    and func.attr in ('run', 'check_output', 'check_call', 'call', 'Popen')):
                 continue
-            if not (isinstance(func.value, ast.Name) and func.value.id == 'subprocess'):
+            if not (isinstance(func.value, ast.Name) and func.value.id in aliases):
                 continue
             if not node.args:
                 continue
@@ -195,7 +218,7 @@ def test_no_test_file_invokes_git_without_sanitizing_the_environment():
                 continue
             if any(kw.arg == 'env' for kw in node.keywords):
                 continue
-            offenders.append('%s:%d' % (path.name, node.lineno))
+            offenders.append('%s:%d' % (path.relative_to(tests_dir), node.lineno))
 
     assert not offenders, (
         'these git subprocess calls pass no env=, so an ambient GIT_DIR (which '

--- a/tests/unit/test_fixtures_do_not_leak_gitdir.py
+++ b/tests/unit/test_fixtures_do_not_leak_gitdir.py
@@ -1,0 +1,134 @@
+"""A test fixture shelling out to `git` must never touch the developer's
+real repository (T31 follow-up).
+
+Git sets `GIT_DIR` (and its siblings `GIT_WORK_TREE`, `GIT_INDEX_FILE`,
+`GIT_OBJECT_DIRECTORY`, `GIT_COMMON_DIR`,
+`GIT_ALTERNATE_OBJECT_DIRECTORIES`) in the environment of hook subprocesses
+-- but only when the push comes from a `git worktree` checkout rather than
+the main one. `pre-push` runs `make verify`, which runs this suite, so a
+push from a worktree hands the pytest *process itself* a `GIT_DIR` naming
+the worktree's real `.git`.
+
+`tests/unit/test_hybrid_gate.py` and
+`tests/unit/test_gate_covers_the_ui_backend.py` shell out to `git init`,
+`git commit`, `git checkout -b`, etc. inside a throwaway `tmp_path`. Before
+the fix, those calls did not sanitise the subprocess environment, so they
+inherited GIT_DIR straight from the ambient pytest process. With GIT_DIR
+set, `git init` in a fresh directory does not create a new repo there -- it
+RE-INITIALISES the repo GIT_DIR already points at, and every later fixture
+`git commit`/`checkout -b` lands there too.
+
+This test runs the REAL fixtures as a subprocess pytest invocation with
+GIT_DIR poisoned in the ambient environment -- exactly the shape a worktree
+push produces -- rather than a hand-written mirror of the fixture code, so
+it stays true to whatever the fixtures actually do rather than to what this
+file assumes they do. It proves two things: the fixtures still pass under a
+poisoned ambient environment, and a stand-in "victim" repository is left
+byte-for-byte untouched: same HEAD commit, same branch, same `core.bare`,
+no new branches, and its one uncommitted file still on disk.
+
+The two node IDs below were chosen to touch all five of the originally
+audited unsanitised call sites between them:
+  - test_gate_covers_the_ui_backend.py's `repo` fixture (git init) and
+    `classify()` (git add/commit, and the needs_e2e.sh invocation) --
+    exercised together because `classify()` is only ever called against an
+    already-initialised `repo`.
+  - test_hybrid_gate.py's `repo` fixture (git init/commit) and `_run()`
+    (the needs_e2e.sh invocation).
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Between them, exercises the repo fixture + classify()/needs_e2e.sh call in
+# BOTH files -- i.e. all five originally audited unsanitised call sites.
+REPRESENTATIVE_NODE_IDS = (
+    'tests/unit/test_hybrid_gate.py::TestTheScriptAnswersTheQuestion::'
+    'test_non_browser_changes_do_not[README.md]',
+    'tests/unit/test_gate_covers_the_ui_backend.py::'
+    'TestOnlyProvablyIrrelevantPathsSkip::test_these_skip[README.md]',
+)
+
+
+def _victim_repo(tmp_path):
+    """A throwaway repo standing in for the developer's real checkout, with
+    a real commit, a real HEAD left mid-work, and uncommitted work sitting
+    in it -- the shape of the actual incidents this test is pinned against.
+    """
+    victim = tmp_path / 'victim'
+    victim.mkdir()
+
+    def git(*args):
+        return subprocess.run(
+            ['git', *args], cwd=str(victim), check=True,
+            capture_output=True, text=True,
+        )
+
+    git('init', '-q', '-b', 'main')
+    git('config', 'user.email', 'victim@example.com')
+    git('config', 'user.name', 'Victim')
+    (victim / 'important.txt').write_text('do not touch\n')
+    git('add', '-A')
+    git('commit', '-qm', 'the only real commit')
+    git('checkout', '-q', '-b', 'feature/in-progress')
+    (victim / 'wip.txt').write_text('uncommitted intent\n')  # untracked on purpose
+
+    return {'dir': victim, 'git_dir': victim / '.git'}
+
+
+def _snapshot(victim):
+    def git(*args):
+        return subprocess.run(
+            ['git', *args], cwd=str(victim['dir']),
+            capture_output=True, text=True,
+        ).stdout.strip()
+
+    return {
+        'head_sha': git('rev-parse', 'HEAD'),
+        'branch': git('rev-parse', '--abbrev-ref', 'HEAD'),
+        'bare': git('config', '--get', 'core.bare'),
+        'branches': sorted(git('branch', '--format=%(refname:short)').split()),
+        'wip_exists': (victim['dir'] / 'wip.txt').exists(),
+    }
+
+
+def test_the_real_fixtures_survive_a_poisoned_ambient_GIT_DIR(tmp_path):
+    victim = _victim_repo(tmp_path)
+    before = _snapshot(victim)
+
+    # This is what git hands a hook subprocess launched from a worktree --
+    # simulated directly rather than via a real `git worktree add`, because
+    # setting GIT_DIR by hand on the child process reproduces exactly what
+    # git itself does; no worktree is needed to prove the defect.
+    poisoned_env = os.environ.copy()
+    poisoned_env['GIT_DIR'] = str(victim['git_dir'])
+
+    result = subprocess.run(
+        [sys.executable, '-B', '-m', 'pytest', *REPRESENTATIVE_NODE_IDS, '-q'],
+        cwd=str(REPO), capture_output=True, text=True, env=poisoned_env,
+    )
+
+    after = _snapshot(victim)
+
+    assert result.returncode == 0, (
+        'the fixtures themselves failed under a poisoned ambient GIT_DIR '
+        '(rather than corrupting the victim, which is checked separately) '
+        'stdout=%s stderr=%s' % (result.stdout, result.stderr)
+    )
+    assert after['head_sha'] == before['head_sha'], (
+        'the victim repository gained commits it never made'
+    )
+    assert after['branch'] == before['branch'], (
+        'the victim repository HEAD moved onto a fixture branch'
+    )
+    assert after['bare'] == before['bare'], (
+        "core.bare flipped on the real repository -- this is the flip that "
+        "broke the working tree in the real incident"
+    )
+    assert after['branches'] == before['branches'], (
+        'fixture branches leaked into the victim repository'
+    )
+    assert after['wip_exists'], 'uncommitted work in the victim disappeared'

--- a/tests/unit/test_fixtures_do_not_leak_gitdir.py
+++ b/tests/unit/test_fixtures_do_not_leak_gitdir.py
@@ -201,46 +201,34 @@ def test_no_test_file_invokes_git_without_sanitizing_the_environment():
     tests_dir = Path(__file__).parent
     offenders = []
 
-    def _calls_sanitizer(node):
+    def _is_sanitized(node):
+        """`env=` must be a DIRECT `sanitized_git_env(...)` call.
+
+        Deliberately no dataflow. The previous version tracked names bound
+        from the sanitiser so `env = sanitized_git_env()` then `env=env` would
+        be recognised -- 43 lines that produced three of this guard's five
+        defects, ending with binding names file-wide rather than per scope, so
+        one function's clean `env` vouched for another function's dirty one.
+
+        Requiring the call inline removes that entire class by construction
+        instead of patching its fifth instance. The cost is a real one and
+        worth stating: a future caller wanting to reuse one env across several
+        calls gets flagged and has to inline. That is a visible, actionable
+        message rather than a silent wrong answer, which is the right way for
+        this to fail given its record.
+        """
+        if isinstance(node, ast.IfExp):
+            # `sanitized_git_env() if env is None else env` -- a helper with a
+            # deliberate caller override. Accepted as a SYNTACTIC form, not by
+            # tracking what the other branch holds: the shape is visible in one
+            # node, so unlike name binding it cannot pick up a value from
+            # somewhere else in the file.
+            return _is_sanitized(node.body) or _is_sanitized(node.orelse)
         return (isinstance(node, ast.Call)
                 and ((isinstance(node.func, ast.Name)
                       and node.func.id == 'sanitized_git_env')
                      or (isinstance(node.func, ast.Attribute)
                          and node.func.attr == 'sanitized_git_env')))
-
-    def _sanitized_names(tree):
-        """Locals bound from `sanitized_git_env(...)`, so `env = ...` then
-        `env=env` is recognised rather than reported.
-
-        Name-sniffing was tried first (`'sanit' in name`) and produced false
-        positives on correct code -- the same failure that killed the regex
-        version. A guard that cries wolf gets deleted, so this reads the
-        assignment instead of guessing from the identifier."""
-        names = set()
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Assign) and _calls_sanitizer(node.value):
-                for target in node.targets:
-                    if isinstance(target, ast.Name):
-                        names.add(target.id)
-            elif isinstance(node, ast.AnnAssign) and node.value is not None:
-                if _calls_sanitizer(node.value) and isinstance(node.target, ast.Name):
-                    names.add(node.target.id)
-        return names
-
-    def _is_sanitized(node, names):
-        """Presence of `env=` is not protection: `env=os.environ.copy()` still
-        carries an inherited GIT_DIR and is exactly as vulnerable as passing
-        nothing."""
-        if _calls_sanitizer(node):
-            return True
-        if isinstance(node, ast.Name) and node.id in names:
-            return True
-        # `sanitized_git_env() if env is None else env` -- the caller-supplied
-        # branch is the caller's responsibility, and every such caller in this
-        # tree is itself checked by this same scan.
-        if isinstance(node, ast.IfExp):
-            return _is_sanitized(node.body, names) or _is_sanitized(node.orelse, names)
-        return False
 
     SPAWNERS = ('run', 'check_output', 'check_call', 'call', 'Popen')
 
@@ -275,7 +263,6 @@ def test_no_test_file_invokes_git_without_sanitizing_the_environment():
         modules, funcs = subprocess_bindings(tree)
         if not modules and not funcs:
             continue
-        sanitized_names = _sanitized_names(tree)
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -299,7 +286,7 @@ def test_no_test_file_invokes_git_without_sanitizing_the_environment():
             if not (isinstance(first, ast.Constant) and first.value == 'git'):
                 continue
             env_kw = next((kw for kw in node.keywords if kw.arg == 'env'), None)
-            if env_kw is not None and _is_sanitized(env_kw.value, sanitized_names):
+            if env_kw is not None and _is_sanitized(env_kw.value):
                 continue
             if env_kw is not None:
                 offenders.append('%s:%d (env= is not sanitized_git_env())'
@@ -395,16 +382,16 @@ def test_the_process_scrub_protects_a_file_that_never_heard_of_the_helper():
     with tempfile.TemporaryDirectory() as tmp:
         victim = Path(tmp) / 'victim'
         victim.mkdir()
-        env = sanitized_git_env()
         subprocess.run(['git', 'init', '-q', '-b', 'main', str(victim)],
-                       check=True, capture_output=True, env=env)
+                       check=True, capture_output=True, env=sanitized_git_env())
         (victim / 'f.txt').write_text('original\n')
         for args in (('add', '-A'), ('-c', 'user.email=t@e.com', '-c', 'user.name=T',
                                      'commit', '-qm', 'seed')):
             subprocess.run(['git', *args], cwd=str(victim), check=True,
-                           capture_output=True, env=env)
+                           capture_output=True, env=sanitized_git_env())
         before = subprocess.run(['git', 'rev-parse', 'HEAD'], cwd=str(victim),
-                                capture_output=True, text=True, env=env).stdout.strip()
+                                capture_output=True, text=True,
+                                env=sanitized_git_env()).stdout.strip()
 
         poisoned = os.environ.copy()
         poisoned['GIT_DIR'] = str(victim / '.git')
@@ -415,11 +402,14 @@ def test_the_process_scrub_protects_a_file_that_never_heard_of_the_helper():
         )
 
         after = subprocess.run(['git', 'rev-parse', 'HEAD'], cwd=str(victim),
-                               capture_output=True, text=True, env=env).stdout.strip()
+                               capture_output=True, text=True,
+                               env=sanitized_git_env()).stdout.strip()
         branch = subprocess.run(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], cwd=str(victim),
-                                capture_output=True, text=True, env=env).stdout.strip()
+                                capture_output=True, text=True,
+                                env=sanitized_git_env()).stdout.strip()
         bare = subprocess.run(['git', 'config', '--get', 'core.bare'], cwd=str(victim),
-                              capture_output=True, text=True, env=env).stdout.strip()
+                              capture_output=True, text=True,
+                              env=sanitized_git_env()).stdout.strip()
 
     assert result.returncode == 0, (
         'the unsanitised suite failed under a poisoned GIT_DIR:\n%s' % result.stdout[-2000:]

--- a/tests/unit/test_fixtures_do_not_leak_gitdir.py
+++ b/tests/unit/test_fixtures_do_not_leak_gitdir.py
@@ -242,31 +242,53 @@ def test_no_test_file_invokes_git_without_sanitizing_the_environment():
             return _is_sanitized(node.body, names) or _is_sanitized(node.orelse, names)
         return False
 
-    def subprocess_aliases(tree):
-        """Every local name bound to the `subprocess` module in this file,
-        including imports nested inside functions and methods."""
-        names = set()
+    SPAWNERS = ('run', 'check_output', 'check_call', 'call', 'Popen')
+
+    def subprocess_bindings(tree):
+        """Names bound to the `subprocess` MODULE, and names bound directly to
+        its spawning FUNCTIONS.
+
+        Both forms, because tracking only the module import made
+        `from subprocess import run` skip the ENTIRE file: `aliases` came back
+        empty and the early `continue` fired before a single call was
+        examined. Missing one call shape is a gap; silently declining to scan
+        a whole file is the guard reporting CLEAN on code it never read, which
+        is the failure this whole exercise is about.
+
+        Covers imports nested inside functions and methods too, which is how
+        the file the original incident happened in writes them.
+        """
+        modules, funcs = set(), set()
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 for alias in node.names:
                     if alias.name == 'subprocess':
-                        names.add(alias.asname or 'subprocess')
-        return names
+                        modules.add(alias.asname or 'subprocess')
+            elif isinstance(node, ast.ImportFrom) and node.module == 'subprocess':
+                for alias in node.names:
+                    if alias.name in SPAWNERS:
+                        funcs.add(alias.asname or alias.name)
+        return modules, funcs
 
     for path in sorted(tests_dir.rglob('*.py')):
         tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
-        aliases = subprocess_aliases(tree)
-        sanitized_names = _sanitized_names(tree)
-        if not aliases:
+        modules, funcs = subprocess_bindings(tree)
+        if not modules and not funcs:
             continue
+        sanitized_names = _sanitized_names(tree)
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
             func = node.func
-            if not (isinstance(func, ast.Attribute)
-                    and func.attr in ('run', 'check_output', 'check_call', 'call', 'Popen')):
-                continue
-            if not (isinstance(func.value, ast.Name) and func.value.id in aliases):
+            if isinstance(func, ast.Attribute):
+                if func.attr not in SPAWNERS:
+                    continue
+                if not (isinstance(func.value, ast.Name) and func.value.id in modules):
+                    continue
+            elif isinstance(func, ast.Name):
+                if func.id not in funcs:
+                    continue
+            else:
                 continue
             if not node.args:
                 continue

--- a/tests/unit/test_fixtures_do_not_leak_gitdir.py
+++ b/tests/unit/test_fixtures_do_not_leak_gitdir.py
@@ -38,10 +38,11 @@ audited unsanitised call sites between them:
 """
 import os
 import subprocess
-from tests.unit.conftest import sanitized_git_env
+from tests.unit.conftest import assert_git_dir_is, sanitized_git_env
 import sys
 from pathlib import Path
 import ast
+import pytest
 
 REPO = Path(__file__).resolve().parents[2]
 
@@ -227,3 +228,60 @@ def test_no_test_file_invokes_git_without_sanitizing_the_environment():
         'tmp dir silently re-inits the repo GIT_DIR names. Pass '
         'env=sanitized_git_env():\n  ' + '\n  '.join(offenders)
     )
+
+
+class TestTheContainmentAssertionIsItselfGuarded:
+    """Isolates the SECOND layer, which was previously untested.
+
+    Measured before this class existed: deleting the containment assertion
+    from both `repo` fixtures left 49 tests passing, because the per-call
+    `sanitized_git_env()` already kept every path clean. Deleting the
+    sanitisation instead failed one test. So the two layers were not two
+    proven layers -- one was proven and the other was decoration that happened
+    to be correct.
+
+    Defence in depth and an untested second layer are indistinguishable from a
+    green run. These tests drive the assertion DIRECTLY, with the first layer
+    deliberately bypassed, so each layer now fails on its own removal.
+    """
+
+    def test_it_rejects_a_git_dir_outside_the_directory(self, tmp_path):
+        """The case it exists for, driven with sanitisation bypassed: an
+        ambient GIT_DIR pointing at another repo, and no `.git` ever created
+        in tmp_path."""
+        victim = tmp_path / 'victim'
+        victim.mkdir()
+        subprocess.run(
+            ['git', 'init', '-q', str(victim)], check=True,
+            capture_output=True, env=sanitized_git_env(),
+        )
+        target = tmp_path / 'throwaway'
+        target.mkdir()
+
+        poisoned = os.environ.copy()
+        poisoned['GIT_DIR'] = str(victim / '.git')
+
+        with pytest.raises(AssertionError) as excinfo:
+            assert_git_dir_is(target, env=poisoned)
+
+        message = str(excinfo.value)
+        assert 'refusing to continue' in message, (
+            'the assertion fired but not with its named, actionable message; '
+            'got: %s' % message
+        )
+        assert str(victim) in message, (
+            'the message must name WHERE git actually pointed, or the reader '
+            'cannot tell which repository was about to be written to'
+        )
+        # And specifically NOT an OSError from resolving a `.git` that was
+        # never created -- the failure mode this helper is shaped to avoid.
+        assert not (target / '.git').exists()
+
+    def test_it_accepts_a_git_dir_inside_the_directory(self, tmp_path):
+        """The other direction, so the assertion cannot be satisfied by
+        rejecting everything."""
+        subprocess.run(
+            ['git', 'init', '-q'], cwd=str(tmp_path), check=True,
+            capture_output=True, env=sanitized_git_env(),
+        )
+        assert_git_dir_is(tmp_path)

--- a/tests/unit/test_fixtures_do_not_leak_gitdir.py
+++ b/tests/unit/test_fixtures_do_not_leak_gitdir.py
@@ -43,6 +43,7 @@ import sys
 from pathlib import Path
 import ast
 import pytest
+import tempfile
 
 REPO = Path(__file__).resolve().parents[2]
 
@@ -172,6 +173,22 @@ def test_no_test_file_invokes_git_without_sanitizing_the_environment():
     guard that cries wolf on correct code gets deleted by the next person in a
     hurry, which is worse than not having it.
 
+    KNOWN LIMIT, stated rather than implied. This matches CALL SHAPES, so it
+    cannot see argv assembled elsewhere -- an `*args`-forwarding wrapper such
+    as `run = lambda *a: subprocess.run(a, ...)` in
+    `test_next_beta_version.py` passes it cleanly while invoking git. Chasing
+    every wrapper, alias and lambda is a losing game: each is a new spelling,
+    and this guard was wrong four times learning that.
+
+    Which is why it is NO LONGER the primary protection. `tests/conftest.py`
+    strips git's location variables from `os.environ` for the whole process
+    before collection, so every subprocess is clean by construction whatever
+    shape the call takes. This guard is defence in depth over that, and its
+    blind spots are survivable because of it. Revisit if the scrub is ever
+    removed, and prove any change by PLANTING an offender rather than reading
+    the code -- every defect in this guard was found that way and none by
+    inspection.
+
     ALIASES ARE RESOLVED PER FILE, and that is not a refinement. The second
     version matched only `subprocess.run`, while `test_hybrid_gate.py` -- the
     file the original incident happened in -- does `import subprocess as sp`
@@ -183,6 +200,47 @@ def test_no_test_file_invokes_git_without_sanitizing_the_environment():
     """
     tests_dir = Path(__file__).parent
     offenders = []
+
+    def _calls_sanitizer(node):
+        return (isinstance(node, ast.Call)
+                and ((isinstance(node.func, ast.Name)
+                      and node.func.id == 'sanitized_git_env')
+                     or (isinstance(node.func, ast.Attribute)
+                         and node.func.attr == 'sanitized_git_env')))
+
+    def _sanitized_names(tree):
+        """Locals bound from `sanitized_git_env(...)`, so `env = ...` then
+        `env=env` is recognised rather than reported.
+
+        Name-sniffing was tried first (`'sanit' in name`) and produced false
+        positives on correct code -- the same failure that killed the regex
+        version. A guard that cries wolf gets deleted, so this reads the
+        assignment instead of guessing from the identifier."""
+        names = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign) and _calls_sanitizer(node.value):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        names.add(target.id)
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                if _calls_sanitizer(node.value) and isinstance(node.target, ast.Name):
+                    names.add(node.target.id)
+        return names
+
+    def _is_sanitized(node, names):
+        """Presence of `env=` is not protection: `env=os.environ.copy()` still
+        carries an inherited GIT_DIR and is exactly as vulnerable as passing
+        nothing."""
+        if _calls_sanitizer(node):
+            return True
+        if isinstance(node, ast.Name) and node.id in names:
+            return True
+        # `sanitized_git_env() if env is None else env` -- the caller-supplied
+        # branch is the caller's responsibility, and every such caller in this
+        # tree is itself checked by this same scan.
+        if isinstance(node, ast.IfExp):
+            return _is_sanitized(node.body, names) or _is_sanitized(node.orelse, names)
+        return False
 
     def subprocess_aliases(tree):
         """Every local name bound to the `subprocess` module in this file,
@@ -198,6 +256,7 @@ def test_no_test_file_invokes_git_without_sanitizing_the_environment():
     for path in sorted(tests_dir.rglob('*.py')):
         tree = ast.parse(path.read_text(encoding='utf-8'), filename=str(path))
         aliases = subprocess_aliases(tree)
+        sanitized_names = _sanitized_names(tree)
         if not aliases:
             continue
         for node in ast.walk(tree):
@@ -217,7 +276,12 @@ def test_no_test_file_invokes_git_without_sanitizing_the_environment():
             first = argv.elts[0]
             if not (isinstance(first, ast.Constant) and first.value == 'git'):
                 continue
-            if any(kw.arg == 'env' for kw in node.keywords):
+            env_kw = next((kw for kw in node.keywords if kw.arg == 'env'), None)
+            if env_kw is not None and _is_sanitized(env_kw.value, sanitized_names):
+                continue
+            if env_kw is not None:
+                offenders.append('%s:%d (env= is not sanitized_git_env())'
+                                 % (path.relative_to(tests_dir), node.lineno))
                 continue
             offenders.append('%s:%d' % (path.relative_to(tests_dir), node.lineno))
 
@@ -285,3 +349,59 @@ class TestTheContainmentAssertionIsItselfGuarded:
             capture_output=True, env=sanitized_git_env(),
         )
         assert_git_dir_is(tmp_path)
+
+
+def test_the_process_scrub_protects_a_file_that_never_heard_of_the_helper():
+    """Isolates the SCRUB layer, the one that actually closes the class.
+
+    The per-call `sanitized_git_env()` only protects call sites that remember
+    to use it, and an AST guard policing that was wrong four times: aliased
+    imports, a subdirectory, accepting any `env=` whatever it contained, and
+    argv built by an `*args`-forwarding lambda. Every wrapper and alias is a
+    new spelling, so shape-matching is a losing game.
+
+    `tests/conftest.py` therefore strips git's location variables from
+    `os.environ` once, for the whole process, before anything is collected.
+    After that every subprocess inherits a clean environment by construction.
+
+    This test drives that specifically: it runs `test_next_beta_version.py`,
+    which builds a repo with a bare `*args` lambda and passes NO `env=`
+    anywhere, under an ambient GIT_DIR pointing at a throwaway victim. Only
+    the scrub can save it -- the helper is never imported there. If the victim
+    survives, the scrub is doing the work.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        victim = Path(tmp) / 'victim'
+        victim.mkdir()
+        env = sanitized_git_env()
+        subprocess.run(['git', 'init', '-q', '-b', 'main', str(victim)],
+                       check=True, capture_output=True, env=env)
+        (victim / 'f.txt').write_text('original\n')
+        for args in (('add', '-A'), ('-c', 'user.email=t@e.com', '-c', 'user.name=T',
+                                     'commit', '-qm', 'seed')):
+            subprocess.run(['git', *args], cwd=str(victim), check=True,
+                           capture_output=True, env=env)
+        before = subprocess.run(['git', 'rev-parse', 'HEAD'], cwd=str(victim),
+                                capture_output=True, text=True, env=env).stdout.strip()
+
+        poisoned = os.environ.copy()
+        poisoned['GIT_DIR'] = str(victim / '.git')
+        result = subprocess.run(
+            [sys.executable, '-B', '-m', 'pytest',
+             'tests/unit/test_next_beta_version.py', '-q'],
+            cwd=str(REPO), capture_output=True, text=True, env=poisoned,
+        )
+
+        after = subprocess.run(['git', 'rev-parse', 'HEAD'], cwd=str(victim),
+                               capture_output=True, text=True, env=env).stdout.strip()
+        branch = subprocess.run(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], cwd=str(victim),
+                                capture_output=True, text=True, env=env).stdout.strip()
+        bare = subprocess.run(['git', 'config', '--get', 'core.bare'], cwd=str(victim),
+                              capture_output=True, text=True, env=env).stdout.strip()
+
+    assert result.returncode == 0, (
+        'the unsanitised suite failed under a poisoned GIT_DIR:\n%s' % result.stdout[-2000:]
+    )
+    assert after == before, 'the victim HEAD moved -- the scrub did not protect it'
+    assert branch == 'main', 'the victim branch changed -- the scrub did not protect it'
+    assert bare == 'false', 'core.bare flipped on the victim -- the exact 2026-08-18 damage'

--- a/tests/unit/test_gate_covers_the_ui_backend.py
+++ b/tests/unit/test_gate_covers_the_ui_backend.py
@@ -27,6 +27,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.unit.conftest import sanitized_git_env
+
 REPO = Path(__file__).resolve().parents[2]
 SCRIPT = REPO / 'scripts' / 'needs_e2e.sh'
 
@@ -35,7 +37,7 @@ def classify(repo_dir, *paths, base='main'):
     """Commit `paths` in a throwaway repo and ask the real script."""
     def git(*args):
         subprocess.run(['git', *args], cwd=str(repo_dir), check=True,
-                       capture_output=True, text=True)
+                       capture_output=True, text=True, env=sanitized_git_env())
     for rel in paths:
         target = repo_dir / rel
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -43,15 +45,30 @@ def classify(repo_dir, *paths, base='main'):
     git('add', '-A')
     git('commit', '-qm', 'change')
     return subprocess.run([str(SCRIPT), base], cwd=str(repo_dir),
-                          capture_output=True, text=True).returncode
+                          capture_output=True, text=True,
+                          env=sanitized_git_env()).returncode
 
 
 @pytest.fixture
 def repo(tmp_path):
     def git(*args):
         subprocess.run(['git', *args], cwd=str(tmp_path), check=True,
-                       capture_output=True, text=True)
+                       capture_output=True, text=True, env=sanitized_git_env())
     git('init', '-q', '-b', 'main')
+
+    # Defense in depth: verify the effect, not just the input. See
+    # test_hybrid_gate.py's `repo` fixture for the full rationale and
+    # tests/unit/test_fixtures_do_not_leak_gitdir.py for the regression test.
+    absolute_git_dir = subprocess.run(
+        ['git', 'rev-parse', '--absolute-git-dir'], cwd=str(tmp_path),
+        check=True, capture_output=True, text=True, env=sanitized_git_env(),
+    ).stdout.strip()
+    assert Path(absolute_git_dir).resolve() == (tmp_path / '.git').resolve(), (
+        'this fixture\'s git operations are not targeting the throwaway '
+        'tmp_path (got %s) -- refusing to continue rather than risk running '
+        'further git commands against a real repository' % absolute_git_dir
+    )
+
     git('config', 'user.email', 't@example.com')
     git('config', 'user.name', 'T')
     (tmp_path / 'seed.txt').write_text('seed\n')

--- a/tests/unit/test_gate_covers_the_ui_backend.py
+++ b/tests/unit/test_gate_covers_the_ui_backend.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.unit.conftest import sanitized_git_env
+from tests.unit.conftest import assert_git_dir_is, sanitized_git_env
 
 REPO = Path(__file__).resolve().parents[2]
 SCRIPT = REPO / 'scripts' / 'needs_e2e.sh'
@@ -59,15 +59,7 @@ def repo(tmp_path):
     # Defense in depth: verify the effect, not just the input. See
     # test_hybrid_gate.py's `repo` fixture for the full rationale and
     # tests/unit/test_fixtures_do_not_leak_gitdir.py for the regression test.
-    absolute_git_dir = subprocess.run(
-        ['git', 'rev-parse', '--absolute-git-dir'], cwd=str(tmp_path),
-        check=True, capture_output=True, text=True, env=sanitized_git_env(),
-    ).stdout.strip()
-    assert Path(absolute_git_dir).resolve() == (tmp_path / '.git').resolve(), (
-        'this fixture\'s git operations are not targeting the throwaway '
-        'tmp_path (got %s) -- refusing to continue rather than risk running '
-        'further git commands against a real repository' % absolute_git_dir
-    )
+    assert_git_dir_is(tmp_path)
 
     git('config', 'user.email', 't@example.com')
     git('config', 'user.name', 'T')

--- a/tests/unit/test_gitleaks_config.py
+++ b/tests/unit/test_gitleaks_config.py
@@ -21,6 +21,7 @@ import re
 from pathlib import Path
 
 import pytest
+from tests.unit.conftest import sanitized_git_env
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CONFIG = REPO_ROOT / ".gitleaks.toml"
@@ -165,8 +166,7 @@ def test_allowlisted_runtime_paths_are_actually_gitignored_and_untracked():
             ["git", "ls-files", "--error-unmatch", path],
             cwd=REPO_ROOT,
             capture_output=True,
-            text=True,
-        )
+            text=True, env=sanitized_git_env())
         assert result.returncode != 0, (
             f"{path} is TRACKED by git but allowlisted from secret scanning — "
             f"that combination hides real secrets. Untrack it or drop the allowlist entry."

--- a/tests/unit/test_hybrid_gate.py
+++ b/tests/unit/test_hybrid_gate.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.unit.conftest import sanitized_git_env
+
 yaml = pytest.importorskip('yaml')
 
 REPO = Path(__file__).resolve().parents[2]
@@ -27,7 +29,8 @@ BROWSER_JOBS = ('ui-e2e-tests', 'accessibility')
 
 def _run(*args, cwd):
     return subprocess.run(
-        [str(SCRIPT), *args], cwd=str(cwd), capture_output=True, text=True
+        [str(SCRIPT), *args], cwd=str(cwd), capture_output=True, text=True,
+        env=sanitized_git_env(),
     ).returncode
 
 
@@ -37,9 +40,28 @@ def repo(tmp_path):
     rather than a mocked `git`."""
     def _git(*args):
         subprocess.run(['git', *args], cwd=tmp_path, check=True,
-                       capture_output=True, text=True)
+                       capture_output=True, text=True, env=sanitized_git_env())
 
     _git('init', '-q', '-b', 'main')
+
+    # Defense in depth: if the environment strip above ever misses a
+    # variable (a new call site added without it, a future git release
+    # adding another GIT_* location var), this catches the effect directly
+    # rather than trusting the input was sanitised. A silent redirect here
+    # would otherwise not surface until a real repository turned up
+    # corrupted, exactly as it did in the T31 follow-up incident this
+    # fixture is now regression-tested against
+    # (test_fixtures_do_not_leak_gitdir.py).
+    absolute_git_dir = subprocess.run(
+        ['git', 'rev-parse', '--absolute-git-dir'], cwd=tmp_path, check=True,
+        capture_output=True, text=True, env=sanitized_git_env(),
+    ).stdout.strip()
+    assert Path(absolute_git_dir).resolve() == (tmp_path / '.git').resolve(), (
+        'this fixture\'s git operations are not targeting the throwaway '
+        'tmp_path (got %s) -- refusing to continue rather than risk running '
+        'further git commands against a real repository' % absolute_git_dir
+    )
+
     _git('config', 'user.email', 't@example.com')
     _git('config', 'user.name', 'T')
     (tmp_path / 'seed.txt').write_text('seed\n')
@@ -296,7 +318,8 @@ class TestARenameAwayFromTheUiStillCounts:
         import subprocess as sp
 
         def _git(*args):
-            sp.run(['git', *args], cwd=repo['dir'], check=True, capture_output=True)
+            sp.run(['git', *args], cwd=repo['dir'], check=True,
+                   capture_output=True, env=sanitized_git_env())
 
         # The template must exist on the BASE, or the net diff is just an
         # added docs file and the test proves nothing.
@@ -318,7 +341,8 @@ class TestARenameAwayFromTheUiStillCounts:
         # Precondition: git really does collapse this to a rename, otherwise
         # the test passes for the wrong reason.
         renamed = sp.run(['git', 'diff', '--name-only', 'main...HEAD'],
-                         cwd=repo['dir'], capture_output=True, text=True).stdout.split()
+                         cwd=repo['dir'], capture_output=True, text=True,
+                         env=sanitized_git_env()).stdout.split()
         assert renamed == ['docs/view.txt'], (
             'git did not detect a rename, so this fixture cannot provoke the '
             'bug: %r' % renamed
@@ -349,9 +373,10 @@ class TestALargeDiffDoesNotSilentlySkip:
         bulk.mkdir(exist_ok=True)
         for i in range(6000):
             (bulk / ('file_%05d.py' % i)).write_text('x\n')
-        sp.run(['git', 'add', '-A'], cwd=repo['dir'], check=True, capture_output=True)
+        sp.run(['git', 'add', '-A'], cwd=repo['dir'], check=True,
+               capture_output=True, env=sanitized_git_env())
         sp.run(['git', 'commit', '-qm', 'a lot'], cwd=repo['dir'], check=True,
-               capture_output=True)
+               capture_output=True, env=sanitized_git_env())
 
         assert _run('main', cwd=repo['dir']) == 0, (
             'a browser-visible file was lost in a large diff'
@@ -377,14 +402,15 @@ class TestThePushBaseIsTheTargetBranchNotTheLastPush:
         import subprocess as sp
         origin = tmp_path / 'origin.git'
         sp.run(['git', 'init', '-q', '--bare', '-b', 'master', str(origin)],
-               check=True, capture_output=True)
+               check=True, capture_output=True, env=sanitized_git_env())
         clone = tmp_path / 'clone'
         sp.run(['git', 'clone', '-q', str(origin), str(clone)],
-               check=True, capture_output=True)
+               check=True, capture_output=True, env=sanitized_git_env())
 
         def _git(*args, cwd=clone):
             return sp.run(['git', *args], cwd=str(cwd), check=True,
-                          capture_output=True, text=True).stdout.strip()
+                          capture_output=True, text=True,
+                          env=sanitized_git_env()).stdout.strip()
 
         _git('config', 'user.email', 't@example.com')
         _git('config', 'user.name', 'T')
@@ -397,7 +423,8 @@ class TestThePushBaseIsTheTargetBranchNotTheLastPush:
     def _base(self, cwd):
         import subprocess as sp
         return sp.run([str(self.BASE_SCRIPT)], cwd=str(cwd),
-                      capture_output=True, text=True).stdout.strip()
+                      capture_output=True, text=True,
+                      env=sanitized_git_env()).stdout.strip()
 
     def test_before_the_first_push_the_base_is_master(self, tmp_path):
         clone, git = self._remote_repo(tmp_path)
@@ -520,7 +547,7 @@ class TestABrokenClassifierStillErrsTowardsRunning:
         assert _run('main', cwd=repo['dir']) == 1
 
         result = sp.run([str(broken), 'main'], cwd=str(repo['dir']),
-                        capture_output=True, text=True)
+                        capture_output=True, text=True, env=sanitized_git_env())
         assert result.returncode == 0, (
             'a classifier that cannot run resolved to SKIP: rc=%d %s'
             % (result.returncode, result.stderr)
@@ -540,18 +567,20 @@ class TestThePushBaseFallsBackAndFailsSafe:
     def _base(self, cwd):
         import subprocess as sp
         return sp.run([str(self.BASE_SCRIPT)], cwd=str(cwd),
-                      capture_output=True, text=True).stdout.strip()
+                      capture_output=True, text=True,
+                      env=sanitized_git_env()).stdout.strip()
 
     def _repo_without_origin_head(self, tmp_path):
         import subprocess as sp
         origin = tmp_path / 'origin.git'
         sp.run(['git', 'init', '-q', '--bare', '-b', 'master', str(origin)],
-               check=True, capture_output=True)
+               check=True, capture_output=True, env=sanitized_git_env())
         work = tmp_path / 'work'
         work.mkdir()
 
         def _git(*args):
-            sp.run(['git', *args], cwd=str(work), check=True, capture_output=True)
+            sp.run(['git', *args], cwd=str(work), check=True,
+                   capture_output=True, env=sanitized_git_env())
 
         _git('init', '-q', '-b', 'master')
         _git('config', 'user.email', 't@example.com')
@@ -565,7 +594,7 @@ class TestThePushBaseFallsBackAndFailsSafe:
         # Modern git sets origin/HEAD on fetch. Remove it, because the case
         # under test is a repo that has never had one.
         sp.run(['git', 'symbolic-ref', '--delete', 'refs/remotes/origin/HEAD'],
-               cwd=str(work), capture_output=True)
+               cwd=str(work), capture_output=True, env=sanitized_git_env())
         return work, _git
 
     def test_the_candidate_ladder_is_used_when_origin_HEAD_is_unset(self, tmp_path):
@@ -573,7 +602,8 @@ class TestThePushBaseFallsBackAndFailsSafe:
 
         import subprocess as sp
         symref = sp.run(['git', 'symbolic-ref', '--quiet', 'refs/remotes/origin/HEAD'],
-                        cwd=str(work), capture_output=True, text=True)
+                        cwd=str(work), capture_output=True, text=True,
+                        env=sanitized_git_env())
         assert symref.returncode != 0, (
             'origin/HEAD exists, so this fixture cannot exercise the ladder'
         )
@@ -588,20 +618,22 @@ class TestThePushBaseFallsBackAndFailsSafe:
         work = tmp_path / 'lonely'
         work.mkdir()
         sp.run(['git', 'init', '-q', '-b', 'nothing-standard', str(work)],
-               check=True, capture_output=True)
+               check=True, capture_output=True, env=sanitized_git_env())
         for args in (['config', 'user.email', 't@example.com'],
                      ['config', 'user.name', 'T']):
-            sp.run(['git', *args], cwd=str(work), check=True, capture_output=True)
+            sp.run(['git', *args], cwd=str(work), check=True,
+                   capture_output=True, env=sanitized_git_env())
         (work / 'a.txt').write_text('a\n')
-        sp.run(['git', 'add', '-A'], cwd=str(work), check=True, capture_output=True)
+        sp.run(['git', 'add', '-A'], cwd=str(work), check=True,
+               capture_output=True, env=sanitized_git_env())
         sp.run(['git', 'commit', '-qm', 'one'], cwd=str(work), check=True,
-               capture_output=True)
+               capture_output=True, env=sanitized_git_env())
 
         assert self._base(work) == ''
 
         # End to end: the empty answer must make the classifier say YES.
         result = sp.run([str(SCRIPT), ''], cwd=str(work),
-                        capture_output=True, text=True)
+                        capture_output=True, text=True, env=sanitized_git_env())
         assert result.returncode == 0, (
             'an unresolvable base resolved to SKIP: %s' % result.stderr
         )

--- a/tests/unit/test_hybrid_gate.py
+++ b/tests/unit/test_hybrid_gate.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.unit.conftest import sanitized_git_env
+from tests.unit.conftest import assert_git_dir_is, sanitized_git_env
 
 yaml = pytest.importorskip('yaml')
 
@@ -52,15 +52,7 @@ def repo(tmp_path):
     # corrupted, exactly as it did in the T31 follow-up incident this
     # fixture is now regression-tested against
     # (test_fixtures_do_not_leak_gitdir.py).
-    absolute_git_dir = subprocess.run(
-        ['git', 'rev-parse', '--absolute-git-dir'], cwd=tmp_path, check=True,
-        capture_output=True, text=True, env=sanitized_git_env(),
-    ).stdout.strip()
-    assert Path(absolute_git_dir).resolve() == (tmp_path / '.git').resolve(), (
-        'this fixture\'s git operations are not targeting the throwaway '
-        'tmp_path (got %s) -- refusing to continue rather than risk running '
-        'further git commands against a real repository' % absolute_git_dir
-    )
+    assert_git_dir_is(tmp_path)
 
     _git('config', 'user.email', 't@example.com')
     _git('config', 'user.name', 'T')

--- a/tests/unit/test_mutation_changed.py
+++ b/tests/unit/test_mutation_changed.py
@@ -29,6 +29,7 @@ SCRIPT = REPO_ROOT / "scripts" / "mutation_changed.py"
 
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 import mutation_changed  # noqa: E402
+from tests.unit.conftest import sanitized_git_env
 
 
 # ── Config parsing ──────────────────────────────────────────────────────────
@@ -392,8 +393,7 @@ def test_runner_env_does_not_duplicate_libs(monkeypatch):
 
 def _git(cwd, *args):
     return subprocess.run(
-        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
-    ).stdout
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True, env=sanitized_git_env()).stdout
 
 
 @pytest.fixture

--- a/tests/unit/test_mutation_changed.py
+++ b/tests/unit/test_mutation_changed.py
@@ -414,8 +414,14 @@ def temp_repo(tmp_path):
 
 
 def run_script(cwd, *args):
+    # sanitized_git_env() even though this spawns python, not git: the script
+    # itself shells out to `git rev-parse --show-toplevel`, so an ambient
+    # GIT_DIR reaches git one hop away. The process-level scrub in
+    # tests/conftest.py already covers this; passing it explicitly keeps the
+    # call honest about what it depends on.
     return subprocess.run(
-        [sys.executable, str(SCRIPT), *args], cwd=cwd, capture_output=True, text=True
+        [sys.executable, str(SCRIPT), *args], cwd=cwd, capture_output=True,
+        text=True, env=sanitized_git_env(),
     )
 
 


### PR DESCRIPTION
**This has corrupted this repository twice in one day**, both times flipping `core.bare` to `true` so the main checkout stopped being a work tree, and the second time it also blocked an unrelated branch's push.

### The mechanism

Git exports `GIT_DIR` into hook subprocesses **only when the push comes from a linked worktree**. Measured:

```
main checkout   GIT_DIR=[unset]
worktree        GIT_DIR=[.../.git/worktrees/<name>]
```

`.githooks/pre-push` runs `make verify`, which runs this suite. The gate-fixture tests shell out to git with `cwd=tmp_path` but an unsanitised environment — and **`cwd` does not win against `GIT_DIR`**. With it set, `git init` in a fresh tmp dir does not create a repo there; it silently re-initialises the repo `GIT_DIR` already names (`warning: re-init`), and every later fixture `commit`/`checkout` lands in the real repository.

Observed, not predicted: a real checkout left sitting on a fixture branch, two fixture commits on a real feature branch, and `core.bare = true`.

### Why it hid

**The gate passes when run directly**, because nothing sets `GIT_DIR`. It fails only through the hook, only from a worktree. So the standalone verdict and the push verdict disagree, and the standalone one is the one you look at — `fix/t36-extraction-escape` went exit 0 standalone and then failed its push gate on this, which is what surfaced it.

### The fix

1. `sanitized_git_env()` in `tests/unit/conftest.py` strips `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_OBJECT_DIRECTORY`, `GIT_COMMON_DIR`, `GIT_ALTERNATE_OBJECT_DIRECTORIES` before every git-invoking subprocess in both gate-fixture files — **including** the `needs_e2e.sh` / `push_base_ref.sh` calls, since those shell out to git themselves.
2. A plain function, deliberately **not** an autouse fixture: `conftest.py` is shared by ~150 test files, and importing it makes each caller's choice explicit.
3. **Defence in depth** — the `repo` fixture asserts, immediately after `git init`, that `git rev-parse --absolute-git-dir` resolves inside the throwaway `tmp_path`. That converts a future unsanitised call site from silent corruption into a named failure.

The originally-audited five call sites covered most tests; this also fixes ~20 more scattered across individual test classes that were equally exposed.

### Verification

Under the real condition — `GIT_DIR` poisoned to the real repo — 75 gate-fixture tests pass, `core.bare` stays `false`, HEAD unchanged.

Mutation-proven: with the stripping removed, the defence-in-depth assertion fires and names the leak.

```
assert PosixPath('.../victim/.git') == PosixPath('.../tmp_path/.git')
```

**Worth recording: my first mutation produced a false RED.** The test failed, but with a collection error rather than the corruption assertion — the edit had removed more than the function body. Caught only because the failure text did not name the behaviour being guarded. A red accepted at face value would have "proven" a guard I had actually broken.

Gate: exit 0.

### Generalises beyond this repo

Any test suite that shells out to git with `cwd=` and an inherited environment has this latent. It surfaces only when something runs the suite from a worktree hook, which is rare enough to sit dormant for a long time and then eat uncommitted work.