### PR TITLE
T52: stop the first-run wizard rendering credentials as type=text

### DIFF
--- a/couchpotato/ui/templates/wizard.html
+++ b/couchpotato/ui/templates/wizard.html
@@ -165,7 +165,7 @@
                   <input type="text" :placeholder="'Indexer URL (e.g. https://api.nzbgeek.info)'" 
                          x-model="entry.host"
                          class="flex-[2] bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
-                  <input type="password" placeholder="API Key" x-model="entry.api_key"
+                  <input type="password" placeholder="API Key" x-model="entry.api_key" autocomplete="off"
                          class="flex-1 bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   <button @click="formData.newznab.entries.splice(idx, 1)" x-show="formData.newznab.entries.length > 1"
                           class="text-cp-muted hover:text-cp-danger transition-colors">
@@ -444,7 +444,7 @@
                   </div>
                   <div>
                     <label class="block text-xs text-cp-muted mb-1">API Key</label>
-                    <input type="password" x-model="formData.downloaderConfig.sabnzbd.api_key" placeholder="Your SABnzbd API key"
+                    <input type="password" x-model="formData.downloaderConfig.sabnzbd.api_key" autocomplete="off" placeholder="Your SABnzbd API key"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                   <div>
@@ -630,7 +630,7 @@
                 <div class="space-y-3">
                   <div>
                     <label class="block text-xs text-cp-muted mb-1">OAuth Token</label>
-                    <input type="password" x-model="formData.downloaderConfig.putio.oauth_token" placeholder="Your Put.io OAuth token"
+                    <input type="password" x-model="formData.downloaderConfig.putio.oauth_token" autocomplete="off" placeholder="Your Put.io OAuth token"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                 </div>
@@ -1398,7 +1398,7 @@ function setupWizard() {
           <div><label class="block text-xs text-cp-muted mb-1">Host</label>
           <input type="text" x-model="formData.downloaderConfig.sabnzbd.host" placeholder="http://localhost:8080" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           <div><label class="block text-xs text-cp-muted mb-1">API Key</label>
-          <input type="password" x-model="formData.downloaderConfig.sabnzbd.api_key" placeholder="Your SABnzbd API key" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+          <input type="password" x-model="formData.downloaderConfig.sabnzbd.api_key" autocomplete="off" placeholder="Your SABnzbd API key" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           <div><label class="block text-xs text-cp-muted mb-1">Category (optional)</label>
           <input type="text" x-model="formData.downloaderConfig.sabnzbd.category" placeholder="movies" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`,
         nzbget: `
@@ -1462,7 +1462,7 @@ function setupWizard() {
           </div>`,
         putio: `
           <div><label class="block text-xs text-cp-muted mb-1">OAuth Token</label>
-          <input type="password" x-model="formData.downloaderConfig.putio.oauth_token" placeholder="Your Put.io OAuth token" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`
+          <input type="password" x-model="formData.downloaderConfig.putio.oauth_token" autocomplete="off" placeholder="Your Put.io OAuth token" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`
       };
       return configs[id] || '';
     },

--- a/couchpotato/ui/templates/wizard.html
+++ b/couchpotato/ui/templates/wizard.html
@@ -165,7 +165,7 @@
                   <input type="text" :placeholder="'Indexer URL (e.g. https://api.nzbgeek.info)'" 
                          x-model="entry.host"
                          class="flex-[2] bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
-                  <input type="text" placeholder="API Key" x-model="entry.api_key"
+                  <input type="password" placeholder="API Key" x-model="entry.api_key"
                          class="flex-1 bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   <button @click="formData.newznab.entries.splice(idx, 1)" x-show="formData.newznab.entries.length > 1"
                           class="text-cp-muted hover:text-cp-danger transition-colors">
@@ -444,7 +444,7 @@
                   </div>
                   <div>
                     <label class="block text-xs text-cp-muted mb-1">API Key</label>
-                    <input type="text" x-model="formData.downloaderConfig.sabnzbd.api_key" placeholder="Your SABnzbd API key"
+                    <input type="password" x-model="formData.downloaderConfig.sabnzbd.api_key" placeholder="Your SABnzbd API key"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                   <div>
@@ -630,7 +630,7 @@
                 <div class="space-y-3">
                   <div>
                     <label class="block text-xs text-cp-muted mb-1">OAuth Token</label>
-                    <input type="text" x-model="formData.downloaderConfig.putio.oauth_token" placeholder="Your Put.io OAuth token"
+                    <input type="password" x-model="formData.downloaderConfig.putio.oauth_token" placeholder="Your Put.io OAuth token"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                 </div>
@@ -1035,7 +1035,7 @@ function setupWizard() {
         fields: [
           { name: 'username', label: 'Username', placeholder: '' },
           { name: 'password', label: 'Password', type: 'password' },
-          { name: 'passkey', label: 'Passkey', full: true }
+          { name: 'passkey', label: 'Passkey', type: 'password', full: true }
         ]
       },
       { 
@@ -1045,7 +1045,7 @@ function setupWizard() {
         enabled: false,
         fields: [
           { name: 'username', label: 'Username' },
-          { name: 'passkey', label: 'Passkey' }
+          { name: 'passkey', label: 'Passkey', type: 'password' }
         ]
       },
       { 
@@ -1398,7 +1398,7 @@ function setupWizard() {
           <div><label class="block text-xs text-cp-muted mb-1">Host</label>
           <input type="text" x-model="formData.downloaderConfig.sabnzbd.host" placeholder="http://localhost:8080" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           <div><label class="block text-xs text-cp-muted mb-1">API Key</label>
-          <input type="text" x-model="formData.downloaderConfig.sabnzbd.api_key" placeholder="Your SABnzbd API key" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+          <input type="password" x-model="formData.downloaderConfig.sabnzbd.api_key" placeholder="Your SABnzbd API key" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           <div><label class="block text-xs text-cp-muted mb-1">Category (optional)</label>
           <input type="text" x-model="formData.downloaderConfig.sabnzbd.category" placeholder="movies" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`,
         nzbget: `
@@ -1462,7 +1462,7 @@ function setupWizard() {
           </div>`,
         putio: `
           <div><label class="block text-xs text-cp-muted mb-1">OAuth Token</label>
-          <input type="text" x-model="formData.downloaderConfig.putio.oauth_token" placeholder="Your Put.io OAuth token" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`
+          <input type="password" x-model="formData.downloaderConfig.putio.oauth_token" placeholder="Your Put.io OAuth token" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`
       };
       return configs[id] || '';
     },

--- a/couchpotato/ui/templates/wizard.html
+++ b/couchpotato/ui/templates/wizard.html
@@ -319,7 +319,17 @@
                             Applied on the shared input because every tracker
                             credential goes through it -- setting it per-field
                             would need the attribute in the data, which is the
-                            shape that hid the passkeys from the first sweep. -#}
+                            shape that hid the passkeys from the first sweep.
+
+                            Known side effect, not an oversight: this input
+                            also renders each tracker's `username`, so a
+                            password manager is told that field is not a login
+                            field and may not offer username autofill there.
+                            That is the accepted cost of the shared-input
+                            shape. Anyone here because "autofill does not work
+                            for tracker usernames" has found the cause, and the
+                            fix is to move the attribute into the field data,
+                            not to drop it. -#}
                         <input :type="field.type || 'text'" x-model="formData.privateTrackers[tracker.id][field.name]"
                                autocomplete="new-password"
                                :placeholder="field.placeholder || ''"

--- a/couchpotato/ui/templates/wizard.html
+++ b/couchpotato/ui/templates/wizard.html
@@ -165,7 +165,7 @@
                   <input type="text" :placeholder="'Indexer URL (e.g. https://api.nzbgeek.info)'" 
                          x-model="entry.host"
                          class="flex-[2] bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
-                  <input type="password" placeholder="API Key" x-model="entry.api_key" autocomplete="off"
+                  <input type="password" placeholder="API Key" x-model="entry.api_key" autocomplete="new-password"
                          class="flex-1 bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   <button @click="formData.newznab.entries.splice(idx, 1)" x-show="formData.newznab.entries.length > 1"
                           class="text-cp-muted hover:text-cp-danger transition-colors">
@@ -444,7 +444,7 @@
                   </div>
                   <div>
                     <label class="block text-xs text-cp-muted mb-1">API Key</label>
-                    <input type="password" x-model="formData.downloaderConfig.sabnzbd.api_key" autocomplete="off" placeholder="Your SABnzbd API key"
+                    <input type="password" x-model="formData.downloaderConfig.sabnzbd.api_key" autocomplete="new-password" placeholder="Your SABnzbd API key"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                   <div>
@@ -630,7 +630,7 @@
                 <div class="space-y-3">
                   <div>
                     <label class="block text-xs text-cp-muted mb-1">OAuth Token</label>
-                    <input type="password" x-model="formData.downloaderConfig.putio.oauth_token" autocomplete="off" placeholder="Your Put.io OAuth token"
+                    <input type="password" x-model="formData.downloaderConfig.putio.oauth_token" autocomplete="new-password" placeholder="Your Put.io OAuth token"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                 </div>
@@ -1398,7 +1398,7 @@ function setupWizard() {
           <div><label class="block text-xs text-cp-muted mb-1">Host</label>
           <input type="text" x-model="formData.downloaderConfig.sabnzbd.host" placeholder="http://localhost:8080" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           <div><label class="block text-xs text-cp-muted mb-1">API Key</label>
-          <input type="password" x-model="formData.downloaderConfig.sabnzbd.api_key" autocomplete="off" placeholder="Your SABnzbd API key" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+          <input type="password" x-model="formData.downloaderConfig.sabnzbd.api_key" autocomplete="new-password" placeholder="Your SABnzbd API key" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           <div><label class="block text-xs text-cp-muted mb-1">Category (optional)</label>
           <input type="text" x-model="formData.downloaderConfig.sabnzbd.category" placeholder="movies" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`,
         nzbget: `
@@ -1462,7 +1462,7 @@ function setupWizard() {
           </div>`,
         putio: `
           <div><label class="block text-xs text-cp-muted mb-1">OAuth Token</label>
-          <input type="password" x-model="formData.downloaderConfig.putio.oauth_token" autocomplete="off" placeholder="Your Put.io OAuth token" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`
+          <input type="password" x-model="formData.downloaderConfig.putio.oauth_token" autocomplete="new-password" placeholder="Your Put.io OAuth token" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`
       };
       return configs[id] || '';
     },

--- a/couchpotato/ui/templates/wizard.html
+++ b/couchpotato/ui/templates/wizard.html
@@ -311,7 +311,17 @@
                     <template x-for="field in tracker.fields" :key="field.name">
                       <div :class="field.full ? 'col-span-2' : ''">
                         <label class="block text-[10px] text-cp-muted mb-1" x-text="field.label"></label>
+                        {#- autocomplete="new-password" for the same reason as the
+                            direct credential inputs: these render as
+                            type="password" for every tracker's `password` and
+                            `passkey`, and without it a manager may offer the
+                            origin's saved LOGIN password as a fill candidate.
+                            Applied on the shared input because every tracker
+                            credential goes through it -- setting it per-field
+                            would need the attribute in the data, which is the
+                            shape that hid the passkeys from the first sweep. -#}
                         <input :type="field.type || 'text'" x-model="formData.privateTrackers[tracker.id][field.name]"
+                               autocomplete="new-password"
                                :placeholder="field.placeholder || ''"
                                class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-1.5 text-xs focus:outline-none focus:border-cp-accent/30">
                       </div>

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -2380,7 +2380,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       `error` string to its own refusal, and the other refusal paths in
       `saveView` still need one.
 
-- [x] T52: the first-run wizard renders credentials as `type="text"` — state: **fixed** (2026-08-20) — **security, pre-existing**
+- [x] T52: the first-run wizard renders credentials as `type="text"` — state: **fixed on #277, awaiting merge** (2026-08-20) — **security, pre-existing**
 
       Seven fields typed, but **only five ever rendered**. `wizard.html:432` opens
       `<template x-if="false && formData.downloader">` spanning lines 432-653, so the
@@ -2436,19 +2436,19 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       the type, and every tracker `password` did. The convention existed; a handful
       were missed. That is the argument for a sweep rather than a list.
 
-      T48 fixed the settings page by declaring `'type': 'password'` on the
-      plugin options. The wizard does NOT read plugin `config` — it carries its
-      own hard-coded field list — so it is unaffected and still renders
-      credentials in the clear.
-
-      Inconsistent within the single template, which is what makes it a
-      defect rather than a decision: `jackett_api_key` and the tracker
-      `password` fields already declare `type: 'password'`, while beside them
-      the tracker `passkey` fields, `sabnzbd.api_key`, `putio.oauth_token` and
-      `newznab.api_key` are hardcoded `type="text"`.
+      Why the wizard was missed by T48: that task fixed the settings page by
+      declaring `'type': 'password'` on the plugin options, and the wizard does
+      not read plugin `config` at all — it carries its own hard-coded field
+      list. So the fix could not reach it, and the wizard went on rendering
+      credentials in the clear until this task. It was inconsistent within the
+      single template, which is what made it a defect rather than a decision:
+      `jackett_api_key` and the tracker `password` fields already declared
+      `type: 'password'`, while beside them the tracker `passkey` fields,
+      `sabnzbd.api_key`, `putio.oauth_token` and `newznab.api_key` were
+      hardcoded `type="text"`.
 
       Lower severity than T48 because the wizard only ever shows what the user
-      is currently typing, never a stored secret — but it is the same
+      is currently typing, never a stored secret — but it was the same
       shoulder-surf and screenshot class, on the one page every new install
       walks through.
 
@@ -2457,7 +2457,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       the real option declarations instead, which would make this class of
       drift impossible rather than fixed-once.
 
-- [ ] T53: the Trakt notifier reads a section that does not exist, so it can never authorise — state: queued (no deps)
+- [ ] T53: the Trakt notifier reads a section that does not exist, so it can never authorise — state: building (no deps)
 
       Found by an adversarial reviewer while tracing T48's read paths, and
       unrelated to that work.
@@ -2533,7 +2533,171 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       several controls, and bundling it into a security fix would have made
       that fix harder to review for the thing it was actually for.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T53, T54, T55 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it.)
+- [ ] T56: the nightly backup the script documents does not exist on the host — state: queued (no deps) — **operability, data**
+
+      Found while taking the pre-promotion backup on 2026-08-20, which is the
+      only reason it was found at all.
+
+      `scripts/backup.sh`'s own header says: "Run this BEFORE every prod
+      promotion, and nightly from cron." Measured on homemedia:
+
+          cron, /etc/cron.d and systemd timers -> no backup schedule of any kind
+          backups/                             -> 20260731-111800,
+                                                  20260731-121928,
+                                                  20260801-203328
+
+      (The full listings are deliberately not reproduced. They fingerprint the
+      distribution and name what else runs as root on the box, and this repo is
+      public. What is load-bearing for the task is the absence, not the rest of
+      the crontab.)
+
+      So the newest snapshot before today was 1 August, nineteen days old, and
+      every one of the three that exist was taken by hand. The nightly half of
+      that sentence has never been true, and the directory listing proves it
+      rather than merely suggesting it: the script landed 2026-07-31 in #214,
+      nineteen days of a `--retain 14` nightly would leave fourteen dated
+      directories, three exist, two of them from the day it landed, and not one
+      of the three is stamped 03:00.
+
+      Be precise about the shape, because it changes the fix. The repo did NOT
+      fail to tell anyone. `docs/development-process.md:475-483` says "Two
+      manual steps, both on the server — neither is automated by this repo",
+      and gives a copy-pasteable `crontab -e` recipe with `--retain 14`. So
+      this is a documented setup step that was never performed, not a false
+      claim in a header. What IS false is `backup.sh:5`, which states the
+      nightly as though it were a property of the system rather than something
+      the operator has to install.
+
+      It ranks high on the project's own data-risk ordering either way: the
+      database is irreplaceable, and the promotion procedure is only reversible
+      because a backup was taken first. The header sentence is exactly what
+      someone reads when deciding whether they still need to take one.
+
+      Five parts. (1) and (5) are the task; (2) to (4) are what makes the
+      answer believable next time:
+
+      1. Install the schedule (systemd timer preferred over cron on this host,
+         since it gives a queryable last-run and a failure state) with
+         `--retain` set, so the backup directory does not grow without bound.
+      2. Verify a snapshot with a check that can see this schema's damage.
+         `PRAGMA integrity_check` does NOT check foreign keys, and
+         `couchpotato/core/db/schema.sql` declares them (`media_identifiers`
+         and `media_tags` both `REFERENCES documents(_id) ON DELETE CASCADE`,
+         with `PRAGMA foreign_keys = ON` set in `sqlite_adapter.py`). An
+         orphaned `media_identifiers` row is exactly the damage a row COUNT
+         cannot see and `integrity_check` will not report. The check is:
+
+             sqlite3 <snapshot>/couchpotato.db 'PRAGMA integrity_check; PRAGMA foreign_key_check;'
+
+         `foreign_key_check` must return zero rows, and it works regardless of
+         the `foreign_keys` pragma setting. Run against `20260820-100129` after
+         this was raised: zero rows, and `quick_check` ok.
+
+      3. Rehearse a RESTORE, once. Nothing in `docs/`, `scripts/backup.sh` or
+         `tests/unit/test_backup_script.py` mentions one, and a backup verified
+         only by reading it is a hypothesis about restore rather than a test of
+         it. Reading cannot exercise the sidecar `-wal` left in the live
+         directory, file ownership under `su-exec`, or whether `config.ini`
+         lands in the layout the container expects (`backup.sh` picks between
+         two candidate paths and warns-and-continues if it finds neither).
+         Restore `20260820-100129` into a scratch data dir and boot against it.
+
+      4. Make the claim falsifiable rather than trusting it a second time.
+         A timer that fires and fails silently reproduces the current state
+         exactly, and nothing in the repo can see the host. The check belongs
+         where it can fail: the promotion path should refuse when the newest
+         snapshot is older than some threshold, rather than the runbook asking
+         a human to remember.
+
+      5. Update the two places that describe the schedule so they describe what
+         was actually installed: `backup.sh`'s header sentence, and
+         `docs/development-process.md`'s "Two manual steps" block, which
+         documents the `crontab -e` form. Whichever mechanism lands, only one of
+         them should be described anywhere. Skipping this part reproduces the
+         defect the task exists to fix, one file to the left, which is the whole
+         reason it is listed rather than left implied.
+
+      Until (1) lands, the pre-promotion backup stays a manual step and must be
+      taken and VERIFIED each time — exit 0 is not enough on a live SQLite
+      database.
+
+      Be exact about why, because the obvious summary welds together two
+      failure modes that are actually disjoint, and gets the dangerous one
+      backwards:
+
+      - **Stale.** `cp` of `couchpotato.db` alone, ignoring the sidecar WAL.
+        The result is internally consistent, opens cleanly and PASSES
+        `PRAGMA integrity_check`, while silently missing every commit still in
+        that WAL. On 2026-08-20 the WAL was 8.6 MB and eight hours newer than
+        the main file, so this is the live risk. **No integrity check can see
+        it**, precisely because it is not corruption.
+      - **Torn.** `cp` of the whole set while a writer or checkpointer is
+        running. That one `integrity_check` DOES catch.
+
+      So an `integrity_check` pass does not rule out a bad `cp`; it only rules
+      out the half that was never the quiet one.
+
+      By the same discipline, be honest about what the 2026-08-20 comparison
+      established. `sqlite3 .backup` reads through a connection, so it sees
+      WAL-resident commits BY CONSTRUCTION: equality with the live read is the
+      expected output of a working tool, not independent corroboration. It
+      falsifies "stale checkpoint" and nothing else. `max(rowid)` is not a row
+      count, and all three metrics are blind to an UPDATE, so a snapshot in
+      which every `documents.data` blob had been truncated would pass every one
+      of them. `backup.sh` refuses to fall
+      through to `cp` at all (see its "Never fall through to `cp`" note and the
+      `NO BACKUP WAS TAKEN` exit) rather than degrade, which is the right call
+      for the same reason.
+
+- [ ] T57: the git-env denylist protecting the unit fixtures is enumerated on the wrong axis — state: queued (no deps) — **security, test-infrastructure**
+
+      Raised by a peer session working on the same harness, and confirmed here
+      by measurement rather than taken on report.
+
+      `tests/unit/conftest.py:32-39` strips six variables before any fixture
+      shells out to git. The list was derived from "what redirects the repo",
+      which is the wrong axis: the question is what git EXPORTS. Two escapes
+      follow from that, and the second is the serious one.
+
+      1. `GIT_CONFIG_PARAMETERS`. A plain commit exports GIT_INDEX_FILE,
+         GIT_PREFIX and the GIT_AUTHOR_* set, but `git -c foo=bar commit` also
+         exports `GIT_CONFIG_PARAMETERS='foo'='bar'`, which then rides into
+         every subprocess. `git -c ... push` from a worktree therefore hands
+         the suite arbitrary config. Same trigger and same class as the GIT_DIR
+         leak already recorded, one name the list does not have.
+
+      2. `GIT_TEMPLATE_DIR` is arbitrary code execution, and it is not a
+         location variable at all, so no denylist built on that axis would ever
+         have contained it. Measured here, not reasoned:
+
+             template dir with an executable hooks/pre-commit
+             GIT_TEMPLATE_DIR=../tmpl git init -q .
+             -> .git/hooks/pre-commit present in the NEW repo
+             -> it EXECUTED during the fixture's own seed commit
+
+         Every throwaway repo the suite creates would run it.
+
+      The fix is to invert: strip git's whole `GIT_*` namespace and allow back
+      only the commit-identity variables (`GIT_AUTHOR_*`, `GIT_COMMITTER_*`),
+      which change what a commit RECORDS rather than where it LANDS. A denylist
+      cannot be finished, because it is wrong again the next time git adds a
+      variable and nothing announces that; a namespace rule excludes the new
+      one the day it ships.
+
+      **The test is the hard part, and the peer's own first attempt at it was
+      proved vacuous.** A test that names `GIT_TEMPLATE_DIR` and
+      `GIT_CONFIG_COUNT` pins two variables while its docstring claims to pin
+      the property, and stays green through three mutations including a revert
+      to a denylist. The assertion that cannot be satisfied by any list of real
+      names is the one to write: a variable that does not exist, e.g.
+      `GIT_NOT_A_REAL_VARIABLE_47B3F9`, must be stripped. Prove it by reverting
+      to the denylist and watching that specific test fail.
+
+      Note `sanitized_git_env()` is also used by `needs_e2e.sh` callers, so
+      widening it touches more than the `repo` fixtures. Check nothing depends
+      on inheriting a `GIT_*` variable before removing the namespace.
+
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T53, T54, T55, T56, T57 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
       **Add to its scope (2026-08-18):** citations that rot. This session
       converted three-line-number citations into a third-party package and
       several stale line references into symbol citations, for one reason:
@@ -5659,3 +5823,33 @@ Every audit finding maps to a PR or to the deferred table above.
 | PR 6 | C1, C2, C3, C4, D2, D3, D5, O3, O4, O6, Q3, S9 (remainder), **Q2 (narrow start)** |
 | Deferred | A4, A5, P4 (fix), Q1 (bulk), Q2 (beyond `core/db/*`), mutmut scope |
 | Won't fix | D4 (legacy deps: a decision, see above) |
+
+- 2026-08-20 10:05 — #277 (T52) CI fully green (16/16). Merge was still
+  BLOCKED, and not by CI: two unresolved review threads on this very file.
+  The finding was correct and is fixed in this commit — the paragraphs
+  describing T52 as unfixed were left in place beneath the block marking it
+  `[x] fixed`, so the entry contradicted itself. Same failure T18 spends four
+  paragraphs on, reproduced inside a task body rather than a dependency list.
+  Pre-promotion backup TAKEN and verified on the prod host:
+  `backups/20260820-100129`, `PRAGMA integrity_check` = ok,
+  `PRAGMA foreign_key_check` = zero rows (added after review pointed out that
+  integrity_check ignores foreign keys and this schema has them), and documents /
+  max(rowid) / media_identifiers all equal to the live database read through
+  its 8.6 MB WAL (4357 / 21039 / 1099), so the snapshot is not a stale
+  checkpoint. Host `scripts/backup.sh` is byte-identical to the repo copy.
+  T53 -> building. The entry-vs-group sweep the task asks for was run first,
+  by AST over the whole tree: 68 config entry names, 32 group names that are
+  not entry names, and exactly ONE call site using a group name as a section
+  (`notifications/trakt.py` -> `trakt_automation`). Every other explicit
+  section literal (`core`, `renamer`, `torrent`, `moviesearcher`, `searcher`,
+  `nzb`, `automation`, `themoviedb`, `tmdb_charts`) is a real entry name; the
+  four configs `ast.literal_eval` cannot evaluate were checked by hand and are
+  all entry names too. Delegated with that sweep required as a mechanised
+  guard rather than a one-off result, since it goes stale on the next plugin.
+  SSH to homemedia: reachable once the owner loaded their identity into
+  `ssh-agent`. Two corrections worth keeping — the earlier "port 22 times out"
+  measurement was wrong, and the hostname stalls intermittently from here while
+  the host's LAN address is reliable, so scripted access should use the
+  address. The address itself belongs in the owner's private host notes, which
+  is where `CLAUDE.md` already routes host-access facts, and not in a file on a
+  public repo.

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -2407,6 +2407,31 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       naming `hdbits.passkey`. A vacuity guard pins each extraction, because the
       tag-only version of this sweep passed while two credentials rendered as text.
 
+      **GAP, recorded rather than papered over: no real-browser assertion.**
+      T48's sibling fix has one (`settings.spec.ts` — "the field is type=password,
+      so it is not shoulder-surfable"), and review reasonably asked for the same
+      here. It matters more here than there, because the tracker fields render
+      through ONE shared input whose type is the runtime expression
+      `:type="field.type || 'text'"` — so the static check reads a data array
+      and an expression and INFERS the result.
+
+      Three attempts at that test were abandoned. Reaching the Providers step
+      and enabling a tracker proved fiddly, and `getByRole` excludes hidden
+      elements, so "wrong step" and "element missing" produce the same failure
+      and cannot be told apart from the message. A guard whose failures cannot
+      be explained is worse than none, so none shipped.
+
+      What DOES exist: the static sweep over both rendering shapes, and review's
+      own browser measurement of this exact branch, which resolved every tracker
+      `password`/`passkey` to `password` in a real DOM and found only the
+      `username` fields as text. So the behaviour is verified once, by review —
+      it is simply not verified continuously.
+
+      Whoever closes this: drive the step by asserting on visible STEP CONTENT
+      first (the pattern that worked for the wizard's refused-save tests), then
+      the toggle, then the input — rather than looking for the toggle to decide
+      whether navigation worked.
+
       Same shape as T48 twice over: 16 of the 21 credential inputs already declared
       the type, and every tracker `password` did. The convention existed; a handful
       were missed. That is the argument for a sweep rather than a list.

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -2380,7 +2380,27 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       `error` string to its own refusal, and the other refusal paths in
       `saveView` still need one.
 
-- [ ] T52: the first-run wizard renders credentials as `type="text"` — state: queued (no deps) — **security, pre-existing**
+- [x] T52: the first-run wizard renders credentials as `type="text"` — state: **fixed** (2026-08-20) — **security, pre-existing**
+
+      Seven fields typed: `newznab entry.api_key`, `sabnzbd.api_key` and
+      `putio.oauth_token` (each appearing twice — once in markup, once in a JS
+      template string), plus `passthepopcorn.passkey` and `hdbits.passkey`.
+
+      **The enumeration nearly went wrong in the way this plan keeps recording.** A
+      regex over `<input>` tags found the first five and reported the file clean
+      otherwise. It cannot see the tracker passkeys: those render through ONE generic
+      input (`:type="field.type || 'text'"`) fed by the `privateTrackers` array, so
+      the credential's name never appears in the markup at all. They were found by
+      reading how that loop works, not by sweeping.
+
+      So the guard checks BOTH shapes, and both are mutation-proven: reverting one
+      direct input fails naming `wizard.html:633`, reverting one tracker field fails
+      naming `hdbits.passkey`. A vacuity guard pins each extraction, because the
+      tag-only version of this sweep passed while two credentials rendered as text.
+
+      Same shape as T48 twice over: 16 of the 21 credential inputs already declared
+      the type, and every tracker `password` did. The convention existed; a handful
+      were missed. That is the argument for a sweep rather than a list.
 
       T48 fixed the settings page by declaring `'type': 'password'` on the
       plugin options. The wizard does NOT read plugin `config` — it carries its
@@ -2479,7 +2499,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       several controls, and bundling it into a security fix would have made
       that fix harder to review for the thing it was actually for.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T48, T49, T50, T52, T53, T54, T55 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it.)
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T48, T49, T50, T53, T54, T55 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it.)
       **Add to its scope (2026-08-18):** citations that rot. This session
       converted three-line-number citations into a third-party package and
       several stale line references into symbol citations, for one reason:

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -2078,7 +2078,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       path `lhci autorun` never takes. The tick argued at length about the
       second and did not notice the first.
 
-- [ ] T48: the settings page renders API keys and tracker passkeys UNMASKED — state: queued (no deps) — **security, pre-existing**
+- [x] T48: the settings page renders API keys and tracker passkeys UNMASKED — state: **merged #275** (`b1ef797a`, 2026-08-19) — **security, pre-existing**. **Ticked late, 2026-08-20:** the merge commit never ticked its own entry, so the box stayed open for a day while the work was on master — found by review of T52, not by me. Exactly the staleness T18's parenthesis predicts about itself, and the reason the needs-list is now a test rather than a promise
 
       Found by the security lens while reviewing T47, and it is the larger half
       of that finding. Independent of Lighthouse: anyone who opens `/settings/`
@@ -2382,9 +2382,18 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
 
 - [x] T52: the first-run wizard renders credentials as `type="text"` — state: **fixed** (2026-08-20) — **security, pre-existing**
 
-      Seven fields typed: `newznab entry.api_key`, `sabnzbd.api_key` and
-      `putio.oauth_token` (each appearing twice — once in markup, once in a JS
-      template string), plus `passthepopcorn.passkey` and `hdbits.passkey`.
+      Seven fields typed, but **only five ever rendered**. `wizard.html:432` opens
+      `<template x-if="false && formData.downloader">` spanning lines 432-653, so the
+      `sabnzbd.api_key` at :447 and the `putio.oauth_token` at :633 are dead copies
+      that never enter the DOM. Review measured that in a real browser; my own
+      description said "each appearing twice — once in markup, once in a JS template
+      string", which implied two LIVE copies and was wrong.
+
+      The live leak was `newznab entry.api_key` (:168), `sabnzbd.api_key` (:1401),
+      `putio.oauth_token` (:1465), `passthepopcorn.passkey` and `hdbits.passkey`.
+      Typing the dead copies too is correct by consistency and harmless — but a
+      222-line dead duplicate that has to be kept in sync with the live template
+      literals is T18 material.
 
       **The enumeration nearly went wrong in the way this plan keeps recording.** A
       regex over `<input>` tags found the first five and reported the file clean
@@ -2499,7 +2508,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       several controls, and bundling it into a security fix would have made
       that fix harder to review for the thing it was actually for.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T48, T49, T50, T53, T54, T55 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it.)
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T53, T54, T55 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it.)
       **Add to its scope (2026-08-18):** citations that rot. This session
       converted three-line-number citations into a third-party package and
       several stale line references into symbol citations, for one reason:

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -1560,6 +1560,40 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       That is AC-SEC-42's protection removed entirely, leaving bcrypt's ~166ms
       as the only brake on credential stuffing.
 
+      **Correction, measured 2026-08-20: LATENT here, not live, and the entry
+      above overstated where it bites.** Two claims in it are wrong.
+
+      This repo documents no reverse proxy at all: `nginx`, `caddy`, `traefik`
+      and "reverse proxy" appear nowhere in `docs/` or `CLAUDE.md`, so "the
+      deployment shape this project documents" describes a shape the project
+      does not document. And production does not have one: the compose file
+      publishes `5050:5050` straight to the container, with no proxy in front.
+
+      The "proxy container talking to a port-mapped app" half is wrong for a
+      different reason, and this was measured rather than argued. Connections
+      were opened from a LAN client while the container's own socket table was
+      read:
+
+          tcp  172.19.0.2:5050  172.16.11.<lan-client>:58536  ESTABLISHED
+
+      The container sees the TRUE client address, not loopback and not the
+      Docker gateway. So `ProxyHeadersMiddleware` does not trust the peer,
+      `X-Forwarded-For` is ignored, and the bypass is not reachable on this
+      deployment as it stands.
+
+      It stays a real defect and stays queued, because the distance to live is
+      one ordinary decision: the moment a TLS terminator is put on that host
+      the trust becomes real, and certbot already runs there. Rank it as latent
+      rather than exploitable, and do not let the ranking be an argument for
+      closing it.
+
+      **A design constraint the entry does not name, and the fix has to solve
+      it.** The localhost exemption deliberately does NOT apply to auth routes.
+      So simply passing `proxy_headers=False` would put every remote user
+      behind a proxy into ONE shared `127.0.0.1` bucket, converting a bypass
+      into a global lockout that one attacker can trigger for everybody. The
+      fix has to be an explicit trusted-proxy opt-in, not a flag flip.
+
       Not caused by the uvicorn 0.51->0.52 bump: the default is identical at
       0.51.0, and neither release touched proxy headers.
 
@@ -2697,7 +2731,33 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       widening it touches more than the `repo` fixtures. Check nothing depends
       on inheriting a `GIT_*` variable before removing the namespace.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T53, T54, T55, T56, T57 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
+- [ ] T58: the wizard's credential masking is verified statically, never in a DOM — state: queued (no deps) — **security, test-coverage**
+
+      Raised on #277 and promoted out of T52's prose deliberately. T52 recorded
+      this gap honestly, but it recorded it as "whoever closes this", which is
+      not an owner and not a date. Review's objection is the right one: T48
+      went stale the same way, and a gap living only inside a ticked task's
+      body is a gap nobody is counting.
+
+      `tests/unit/test_wizard_credential_fields.py` proves the tracker
+      credentials are masked by reading the `privateTrackers` data array and
+      the shared input's `:type="field.type || 'text'"` expression, then
+      INFERRING the resolved attribute. That is a real guard and it caught real
+      leaks, but it is not a measurement of what the browser renders, and the
+      thing being guarded is credential masking.
+
+      Three attempts at a full-navigation Playwright test were abandoned under
+      T52, for a good reason: `getByRole` excludes hidden elements, so "wrong
+      wizard step" and "element missing" produce the same failure and cannot be
+      told apart from the message.
+
+      Review's suggestion sidesteps that entirely and is the approach to take
+      first: render the template in isolation with `page.setContent()`, Alpine
+      loaded, and a fixed `field.type`, rather than navigating to the Providers
+      step at all. The fragility that killed the three attempts was the
+      navigation, not the assertion.
+
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T53, T54, T55, T56, T57, T58 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
       **Add to its scope (2026-08-18):** citations that rot. This session
       converted three-line-number citations into a third-party package and
       several stale line references into symbol citations, for one reason:

--- a/tests/unit/test_wizard_credential_fields.py
+++ b/tests/unit/test_wizard_credential_fields.py
@@ -40,6 +40,14 @@ WIZARD = (Path(__file__).resolve().parents[2]
 # `entry.user_key` past the first version of this pattern. T48's own docstring
 # already listed `user_key` among the differently-named credentials it had to
 # fix, so this was a known name the pattern did not know.
+#
+# `auth` is an unanchored substring, so it also fires on `author`,
+# `authorization` and `authorize`. That breadth is deliberate, and it is the
+# safe direction to be wrong in: a false hit fails the build and gets looked
+# at, a miss ships a credential in the clear. Nothing in the template matches
+# it today for a non-credential reason. When something does, narrow the
+# IDENTIFIER the sweep feeds this pattern -- do not loosen the pattern, which
+# is the same instruction the assertion message carries.
 CREDENTIAL = re.compile(
     r'(api_?key|user_?key|passkey|pass_key|secret|token|password|cookie|auth)',
     re.I)
@@ -50,7 +58,20 @@ def _text() -> str:
 
 
 def _direct_inputs():
-    """(line, type, identifier) for every credential-ish `<input>` tag."""
+    """(line, type, identifier) for every credential-ish `<input>` tag.
+
+    Known simplification, in the same spirit as this file's vacuity guards:
+    `placeholder="([^"]+)"` cannot tell a literal `placeholder="..."` from an
+    Alpine-bound `:placeholder="..."`, because it matches from just after the
+    colon and so reads the BOUND EXPRESSION as if it were placeholder text.
+    Two consequences, neither live today. A dynamically-bound placeholder on a
+    non-credential field that happened to contain a credential word would trip
+    this test with a message pointing at something that is not a credential.
+    And a genuine credential identified ONLY by a dynamic placeholder cannot be
+    told apart from that case. `x-model` is the primary signal and covers every
+    credential field in this template, which is why the simplification is
+    tolerable rather than merely unnoticed.
+    """
     s = _text()
     for m in re.finditer(r'<input\b[^>]*>', s, re.S):
         tag = m.group(0)

--- a/tests/unit/test_wizard_credential_fields.py
+++ b/tests/unit/test_wizard_credential_fields.py
@@ -1,0 +1,120 @@
+"""T52: the first-run wizard must not render credentials as `type="text"`.
+
+T48 fixed the settings page by declaring `'type': 'password'` on the plugin
+options. The wizard does NOT read plugin `config` -- it carries its own
+hard-coded field list -- so it was unaffected and kept rendering credentials in
+the clear on the one page every new install walks through.
+
+Lower severity than T48 because the wizard only ever shows what the user is
+currently typing, never a stored secret. Same shoulder-surf and screenshot
+class though, and inconsistent *within a single template*: 16 of its 21
+credential inputs already declare `type="password"`, and every tracker
+`password` field does. The convention exists; a handful were missed.
+
+TWO SHAPES, and the second is why this is a test rather than a one-off fix:
+
+1. **Direct inputs** -- `<input type="text" x-model="...api_key">`. A regex over
+   the input tags finds these.
+2. **Data-driven fields** -- the private-tracker list renders through one
+   generic input (`:type="field.type || 'text'"`) fed by a `privateTrackers`
+   array, so the credential's NAME never appears in the tag at all.
+
+A sweep written for shape 1 alone reports the file clean while
+`passthepopcorn.passkey` and `hdbits.passkey` render as plain text. That is
+exactly what happened when this task was first scoped: the direct-input sweep
+missed both, and they were only found by reading how the tracker loop works.
+
+So this checks both, and a new credential added in either shape fails it.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+WIZARD = (Path(__file__).resolve().parents[2]
+          / 'couchpotato/ui/templates/wizard.html')
+
+CREDENTIAL = re.compile(
+    r'(api_?key|passkey|pass_key|secret|token|password|cookie)', re.I)
+
+
+def _text() -> str:
+    return WIZARD.read_text(encoding='utf-8')
+
+
+def _direct_inputs():
+    """(line, type, identifier) for every credential-ish `<input>` tag."""
+    s = _text()
+    for m in re.finditer(r'<input\b[^>]*>', s, re.S):
+        tag = m.group(0)
+        model = re.search(r'x-model="([^"]+)"', tag)
+        ph = re.search(r'placeholder="([^"]+)"', tag)
+        ident = f'{model.group(1) if model else ""} {ph.group(1) if ph else ""}'
+        if not CREDENTIAL.search(ident):
+            continue
+        t = re.search(r':type="([^"]+)"|type="([^"]+)"', tag)
+        typ = (t.group(1) or t.group(2)) if t else None
+        yield s[:m.start()].count('\n') + 1, typ, ident.strip()
+
+
+def _tracker_fields():
+    """(tracker, field, declares_password) from the `privateTrackers` array."""
+    s = _text()
+    start = s.index('    privateTrackers: [')
+    block = s[start:s.index('\n    ],', start)]
+    current = None
+    for line in block.split('\n'):
+        m = re.search(r"id: '([^']+)'", line)
+        if m:
+            current = m.group(1)
+        f = re.search(r"\{ name: '([^']+)'", line)
+        if f:
+            yield current, f.group(1), "type: 'password'" in line
+
+
+class TestNoCredentialRendersAsPlainText:
+
+    def test_direct_inputs_are_password_typed(self):
+        leaking = [
+            f'{WIZARD.name}:{line} {ident} (type={typ!r})'
+            for line, typ, ident in _direct_inputs()
+            if typ != 'password'
+        ]
+        assert not leaking, (
+            'credential inputs rendered in the clear:\n  '
+            + '\n  '.join(leaking)
+            + '\n\nDeclare type="password". Do NOT loosen the pattern.'
+        )
+
+    def test_tracker_fields_are_password_typed(self):
+        """The shape a tag-level sweep cannot see: these render through one
+        generic `:type="field.type || 'text'"` input, so the credential name is
+        in the data, not the markup."""
+        leaking = [
+            f'{tracker}.{field}'
+            for tracker, field, typed in _tracker_fields()
+            if CREDENTIAL.search(field) and not typed
+        ]
+        assert not leaking, (
+            f'tracker credential fields with no declared type: {leaking}. '
+            f"They render as text via `field.type || 'text'`."
+        )
+
+
+class TestTheSweepsCannotPassVacuously:
+    """Both assertions above pass trivially if their extraction finds nothing.
+    This file exists because the FIRST version of this sweep did exactly that
+    for the tracker fields."""
+
+    def test_the_input_sweep_finds_the_known_inputs(self):
+        found = list(_direct_inputs())
+        assert len(found) > 15, f'only {len(found)} credential inputs found'
+        assert any('formData.password' in i for _, _, i in found)
+
+    def test_the_tracker_sweep_finds_the_known_trackers(self):
+        found = list(_tracker_fields())
+        names = {t for t, _, _ in found}
+        assert 'passthepopcorn' in names and 'hdbits' in names, names
+        assert any(f == 'passkey' for _, f, _ in found), 'no passkey field seen'

--- a/tests/unit/test_wizard_credential_fields.py
+++ b/tests/unit/test_wizard_credential_fields.py
@@ -145,11 +145,22 @@ class TestTheSweepsCannotPassVacuously:
         for tracker, field, _ in found:
             per_tracker.setdefault(tracker, set()).add(field)
 
-        declared = set(re.findall(r"id:\s*'([^']+)'", _text()[
-            _text().index('    privateTrackers: ['):]))
+        # Bounded to the tracker array. The first version scanned from
+        # `privateTrackers` to END OF FILE, so any unrelated `id: '...'` added
+        # later in wizard.html would be reported as a missing tracker -- a
+        # false failure in the guard, pointing at innocent code.
+        text = _text()
+        start = text.index('    privateTrackers: [')
+        block = text[start:text.index('\n    ],', start)]
+        declared = set(re.findall(r"id:\s*'([^']+)'", block))
         seen = set(per_tracker)
-        assert declared <= seen or not declared - seen, (
-            f'trackers declared but not extracted: {sorted(declared - seen)}'
+
+        # Both directions. The first version was `declared <= seen or not
+        # declared - seen`, which is the same predicate twice -- `X or X`. It
+        # could not catch extraction inventing a tracker that is not declared.
+        assert declared == seen, (
+            f'declared but not extracted: {sorted(declared - seen)}; '
+            f'extracted but not declared: {sorted(seen - declared)}'
         )
         for tracker, fields in per_tracker.items():
             assert fields, f'{tracker} yielded no fields'

--- a/tests/unit/test_wizard_credential_fields.py
+++ b/tests/unit/test_wizard_credential_fields.py
@@ -36,8 +36,13 @@ pytestmark = pytest.mark.unit
 WIZARD = (Path(__file__).resolve().parents[2]
           / 'couchpotato/ui/templates/wizard.html')
 
+# `user_?key` and `auth` are here because review got an untyped
+# `entry.user_key` past the first version of this pattern. T48's own docstring
+# already listed `user_key` among the differently-named credentials it had to
+# fix, so this was a known name the pattern did not know.
 CREDENTIAL = re.compile(
-    r'(api_?key|passkey|pass_key|secret|token|password|cookie)', re.I)
+    r'(api_?key|user_?key|passkey|pass_key|secret|token|password|cookie|auth)',
+    re.I)
 
 
 def _text() -> str:
@@ -60,18 +65,34 @@ def _direct_inputs():
 
 
 def _tracker_fields():
-    """(tracker, field, declares_password) from the `privateTrackers` array."""
+    """(tracker, field, declares_password) from the `privateTrackers` array.
+
+    Extracts OBJECTS, not lines. The first version matched the literal
+    `"{ name: '"` on a single line, so review got two mutations past it: one
+    that removed the space (`{name:`), and one that split the object across
+    three lines. Both rendered `hdbits.passkey` as plain text with the suite
+    green -- the incidentally-passing shape, inside the class written to
+    prevent it. Someone adding a seventh tracker next quarter would format the
+    object across lines because it has four properties, and that is all it
+    would take.
+    """
     s = _text()
     start = s.index('    privateTrackers: [')
     block = s[start:s.index('\n    ],', start)]
-    current = None
-    for line in block.split('\n'):
-        m = re.search(r"id: '([^']+)'", line)
-        if m:
-            current = m.group(1)
-        f = re.search(r"\{ name: '([^']+)'", line)
-        if f:
-            yield current, f.group(1), "type: 'password'" in line
+
+    # Split into per-tracker chunks first so a field is attributed correctly
+    # however its own object is wrapped.
+    chunks = re.split(r"(?=\bid:\s*')", block)
+    for chunk in chunks:
+        m = re.search(r"id:\s*'([^']+)'", chunk)
+        if not m:
+            continue
+        tracker = m.group(1)
+        for obj in re.findall(r'\{[^{}]*\}', chunk, re.S):
+            f = re.search(r"name:\s*'([^']+)'", obj)
+            if f:
+                yield tracker, f.group(1), re.search(
+                    r"type:\s*'password'", obj) is not None
 
 
 class TestNoCredentialRendersAsPlainText:
@@ -113,8 +134,25 @@ class TestTheSweepsCannotPassVacuously:
         assert len(found) > 15, f'only {len(found)} credential inputs found'
         assert any('formData.password' in i for _, _, i in found)
 
-    def test_the_tracker_sweep_finds_the_known_trackers(self):
+    def test_the_tracker_sweep_sees_every_declared_tracker(self):
+        """Counts per tracker rather than asserting membership.
+
+        The first version asked `any(f == 'passkey')`, which passthepopcorn
+        alone satisfied -- so an extraction that silently stopped seeing
+        hdbits' fields still passed. Review demonstrated exactly that."""
         found = list(_tracker_fields())
-        names = {t for t, _, _ in found}
-        assert 'passthepopcorn' in names and 'hdbits' in names, names
-        assert any(f == 'passkey' for _, f, _ in found), 'no passkey field seen'
+        per_tracker = {}
+        for tracker, field, _ in found:
+            per_tracker.setdefault(tracker, set()).add(field)
+
+        declared = set(re.findall(r"id:\s*'([^']+)'", _text()[
+            _text().index('    privateTrackers: ['):]))
+        seen = set(per_tracker)
+        assert declared <= seen or not declared - seen, (
+            f'trackers declared but not extracted: {sorted(declared - seen)}'
+        )
+        for tracker, fields in per_tracker.items():
+            assert fields, f'{tracker} yielded no fields'
+        assert len(per_tracker) >= 6, (
+            f'only {len(per_tracker)} trackers extracted: {sorted(per_tracker)}'
+        )


### PR DESCRIPTION
T48 fixed the settings page by declaring `'type': 'password'` on the plugin options. The wizard does **not** read plugin `config` — it carries its own hard-coded field list — so it was unaffected and kept rendering credentials in the clear on the one page every new install walks through.

Lower severity than T48: the wizard only ever shows what the user is currently typing, never a stored secret. Same shoulder-surf and screenshot class, and inconsistent *within a single template* — 16 of its 21 credential inputs already declared `type="password"`, and every tracker `password` field did. The convention existed; a handful were missed.

## Two rendering shapes, and the second is why this is a guard rather than a fix

1. **Direct inputs** — `<input type="text" x-model="...api_key">`. A regex over input tags finds these.
2. **Data-driven fields** — the private-tracker list renders through *one* generic input (`:type="field.type || 'text'"`) fed by a `privateTrackers` array, so the credential's name never appears in the markup.

A sweep written for shape 1 alone reports the file clean while `passthepopcorn.passkey` and `hdbits.passkey` render as plain text. That is exactly what my first sweep did — they were found by reading how the tracker loop works, not by sweeping.

## What review caught

Three mutations got past the guard I built to hold this line:

- the tracker extraction matched the literal `"{ name: '"` **on one line**, so removing the space or splitting the object across lines evaded it — and the vacuity guard missed that because passthepopcorn's passkey alone satisfied `any(f == 'passkey')`
- `user_key` evaded the credential vocabulary, a name T48's own docstring already lists

Both closed: object-level extraction with `re.S`, and a vacuity guard that counts fields per tracker rather than testing membership. All three evasions now fail by name.

Two of my **records** were also wrong:

- I claimed seven leaking fields. Only **five ever rendered** — `wizard.html:432` opens `x-if="false && formData.downloader"` spanning 432–653, so two are dead copies. Review measured that in a real browser.
- **T48 merged as `b1ef797a` and never ticked its own entry**, so the box sat open for a day while the work was on master. Ticked here, and removed from T18's dependency list.

## Also

`autocomplete="off"` on the newly-masked inputs — reasoned, not measured. Making a field `type=password` on an origin that also serves a login form invites a password manager to offer the saved login password as a fill candidate, which could not happen while it was `type=text`.

Records **T18 material**: a 222-line dead duplicate that has to be kept in sync with the live template literals.

`make verify` exit 0. 10 unit tests, 8 E2E, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc