### PR TITLE
T53: the Trakt notifier reads a section that does not exist, so it can never authorise

### DIFF
--- a/couchpotato/core/notifications/trakt.py
+++ b/couchpotato/core/notifications/trakt.py
@@ -23,19 +23,19 @@ class Trakt(Notification, TraktBase):
     listen_to = ['renamer.after']
     enabled_option = 'notification_enabled'
 
-    def conf(self, attr, *args, **kwargs):
-        """Override conf to read OAuth credentials from automation settings."""
-        # These settings are shared with the automation module
-        shared_settings = ['automation_client_id', 'automation_client_secret', 
-                          'automation_oauth_token', 'automation_oauth_refresh']
-
-        if attr in shared_settings:
-            # Read from the automation config section
-            from couchpotato.environment import Env
-            value = Env.setting(attr, 'trakt_automation')
-            return value
-
-        return super().conf(attr, *args, **kwargs)
+    # T53: no `conf()` override here any more. This class and the automation
+    # provider (`.../automation/trakt/main.py`) both declare their plugin
+    # `config` under the SAME top-level entry name, `'trakt'` -- see that
+    # module's `config[0]['name']` and this file's own, below -- and
+    # `Plugin.conf()`'s default section is `self.getName().lower()`, which is
+    # `'trakt'` for this class too (nothing calls `setName` on it). So the
+    # inherited `Plugin.conf()` already reads the OAuth credentials the
+    # automation module writes; a previous version of this method
+    # deliberately redirected `automation_client_id` and friends to section
+    # `'trakt_automation'`, which is the automation module's GROUP name, not
+    # its entry name -- `loader.py` never registers anything under a group
+    # name -- so every read there came back `''` and this notifier could
+    # never authorise.
 
     def notify(self, message='', data=None, listener=None):
         if not data:

--- a/couchpotato/core/notifications/trakt.py
+++ b/couchpotato/core/notifications/trakt.py
@@ -20,6 +20,22 @@ class Trakt(Notification, TraktBase):
         'test': 'sync/last_activities',
     }
 
+    # NECESSARY BUT NOT SUFFICIENT, and worth reading before concluding that
+    # Trakt works. T53 fixed credential resolution: `conf()` now reads the
+    # section the automation module actually writes, so the settings page's
+    # Test button genuinely authorises. The COLLECTION path below is still
+    # dead, because `renamer.after` is never fired -- the only dispatch in the
+    # renamer package is `fireEvent('renamer.scan', ...)`, whose auto-derived
+    # suffix is `renamer.scan.after`. Measured on the loaded app: 24 handlers
+    # registered on `renamer.after`, zero firing sites in the tree. Tracked as
+    # the renamer event chain in `docs/technical-debt.md` and
+    # `specs/RENAMER-EVENT-CHAIN.md`.
+    #
+    # The consequence is a signal that lies in the user's favour: after T53 the
+    # Test button reports healthy while downloads are never added to the
+    # collection. Do NOT close that by widening `listen_to` here --
+    # `tests/unit/test_downloaded_review_notify.py` deliberately pins that this
+    # notifier must not listen to `movie.downloaded`/`movie.snatched`.
     listen_to = ['renamer.after']
     enabled_option = 'notification_enabled'
 

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -2414,7 +2414,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       `error` string to its own refusal, and the other refusal paths in
       `saveView` still need one.
 
-- [x] T52: the first-run wizard renders credentials as `type="text"` — state: **fixed on #277, awaiting merge** (2026-08-20) — **security, pre-existing**
+- [x] T52: the first-run wizard renders credentials as `type="text"` — state: **merged #277** (`4cc87966`, 2026-08-20) — **security, pre-existing**
 
       Seven fields typed, but **only five ever rendered**. `wizard.html:432` opens
       `<template x-if="false && formData.downloader">` spanning lines 432-653, so the
@@ -2491,7 +2491,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       the real option declarations instead, which would make this class of
       drift impossible rather than fixed-once.
 
-- [ ] T53: the Trakt notifier reads a section that does not exist, so it can never authorise — state: building (no deps)
+- [ ] T53: the Trakt notifier reads a section that does not exist, so it can never authorise — state: pr-open (no deps)
 
       Found by an adversarial reviewer while tracing T48's read paths, and
       unrelated to that work.
@@ -2509,6 +2509,24 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       never worked, and the failure mode is a log line that reads like a user
       configuration problem rather than a bug — which is presumably why it has
       survived.
+
+      **The relationship to the renamer chain is closer than "same family",
+      and both reviewers landed on it independently.** T53 fixes credential
+      RESOLUTION, not reachability. This notifier's only automatic trigger is
+      `renamer.after`, which has 24 registered handlers and zero firing sites:
+      the single dispatch in the renamer package is `fireEvent('renamer.scan',
+      ...)`, whose auto-derived suffix is `renamer.scan.after`. So after T53 the
+      collection path is still dead and only the settings page's Test button is
+      live.
+
+      That combination is worse than either half alone, and it is the thing to
+      say in a release note. Before T53 the Test button failed, which at least
+      matched reality. After T53 it succeeds, so the one signal a user can
+      reach reports healthy while nothing is ever added to their collection.
+      "The Trakt notifier now authorises" is the honest claim; "now notifies"
+      is not. Recorded at the `listen_to` line in the source as well, with an
+      explicit warning against closing it by widening `listen_to` --
+      `tests/unit/test_downloaded_review_notify.py` pins that deliberately.
 
       Same family as the renamer event chain (see the `renamer.before/after`
       note): correct-looking plugin code wired to something that is not there.
@@ -5883,6 +5901,25 @@ Every audit finding maps to a PR or to the deferred table above.
 | PR 6 | C1, C2, C3, C4, D2, D3, D5, O3, O4, O6, Q3, S9 (remainder), **Q2 (narrow start)** |
 | Deferred | A4, A5, P4 (fix), Q1 (bulk), Q2 (beyond `core/db/*`), mutmut scope |
 | Won't fix | D4 (legacy deps: a decision, see above) |
+
+- 2026-08-20 10:50 — #277 (T52) MERGED as `4cc87966` after two review rounds:
+  the self-contradicting spec entry, then four nits, all taken. T53 rebased on
+  it and pushed. Two reviewers on T53, security CLEAN, correctness found the
+  guard could disable itself: nothing asserted the entry-name and group-name
+  sets stay distinct, so one plausible line folding groups into entries makes
+  the guard a tautology. Measured with that line AND the original defect
+  restored: 10 passed. The existing vacuity checks cannot see it because
+  conflation makes the sweep find MORE. Closed with a positive control, proven
+  by re-running that mutation. Note the shape rather than the instance: three
+  guards on this branch have now been defeated by something the author did not
+  think to mutate, and each was found by a reviewer attacking the guard rather
+  than the code.
+  Dependabot #114 (`extract-zip`, high) TRIAGED as HOLD, with the condition
+  written down: no patched version exists (`first_patched_version` is null),
+  it is dev-only and transitive via `@lhci/cli -> lighthouse -> puppeteer-core
+  -> @puppeteer/browsers`, and `lhci` runs in neither CI nor `make verify` --
+  only `npm run test:lighthouse` by hand. Revisit when a patch ships or when
+  T47 changes that path, whichever comes first.
 
 - 2026-08-20 10:05 — #277 (T52) CI fully green (16/16). Merge was still
   BLOCKED, and not by CI: two unresolved review threads on this very file.

--- a/tests/unit/test_config_section_entry_vs_group.py
+++ b/tests/unit/test_config_section_entry_vs_group.py
@@ -177,7 +177,15 @@ def _collect_section_literal_call_sites(root):
                 continue
             func = node.func
 
-            if func.attr == 'setting' and isinstance(func.value, ast.Name) and func.value.id == 'Env':
+            # Matched on the ATTRIBUTE alone, deliberately, rather than on
+            # `Env.setting`. `.setting()` has no other meaning in this tree
+            # (measured: zero aliased `Env` imports and zero dotted
+            # `environment.Env` access today), and pinning the receiver to the
+            # name `Env` is how the same guard family has been evaded here
+            # before -- `conftest.py`'s header records an AST guard that missed
+            # `subprocess as sp`. Widening costs nothing and closes the alias,
+            # the dotted access, and whatever spelling arrives next.
+            if func.attr == 'setting':
                 if (len(node.args) >= 2 and isinstance(node.args[1], ast.Constant)
                         and isinstance(node.args[1].value, str)):
                     sites.append((path, node.lineno, node.args[1].value))
@@ -299,6 +307,38 @@ class TestSweepFindsSomethingRealNotNothing:
             f'only {len(sweep["call_sites"])} section-literal call sites '
             f'found -- a guard that finds zero, or close to it, and then '
             f'passes is exactly the failure this sweep exists to prevent'
+        )
+
+    def test_groups_and_entries_are_not_conflated(self, sweep):
+        """The guard's one silently-fatal regression, and neither the vacuity
+        counts nor a reintroduced defect can see it.
+
+        Every other check here asks "did the sweep find enough?". Folding group
+        names into `entries` makes it find MORE, so the counts get happier
+        while `test_no_call_site_names_a_group_instead_of_an_entry` becomes a
+        tautology: every group name is now an entry name, so nothing can ever
+        violate it. Measured: with that one line added AND the original T53
+        defect restored in `notifications/trakt.py`, all ten tests in this file
+        passed.
+
+        So this asserts the distinction the guard rests on, not the volume:
+        `trakt_automation` is the canonical group-that-is-not-an-entry, and the
+        two sets must stay meaningfully different in bulk."""
+        assert 'trakt_automation' in sweep['groups'], (
+            'the sweep no longer sees the group name whose confusion with an '
+            'entry name is the entire reason this file exists'
+        )
+        assert 'trakt_automation' not in sweep['entries'], (
+            '`trakt_automation` has been collected as an ENTRY name. Either a '
+            'plugin now genuinely declares it as one, or the collector is '
+            'folding group names into entries -- which makes the guard below '
+            'unable to fail'
+        )
+        only_groups = sweep['groups'] - sweep['entries']
+        assert len(only_groups) >= 25, (
+            f'only {len(only_groups)} group names are not also entry names '
+            f'(36 at the time of writing). A collapse toward zero means the '
+            f'two sets have been conflated and the guard cannot fail'
         )
 
     def test_known_call_sites_are_among_them(self, sweep):

--- a/tests/unit/test_config_section_entry_vs_group.py
+++ b/tests/unit/test_config_section_entry_vs_group.py
@@ -1,0 +1,367 @@
+"""T53's real fix is not the Trakt notifier -- it is making sure the same
+mistake cannot come back unnoticed anywhere else in this tree.
+
+`couchpotato/core/loader.py::loadSettings` registers every plugin's `config`
+block under its top-level ENTRY name (`section['name']`); it never registers
+anything under a group's `name`. `couchpotato/core/notifications/trakt.py`
+used to pass `'trakt_automation'` -- the automation module's GROUP name -- to
+`Env.setting()`, so it always read a section nothing had ever written to.
+That defect shape is not specific to Trakt: it is available at every call
+site anywhere in this tree that hands `Env.setting()`/`.conf()` a section as
+a hand-typed string literal, because nothing ties that string to the
+`config` declarations it is supposed to name.
+
+This sweeps the WHOLE `couchpotato/` tree structurally rather than relying
+on the hand sweep that found T53 in the first place: it collects every
+entry/group name declared by every module-level `config = [...]`, collects
+every section literal handed to `Env.setting()`/`.conf()`/`super().conf()`,
+and asserts every literal is an entry name.
+
+Deliberately NOT built on `ast.literal_eval`. Four files in this tree
+interpolate a runtime value somewhere inside their `config` dict --
+`getDownloadDir()`, `uuid4().hex`, `random.randint(...)`, a shared
+`rename_options` list -- which makes `literal_eval` raise on the WHOLE
+assignment and would silently drop that file's entry name from the sweep:
+`blackhole` (`downloaders/blackhole.py`), `core` (`_base/_core.py`),
+`moviesearcher` (`media/movie/searcher.py`) and `renamer`
+(`plugins/renamer/api.py`, the ONLY place `renamer` is declared -- there is
+no fallback declaration elsewhere in the tree). A sweep that cannot see
+those four is worse than no sweep: it looks complete and is not, which is
+exactly the shape `trakt_automation` exploited to begin with. So the
+extractor walks the AST structurally and reads only the `'name'` key's own
+value node, never the surrounding dict, which survives interpolation
+anywhere else in that dict.
+"""
+import ast
+import os
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+COUCHPOTATO_ROOT = os.path.join(REPO_ROOT, 'couchpotato')
+
+# Call sites this sweep is not expected to flag, because it cannot tell they
+# are wrong from the AST alone. Empty on purpose -- see
+# `TestNoExemptionIsDeadWeight` below for why an empty set is the better
+# outcome here, not a shortcut.
+EXEMPT = frozenset()
+
+
+def _iter_py_files(root):
+    """Every `.py` file under `root`, deterministically ordered so a
+    failure's file list does not depend on filesystem iteration order."""
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(d for d in dirnames if d != '__pycache__')
+        for filename in sorted(f for f in filenames if f.endswith('.py')):
+            yield os.path.join(dirpath, filename)
+
+
+def _dict_str_value(dict_node, key):
+    """The string value bound to `key` in a `Dict` AST node's OWN keys --
+    not recursively. Returns `None` if `key` is absent or its value is not a
+    plain string constant (an interpolated value, for instance)."""
+    for key_node, value_node in zip(dict_node.keys, dict_node.values):
+        if isinstance(key_node, ast.Constant) and key_node.value == key:
+            if isinstance(value_node, ast.Constant) and isinstance(value_node.value, str):
+                return value_node.value
+            return None
+    return None
+
+
+def _dict_value_node(dict_node, key):
+    """The raw AST node bound to `key`, so a caller can check its own type
+    (a `groups` value is expected to be a list literal)."""
+    for key_node, value_node in zip(dict_node.keys, dict_node.values):
+        if isinstance(key_node, ast.Constant) and key_node.value == key:
+            return value_node
+    return None
+
+
+def _collect_entries_and_groups(root):
+    """Structurally walk every module-level `config = [...]` under `root`.
+
+    Returns `(entries, groups, files_with_config)`: the set of every entry
+    name, the set of every group name, and the set of files that declared a
+    `config`. The asserts inside this loop are deliberate -- if a file's
+    `config` does not have the shape every declaration in this tree is
+    known to have (a list of dicts, each with a literal string `'name'`),
+    this must fail loudly rather than quietly contribute nothing to
+    `entries`. A collector that skips silently on the unexpected case is
+    exactly the trap `ast.literal_eval` would set here.
+    """
+    entries = set()
+    groups = set()
+    files_with_config = set()
+
+    for path in _iter_py_files(root):
+        source = open(path, encoding='utf-8').read()
+        tree = ast.parse(source, filename=path)
+
+        for node in tree.body:
+            is_config_assign = (
+                isinstance(node, ast.Assign)
+                and any(isinstance(t, ast.Name) and t.id == 'config' for t in node.targets)
+            )
+            if not is_config_assign:
+                continue
+
+            files_with_config.add(path)
+            assert isinstance(node.value, ast.List), (
+                f'{path}:{node.lineno}: module-level `config` is not a list '
+                f'literal -- this sweep only knows how to walk a list of '
+                f'dicts, and it must not silently ignore anything else'
+            )
+
+            for entry_node in node.value.elts:
+                assert isinstance(entry_node, ast.Dict), (
+                    f'{path}:{entry_node.lineno}: a `config` list element '
+                    f'is not a dict literal'
+                )
+                name = _dict_str_value(entry_node, 'name')
+                assert name is not None, (
+                    f'{path}:{entry_node.lineno}: a `config` entry has no '
+                    f'literal string `name` -- the sweep cannot register '
+                    f'this entry and must not pretend it did'
+                )
+                entries.add(name)
+
+                groups_node = _dict_value_node(entry_node, 'groups')
+                if groups_node is None:
+                    continue
+                assert isinstance(groups_node, ast.List), (
+                    f'{path}:{groups_node.lineno}: a `config` entry\'s '
+                    f'`groups` is not a list literal'
+                )
+                for group_node in groups_node.elts:
+                    if not isinstance(group_node, ast.Dict):
+                        continue
+                    gname = _dict_str_value(group_node, 'name')
+                    if gname:
+                        groups.add(gname)
+
+    return entries, groups, files_with_config
+
+
+def _collect_section_literal_call_sites(root):
+    """Every `Env.setting(...)` / `.conf(...)` / `super().conf(...)` call
+    that passes `section` as a string literal: the positional 2nd argument
+    for `Env.setting` (its signature is `setting(attr, section='core', ...)`
+    -- both real call sites in this tree that use `Env.setting` positionally
+    do so for `section`), or the keyword `section=` for either (both forms
+    are in real use here: `Env.setting('api_key', section='themoviedb')` in
+    `plugins/suggestion.py`, and `self.conf('search_on_add',
+    section='moviesearcher')` in `media/movie/_base/main.py`). Also checks
+    `.conf`'s `section` passed positionally as its 4th argument
+    (`Plugin.conf(self, attr, value=None, default=None, section=None)`) --
+    unused today, kept because nothing stops a future call site doing it and
+    the point of an AST sweep is not needing to notice that by hand.
+
+    A call whose section is DERIVED rather than literal --
+    `Env.setting('extra_score', section=provider.lower())`,
+    `Env.setting('seed_ratio', section=self.provider.getName().lower())` --
+    is deliberately NOT collected: there is nothing here to check it
+    against ahead of time, and flagging it would just be noise.
+
+    Returns a list of `(path, lineno, section)`.
+    """
+    sites = []
+
+    for path in _iter_py_files(root):
+        source = open(path, encoding='utf-8').read()
+        tree = ast.parse(source, filename=path)
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            func = node.func
+
+            if func.attr == 'setting' and isinstance(func.value, ast.Name) and func.value.id == 'Env':
+                if (len(node.args) >= 2 and isinstance(node.args[1], ast.Constant)
+                        and isinstance(node.args[1].value, str)):
+                    sites.append((path, node.lineno, node.args[1].value))
+                for kw in node.keywords:
+                    if kw.arg == 'section' and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                        sites.append((path, node.lineno, kw.value.value))
+
+            elif func.attr == 'conf':
+                for kw in node.keywords:
+                    if kw.arg == 'section' and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                        sites.append((path, node.lineno, kw.value.value))
+                if (len(node.args) >= 4 and isinstance(node.args[3], ast.Constant)
+                        and isinstance(node.args[3].value, str)):
+                    sites.append((path, node.lineno, node.args[3].value))
+
+    return sites
+
+
+@pytest.fixture(scope='module')
+def sweep():
+    entries, groups, files_with_config = _collect_entries_and_groups(COUCHPOTATO_ROOT)
+    call_sites = _collect_section_literal_call_sites(COUCHPOTATO_ROOT)
+    return {
+        'entries': entries,
+        'groups': groups,
+        'files_with_config': files_with_config,
+        'call_sites': call_sites,
+    }
+
+
+def _rel(path):
+    return os.path.relpath(path, REPO_ROOT)
+
+
+class TestTheExtractorDoesNotSkipTheHardFiles:
+    """The four files whose `config` cannot survive `ast.literal_eval`.
+    Pinned individually so a future refactor of the extractor cannot regress
+    back to `literal_eval` and quietly pass anyway -- the whole-tree baseline
+    counts below would still drop by exactly these four, but a raw number
+    going from 72 to 68 reads as "maybe fine", where a named entry
+    disappearing does not.
+    """
+
+    KNOWN_HARD_FILES = {
+        os.path.join(COUCHPOTATO_ROOT, 'core', 'downloaders', 'blackhole.py'): 'blackhole',
+        os.path.join(COUCHPOTATO_ROOT, 'core', '_base', '_core.py'): 'core',
+        os.path.join(COUCHPOTATO_ROOT, 'core', 'media', 'movie', 'searcher.py'): 'moviesearcher',
+        os.path.join(COUCHPOTATO_ROOT, 'core', 'plugins', 'renamer', 'api.py'): 'renamer',
+    }
+
+    @pytest.mark.parametrize('path,entry_name', sorted(KNOWN_HARD_FILES.items()))
+    def test_file_is_seen_and_its_entry_is_extracted(self, sweep, path, entry_name):
+        assert path in sweep['files_with_config'], (
+            f'{_rel(path)} was not even visited by the sweep -- check '
+            f'`_iter_py_files` and the file still exists at this path'
+        )
+        assert entry_name in sweep['entries'], (
+            f'{_rel(path)} declares entry {entry_name!r}, but it is missing '
+            f'from the extracted entry names -- the structural walk regressed '
+            f'to something that cannot survive this file\'s interpolated '
+            f'`config` values (this is exactly what `ast.literal_eval` would '
+            f'do)'
+        )
+
+    def test_renamer_has_no_fallback_declaration(self, sweep):
+        """If some OTHER file ever starts declaring entry `renamer` too, the
+        test above would keep passing even with a broken extractor for
+        `renamer/api.py`, because the entry would still show up from
+        elsewhere. Pin that `api.py` is the sole source today, so the test
+        above is proven to be exercising the hard case and not accidentally
+        redundant with an easy one."""
+        declares_renamer = [
+            f for f in sweep['files_with_config']
+            if f != os.path.join(COUCHPOTATO_ROOT, 'core', 'plugins', 'renamer', 'api.py')
+            and 'renamer' in _entries_declared_by(f)
+        ]
+        assert declares_renamer == [], (
+            f'entry `renamer` is now ALSO declared by {declares_renamer!r} -- '
+            f'`test_file_is_seen_and_its_entry_is_extracted` no longer proves '
+            f'what its docstring claims; update this pin'
+        )
+
+
+def _entries_declared_by(path):
+    """Every entry name a single file declares -- deliberately scoped to
+    just this one file rather than reusing `_collect_entries_and_groups`
+    over its directory, because a sibling file in the same directory could
+    declare the same entry name and this needs a precise per-file answer."""
+    source = open(path, encoding='utf-8').read()
+    tree = ast.parse(source, filename=path)
+    names = set()
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(isinstance(t, ast.Name) and t.id == 'config' for t in node.targets):
+            if isinstance(node.value, ast.List):
+                for entry_node in node.value.elts:
+                    if isinstance(entry_node, ast.Dict):
+                        name = _dict_str_value(entry_node, 'name')
+                        if name:
+                            names.add(name)
+    return names
+
+
+class TestSweepFindsSomethingRealNotNothing:
+    """A sweep that silently found zero entries or zero call sites would
+    pass every assertion below it vacuously -- an empty guard cannot fail.
+    These numbers are measured against this tree (72 entries, 19 call
+    sites as of this fix) with headroom, so the baseline holds as the tree
+    grows and only breaks if the extraction itself breaks."""
+
+    def test_at_least_65_entries_found(self, sweep):
+        assert len(sweep['entries']) >= 65, (
+            f'only {len(sweep["entries"])} entry names extracted -- the '
+            f'walk over module-level `config = [...]` is finding far less '
+            f'than this tree actually declares'
+        )
+
+    def test_at_least_15_section_literal_call_sites_found(self, sweep):
+        assert len(sweep['call_sites']) >= 15, (
+            f'only {len(sweep["call_sites"])} section-literal call sites '
+            f'found -- a guard that finds zero, or close to it, and then '
+            f'passes is exactly the failure this sweep exists to prevent'
+        )
+
+    def test_known_call_sites_are_among_them(self, sweep):
+        by_suffix = {
+            (_rel(p).replace(os.sep, '/'), section)
+            for p, _lineno, section in sweep['call_sites']
+        }
+        assert ('couchpotato/core/plugins/suggestion.py', 'themoviedb') in by_suffix, (
+            'expected `Env.setting(\'api_key\', section=\'themoviedb\')` in '
+            'plugins/suggestion.py to be collected'
+        )
+        assert ('couchpotato/core/plugins/dashboard.py', 'moviesearcher') in by_suffix, (
+            'expected `Env.setting(\'wait_for_release\', '
+            'section=\'moviesearcher\')` in plugins/dashboard.py to be '
+            'collected'
+        )
+
+
+class TestEverySectionLiteralIsAnEntryName:
+    """The actual guard. T53's shape, generalised: a section literal that
+    names a GROUP rather than an ENTRY reads exactly like a working config
+    read and always returns the default, because `loader.py` never
+    registers anything under a group name."""
+
+    def test_no_call_site_names_a_group_instead_of_an_entry(self, sweep):
+        entries = sweep['entries']
+        groups = sweep['groups']
+        violations = []
+
+        for path, lineno, section in sweep['call_sites']:
+            if section in entries or section in EXEMPT:
+                continue
+            shape = (
+                'names a GROUP, not an entry -- this is the exact T53 shape'
+                if section in groups else
+                'names neither a known entry nor a known group'
+            )
+            violations.append(f'{_rel(path)}:{lineno}: section={section!r} -- {shape}')
+
+        assert violations == [], (
+            'section literal(s) do not match any plugin entry name:\n  '
+            + '\n  '.join(violations)
+        )
+
+
+class TestNoExemptionIsDeadWeight:
+    """`EXEMPT` is empty, and that is the better outcome, not a shortcut
+    taken because nothing was found. The hand sweep the orchestrator ran
+    before this guard existed measured `trakt_automation` as the ONLY
+    literal group-name section in the tree, and this fix removes that one
+    call site rather than special-casing it -- so there is nothing left to
+    exempt. If a future change adds one back and cannot fix it immediately,
+    add it to `EXEMPT` and this test starts checking it the same way
+    `test_settings_credential_masking.py`'s equivalent does: that the
+    exempted (file, line, section) still exists, and that removing it from
+    `EXEMPT` would make `test_no_call_site_names_a_group_instead_of_an_entry`
+    fail -- proving the exemption is doing real work rather than sitting
+    there as decoration."""
+
+    def test_exempt_is_empty_and_that_is_deliberate(self):
+        assert EXEMPT == frozenset(), (
+            'EXEMPT is no longer empty -- add a case to this class that '
+            'proves each entry corresponds to a real call site AND that '
+            'the site would fail the guard without the exemption, the same '
+            'way test_settings_credential_masking.py proves its exemptions'
+        )

--- a/tests/unit/test_trakt_notifier_credentials.py
+++ b/tests/unit/test_trakt_notifier_credentials.py
@@ -1,0 +1,151 @@
+"""T53: the Trakt notifier reads a config section nothing registers, so it
+can never authorise.
+
+`couchpotato/core/loader.py::loadSettings` registers every plugin's `config`
+block under the top-level ENTRY name (`section['name']`), never under a
+group's `name`. The Trakt automation module declares entry name `'trakt'`
+with a group named `'trakt_automation'` -- and `couchpotato/core/notifications
+/trakt.py` used to override `conf()` to read `automation_client_id`,
+`automation_client_secret`, `automation_oauth_token` and
+`automation_oauth_refresh` from section `'trakt_automation'`, the GROUP name.
+Nothing ever registers that section, so every read came back `''` and the
+notifier logged "Trakt not authorized" regardless of how the user had
+configured it.
+
+This test drives the REAL loader path, not a stand-in for it: both the
+automation module's `config` and the notifier's own `config` go through
+`Loader.loadSettings` -- the exact call `Loader.run()` makes for every
+discovered plugin -- into a real `Settings` bound to a `tmp_path` config file.
+A fixture that called `Settings.registerDefaults` directly, or synthesised its
+own `config` dict, would keep passing even if `loadSettings` regressed the
+section name again; going through `loadSettings` is the only way this test
+can see that class of bug.
+"""
+import importlib
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from couchpotato.core import event as cp_event
+from couchpotato.core.loader import Loader
+from couchpotato.core.settings import Settings
+from couchpotato.environment import Env
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from env_helper import env_restored  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+AUTOMATION_MODULE = 'couchpotato.core.media.movie.providers.automation.trakt'
+NOTIFIER_MODULE = 'couchpotato.core.notifications.trakt'
+
+# The credentials the automation module's OAuth flow writes, and which the
+# notifier must read back under the same names.
+CREDENTIALS = {
+    'automation_client_id': 'REAL_CLIENT_ID',
+    'automation_client_secret': 'REAL_CLIENT_SECRET',
+    'automation_oauth_token': 'REAL_OAUTH_TOKEN',
+    'automation_oauth_refresh': 'REAL_OAUTH_REFRESH',
+}
+
+
+@contextmanager
+def _events_scoped_to(settings):
+    """Wire `settings.options` / `settings.register` to `settings` alone for
+    the duration of the block, then restore whatever was there before.
+
+    `Settings.setFile()` calls `connectEvents()`, which adds handlers to the
+    process-wide registry in `couchpotato.core.event` and never removes them
+    -- every earlier test in this session that built a `Settings()` has left
+    one sitting there. Firing the real event with all of that attached would
+    still be CORRECT (each stale handler only ever touches its own orphaned
+    instance), just slow and dependent on collection order. Snapshotting and
+    restoring these two names keeps `Loader.loadSettings`'s real
+    fireEvent-based path -- nothing about it is stubbed -- while making the
+    test deterministic regardless of what ran before it.
+    """
+    names = ('settings.options', 'settings.register')
+    saved = {name: list(cp_event.events.get(name, [])) for name in names}
+    for name in names:
+        cp_event.events[name] = []
+    cp_event.addEvent('settings.options', settings.addOptions)
+    cp_event.addEvent('settings.register', settings.registerDefaults)
+    try:
+        yield
+    finally:
+        for name, handlers in saved.items():
+            cp_event.events[name] = handlers
+
+
+def _load_via_loader(settings, module):
+    """Drive `Loader.loadSettings` for real -- the exact call `Loader.run()`
+    makes for every plugin module it discovers -- rather than calling
+    `Settings.registerDefaults` by hand. T53 is a bug in what `loadSettings`
+    passes as the section name, so a test that bypasses `loadSettings` could
+    not see it."""
+    with _events_scoped_to(settings):
+        ok = Loader().loadSettings(module, module.__name__, save=False)
+    assert ok, f'loadSettings reported failure for {module.__name__}'
+
+
+@pytest.fixture
+def wired_settings(tmp_path):
+    """A real `Settings`, bound to a real config file on disk holding the
+    credentials as the automation module's OAuth flow would have written
+    them -- under `[trakt]`, its own top-level entry name -- with both
+    plugins' `config` blocks registered through the real loader path, and
+    made the active `Env.setting()` target for the duration of the test."""
+    cfg = tmp_path / 'config.ini'
+    body = '[trakt]\n' + ''.join(
+        f'{name} = {value}\n' for name, value in CREDENTIALS.items()
+    )
+    cfg.write_text(body, encoding='utf-8')
+
+    with env_restored():
+        settings = Settings()
+        settings.setFile(str(cfg))
+        Env.set('settings', settings)
+
+        automation_module = importlib.import_module(AUTOMATION_MODULE)
+        notifier_module = importlib.import_module(NOTIFIER_MODULE)
+        _load_via_loader(settings, automation_module)
+        _load_via_loader(settings, notifier_module)
+
+        yield settings, notifier_module
+
+
+class TestTraktNotifierReadsWhatAutomationWrote:
+    """The regression pin for T53."""
+
+    @pytest.mark.parametrize('credential', sorted(CREDENTIALS))
+    def test_notifier_reads_the_credential_automation_wrote(
+        self, wired_settings, credential,
+    ):
+        _settings, notifier_module = wired_settings
+        notifier = notifier_module.Trakt.__new__(notifier_module.Trakt)
+
+        got = notifier.conf(credential)
+
+        assert got == CREDENTIALS[credential], (
+            f'notifier.conf({credential!r}) -> {got!r}; the automation '
+            f'module wrote it to section [trakt] and the notifier must read '
+            f'it from the same place -- got an empty/wrong value, which '
+            f'means the notifier is still reading a section nothing '
+            f'registers'
+        )
+
+    def test_the_automation_module_itself_reads_the_same_credential(
+        self, wired_settings,
+    ):
+        """Control: prove the automation side already works, so a failure
+        above is provably the notifier's bug and not a fixture mistake."""
+        settings, _notifier_module = wired_settings
+        automation_module = importlib.import_module(AUTOMATION_MODULE)
+
+        provider = automation_module.Trakt.__new__(automation_module.Trakt)
+
+        assert provider.conf('automation_oauth_token') == 'REAL_OAUTH_TOKEN'
+        assert settings.get('automation_oauth_token', 'trakt') == 'REAL_OAUTH_TOKEN'


### PR DESCRIPTION
## What

`couchpotato/core/notifications/trakt.py` overrode `conf()` to read its four OAuth credentials from section `trakt_automation`. Nothing registers that section.

`loader.py:110-115` registers plugin settings under the top-level config ENTRY name (`section['name']`), never the group name. The Trakt automation module declares entry `trakt` with group `trakt_automation`, so the credentials the OAuth flow writes land in `[trakt]`. Every read through the override returned `''`, and the notifier logged "Trakt not authorized" no matter how the user had configured it.

The override was also redundant. `Plugin.conf` defaults the section to `self.getName().lower().split(':')[0]`, which is `trakt` for this class too, so it is deleted rather than patched.

## Necessary but not sufficient, and this belongs in the release note

**The notifier now authorises. It still does not notify.** Its only automatic trigger is `renamer.after`, which has 24 registered handlers and zero firing sites: the single dispatch in the renamer package is `fireEvent('renamer.scan', ...)`, whose auto-derived suffix is `renamer.scan.after`. That chain is pre-existing recorded debt (`docs/technical-debt.md`, `specs/RENAMER-EVENT-CHAIN.md`).

The combination is worth stating plainly, because it is worse than either half. Before this change the Test button failed, which matched reality. After it, Test succeeds while nothing is ever added to the user's collection, so the one signal they can reach reports healthy. Recorded at the `listen_to` line, with an explicit warning against "fixing" it by widening `listen_to` — `tests/unit/test_downloaded_review_notify.py` pins that deliberately.

## The guard, which is the durable half

The task asked for the other `Env.setting(..., '<section>')` call sites to be swept rather than this instance fixed alone. A hand sweep goes stale on the next plugin, so `tests/unit/test_config_section_entry_vs_group.py` mechanises it: AST over the whole tree, entry names vs group names, every string-literal section must be an entry name. Measured 72 entries, 19 literal call sites, 0 violations, `EXEMPT` empty.

Extraction is structural rather than `ast.literal_eval`, which matters: four configs interpolate runtime values and would be silently dropped, taking `core`, `moviesearcher`, `renamer` and `blackhole` with them.

### Mutation evidence

- Reintroduce the defect in a different form to the original: behaviour test fails on all four credentials, AST guard fails naming `trakt.py:43`.
- Blind the collector (`return sites` -> `return []`): two vacuity tests fail naming the expected site, so the sweep cannot pass on an empty set.
- **Review found a third, which the first two could not reach.** Nothing asserted the entry-name and group-name sets stay distinct. Folding groups into entries makes every group name an entry name, so the guard becomes a tautology — measured with that line *and* the original defect restored: 10 passed. The vacuity counts are blind to it because conflation makes the sweep find *more*. Closed with a positive control, proven by re-running that exact mutation.

All restores confirmed byte-identical by hash, by file copy rather than `git checkout --`.

## Review

Two `code-reviewer` agents. Security/privacy CLEAN, having driven the real credentials through the real HTTP stack under four failure shapes with `PrivacyFilter` attached: no token, secret or client ID appears verbatim in any log record, traceback or cached payload. Correctness found the conflation hole above, and both independently flagged the reachability claim.

The matcher was also widened to key on the `.setting` attribute rather than the receiver being named `Env`, closing an aliased-import evasion — the same gap `conftest.py`'s header records this guard family falling into once before with `subprocess as sp`.

## Gate

`scripts/verify.sh` full run: ruff clean, 3557 unit passed, E2E 40 passed. Exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc