### PR TITLE
docs: backups before risky promotions, not nightly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ persona from memory; `AGENTS.md` is the review rubric they apply.
 | `make check-secrets` | Secret scan of the working tree (same command CI runs) |
 | `make coverage` | Generate the Python + JS coverage reports SonarQube ingests |
 | `make sonar` | Scan into self-hosted SonarQube after a merge that changed analysed code. Reporting only — **never a gate, never in CI**. Runs `coverage` first so the reports cannot be forgotten |
-| `./scripts/backup.sh` | Snapshot prod SQLite DB + settings. Run before any promotion carrying a change to a write path — mechanically: take it **unless** every file changed since the last promotion is docs, tests or CI config. Not nightly |
+| `./scripts/backup.sh` | Snapshot prod SQLite DB + settings before a promotion. Not nightly. The trigger is an exempt list, stated once in `scripts/backup.sh`'s header and mirrored in `docs/development-process.md` — do not paraphrase it here, a third copy is a third thing to drift |
 
 ## Hard rules — never break these
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ persona from memory; `AGENTS.md` is the review rubric they apply.
 | `make check-secrets` | Secret scan of the working tree (same command CI runs) |
 | `make coverage` | Generate the Python + JS coverage reports SonarQube ingests |
 | `make sonar` | Scan into self-hosted SonarQube after a merge that changed analysed code. Reporting only — **never a gate, never in CI**. Runs `coverage` first so the reports cannot be forgotten |
-| `./scripts/backup.sh` | Snapshot prod SQLite DB + settings — run before every deploy |
+| `./scripts/backup.sh` | Snapshot prod SQLite DB + settings — run before a promotion that could touch the database (schema, migration, `couchpotato/core/db/`, or an unattended write path such as the scanner or renamer). Not nightly, not before every deploy |
 
 ## Hard rules — never break these
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ persona from memory; `AGENTS.md` is the review rubric they apply.
 | `make check-secrets` | Secret scan of the working tree (same command CI runs) |
 | `make coverage` | Generate the Python + JS coverage reports SonarQube ingests |
 | `make sonar` | Scan into self-hosted SonarQube after a merge that changed analysed code. Reporting only — **never a gate, never in CI**. Runs `coverage` first so the reports cannot be forgotten |
-| `./scripts/backup.sh` | Snapshot prod SQLite DB + settings — run before a promotion that could touch the database (schema, migration, `couchpotato/core/db/`, or an unattended write path such as the scanner or renamer). Not nightly, not before every deploy |
+| `./scripts/backup.sh` | Snapshot prod SQLite DB + settings. Run before any promotion carrying a change to a write path — mechanically: take it **unless** every file changed since the last promotion is docs, tests or CI config. Not nightly |
 
 ## Hard rules — never break these
 

--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -483,6 +483,14 @@ schema", because this project has already lost data the other way: the
 `_query_index` defects fixed in 2026-02 corrupted records during an ordinary
 library scan, with no migration involved. Ask what the release can write.
 
+**What this policy does not cover, stated rather than left implicit.** That same
+example is the argument against a promotion-gated trigger as well as for a broad
+one: the corruption happened during normal running, not during a promotion, so
+no pre-promotion snapshot would have caught it. A write path that corrupts data
+three days after a deploy falls between backups here, where a nightly would not
+have. That residual risk is accepted deliberately. If this policy is ever
+revisited, that is the thread to pull.
+
 **There is no nightly backup and none is wanted.** Snapshots are taken at the
 moment that makes them recoverable, which is immediately before a risky
 promotion, rather than on a schedule that drifts out of date and gets ignored.

--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -337,8 +337,10 @@ promotion). Full design: `specs/FEAT-release-channels.md`.
 
 ### Deploying to prod (backup → rollback tag → restart → verify)
 
-A promotion is reversible only if you capture two things *before* restarting:
-the database, and the digest of the image currently running. Neither is
+A promotion that could touch the database is reversible only if you capture two
+things *before* restarting: the database, and the digest of the image currently
+running. The image digest is worth recording for EVERY promotion; the database
+snapshot follows the trigger in "Backups" below. Neither is
 recoverable afterwards — `:latest` has already moved by the time you deploy, so
 "just re-pull the old one" is not available.
 
@@ -346,8 +348,10 @@ recoverable afterwards — `:latest` has already moved by the time you deploy, s
 # SSH credentials in Openclaw memory (topics/couchpotato.md)
 cd /var/lib/plexmediaserver/CouchPotato
 
-# 1. Back up the DB + settings (see "Backups" below; ~seconds, live-safe).
-./scripts/backup.sh
+# 1. Back up the DB + settings, IF this promotion could touch the database
+#    (see "Backups" below for the trigger; ~seconds, live-safe). When in
+#    doubt, take it: the cost is seconds and the alternative is unrecoverable.
+./scripts/backup.sh --retain 14
 
 # 2. Record what is running now, so rollback has a target.
 #    The digest is the only reliable handle — the tag :latest is about to move.
@@ -443,8 +447,10 @@ and prunes only its own timestamped output.
 the Docker image puts it — `Dockerfile:97` runs
 `--config_file=/config/config.ini` with `--data_dir=/data`, so it sits one level
 above the data dir). Checking only the first would have meant prod snapshots
-quietly containing the database alone: the script warns and exits 0, so a nightly
-cron would report success forever while never capturing settings.
+quietly containing the database alone: the script warns and exits 0, so every run
+would report success while never capturing settings. That is why the
+verification below checks `config.ini` is present in the snapshot rather than
+only that the database opens.
 
 Both paths default to the prod layout, so on the server it takes no arguments
 (`make backup` is a shortcut for the no-argument form):
@@ -500,17 +506,50 @@ the script there once:
 
 ```bash
 scp scripts/backup.sh homemedia:/var/lib/plexmediaserver/CouchPotato/scripts/
-ssh homemedia 'cd /var/lib/plexmediaserver/CouchPotato && ./scripts/backup.sh'
+ssh homemedia 'cd /var/lib/plexmediaserver/CouchPotato && ./scripts/backup.sh --retain 14'
 ```
 
-**Verify the snapshot rather than trusting exit 0.** `PRAGMA integrity_check`
-does not check foreign keys, and this schema declares them, so run both:
+**Pass `--retain N`.** Retention used to live only on the nightly cron line, so
+removing the nightly took the only pruning mechanism in the documented workflow
+with it. Without it `backups/` grows by one full DB plus settings snapshot per
+risky promotion, forever, on the volume that also holds the live database. That
+is a slow way to reproduce the disk-full failure these snapshots exist to
+survive.
+
+**Verify the snapshot rather than trusting exit 0.** Three things, and the
+second and third are the ones people skip.
 
 ```bash
-sqlite3 <BACKUP_DIR>/<stamp>/couchpotato.db 'PRAGMA integrity_check; PRAGMA foreign_key_check;'
+B=<BACKUP_DIR>/<stamp>
+sqlite3 "$B/couchpotato.db" 'PRAGMA integrity_check; PRAGMA foreign_key_check;'
+test -r "$B/config.ini" && echo 'settings present'
 ```
 
-`integrity_check` must print `ok` and `foreign_key_check` must return no rows.
+1. `integrity_check` must print `ok`.
+2. `foreign_key_check` must return **no rows**. `integrity_check` does not check
+   foreign keys, and this schema declares them (`media_identifiers` and
+   `media_tags` both `REFERENCES documents(_id)`), so an orphaned row passes the
+   first check and fails recovery.
+3. `config.ini` must be present. `backup.sh` deliberately WARNS and exits 0 when
+   it cannot find the settings file, so both PRAGMAs can pass on a snapshot with
+   no settings in it at all. The database alone does not restore a working
+   install.
+
+**If `sqlite3` is not on the host**, use the interpreter instead. The script
+itself falls back to Python's `sqlite3` module for exactly this case, so a
+verification step that only speaks `sqlite3` fails on precisely the hosts the
+fallback exists to support:
+
+```bash
+python3 - "$B/couchpotato.db" <<'CHECK'
+import sqlite3, sys
+c = sqlite3.connect('file:%s?mode=ro' % sys.argv[1], uri=True)
+print('integrity_check:', c.execute('PRAGMA integrity_check').fetchall())
+print('foreign_key_check rows:', c.execute('PRAGMA foreign_key_check').fetchall())
+CHECK
+```
+
+Expect `[('ok',)]` and an empty list.
 
 ### Beta testers
 
@@ -529,7 +568,7 @@ toggle.
 | `scripts/check_test_traps.py` | False-green guard — stage 2 of `make verify` |
 | `scripts/check_conformance.py` | Design-system drift gate |
 | `scripts/mutation_changed.py` | Mutation testing scoped to changed files |
-| `scripts/backup.sh` | Prod DB + settings snapshot (pre-deploy and nightly) |
+| `scripts/backup.sh` | Prod DB + settings snapshot, before a promotion that could touch the database. Not nightly |
 
 Each of these is itself unit-tested (`tests/unit/test_check_test_traps.py`,
 `test_check_conformance.py`, `test_mutation_changed.py`, `test_backup_script.py`)

--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -348,9 +348,9 @@ recoverable afterwards — `:latest` has already moved by the time you deploy, s
 # SSH credentials in Openclaw memory (topics/couchpotato.md)
 cd /var/lib/plexmediaserver/CouchPotato
 
-# 1. Back up the DB + settings unless this promotion changed ONLY docs, tests
-#    or CI config (see "Backups" below; ~seconds, live-safe). When in doubt,
-#    take it: the cost is seconds and the alternative is unrecoverable.
+# 1. Back up the DB + settings unless every file this promotion changed is in
+#    the exempt list under "Backups" below (~seconds, live-safe). When in
+#    doubt, take it: the cost is seconds and the alternative is unrecoverable.
 ./scripts/backup.sh --retain 14
 
 # 2. Record what is running now, so rollback has a target.

--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -485,8 +485,23 @@ feels:
 > Take the backup **unless** every file changed since the last promotion is in
 > the exempt set. If anything else changed, take it.
 >
-> Exempt: `docs/`, `specs/`, `*.md`, `tests/`, `.github/`, and lint or
-> formatter config that does not ship in the image.
+> Exempt: `docs/`, `specs/`, `*.md`, `tests/`, `.github/`
+
+Get the changed-file list mechanically rather than from memory. The last
+promotion is the newest stable tag:
+
+```bash
+git diff --name-only "$(git tag -l 'v*' | grep -v -- '-beta' | sort -V | tail -1)"..HEAD
+```
+
+Two categories were proposed for this list and removed, both for the same
+reason. "Pure-presentation assets with no script in them" needs someone to
+decide what counts as presentation, and is wrong here anyway because a template
+can reach a write API. "Lint or formatter config that does not ship in the
+image" is an **empty category**: ruff's config lives in `pyproject.toml`, and
+the Dockerfile's `COPY . ${APP_DIR}/` ships the whole tree, so nothing
+qualifies. A category that names nothing, or that needs a judgement to apply,
+has no place in a rule whose purpose is removing the judgement.
 
 **Phrased as "unless" on purpose.** An earlier draft asked the operator to
 decide whether a release "could touch the database". That has one failure mode

--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -337,10 +337,10 @@ promotion). Full design: `specs/FEAT-release-channels.md`.
 
 ### Deploying to prod (backup → rollback tag → restart → verify)
 
-A promotion that could touch the database is reversible only if you capture two
-things *before* restarting: the database, and the digest of the image currently
-running. The image digest is worth recording for EVERY promotion; the database
-snapshot follows the trigger in "Backups" below. Neither is
+A promotion is reversible only if you capture two things *before* restarting:
+the database, and the digest of the image currently running. The image digest is
+worth recording for EVERY promotion; the database snapshot follows the trigger
+in "Backups" below, which in practice means almost every promotion. Neither is
 recoverable afterwards — `:latest` has already moved by the time you deploy, so
 "just re-pull the old one" is not available.
 
@@ -348,9 +348,9 @@ recoverable afterwards — `:latest` has already moved by the time you deploy, s
 # SSH credentials in Openclaw memory (topics/couchpotato.md)
 cd /var/lib/plexmediaserver/CouchPotato
 
-# 1. Back up the DB + settings, IF this promotion could touch the database
-#    (see "Backups" below for the trigger; ~seconds, live-safe). When in
-#    doubt, take it: the cost is seconds and the alternative is unrecoverable.
+# 1. Back up the DB + settings unless this promotion changed ONLY docs, tests
+#    or CI config (see "Backups" below; ~seconds, live-safe). When in doubt,
+#    take it: the cost is seconds and the alternative is unrecoverable.
 ./scripts/backup.sh --retain 14
 
 # 2. Record what is running now, so rollback has a target.
@@ -478,16 +478,33 @@ independently-chosen one are both true of the same suite — reviewers found
 survivors this way twice. Treat a score as "these specific behaviours are pinned",
 never as "the tests are sufficient".
 
-**When to take one.** Before a promotion that could touch the database, and not
-otherwise. That means a schema change or migration, or a release carrying
-changes to `couchpotato/core/db/` or to a write path that runs unattended, such
-as the library scanner or the renamer. A UI-only, docs-only or packaging-only
-promotion does not need one.
+**When to take one.** Before any promotion carrying a change to a write path.
+The trigger is a mechanical test, not a judgement about how risky the release
+feels:
 
-The trigger is deliberately "could touch the database" rather than "changes the
-schema", because this project has already lost data the other way: the
-`_query_index` defects fixed in 2026-02 corrupted records during an ordinary
-library scan, with no migration involved. Ask what the release can write.
+> Take the backup **unless** every file changed since the last promotion is in
+> the exempt set. If anything else changed, take it.
+>
+> Exempt: `docs/`, `specs/`, `*.md`, `tests/`, `.github/`, and lint or
+> formatter config that does not ship in the image.
+
+**Phrased as "unless" on purpose.** An earlier draft asked the operator to
+decide whether a release "could touch the database". That has one failure mode
+and it is a reliable one: the judgement is made by the person who wants to
+deploy, under time pressure, and "this one is fine" is free to say and expensive
+to be wrong about. Defaulting to taking it costs seconds.
+
+Two things an earlier draft of this policy got wrong, kept here because they are
+why the exempt list is short rather than long:
+
+- **"UI-only cannot damage data" is false in this codebase.** The UI calls
+  destructive APIs directly: `ui/templates/partials/movie_detail.html` fires
+  `media.delete`, and both `wizard.html` and the settings partial fire
+  `settings.save`. A wrong id destroys library records as thoroughly as a
+  migration would.
+- **"No schema change" does not mean "cannot corrupt".** The `_query_index`
+  defects fixed in 2026-02 corrupted records during an ordinary library scan,
+  with no migration involved.
 
 **What this policy does not cover, stated rather than left implicit.** That same
 example is the argument against a promotion-gated trigger as well as for a broad
@@ -568,7 +585,7 @@ toggle.
 | `scripts/check_test_traps.py` | False-green guard — stage 2 of `make verify` |
 | `scripts/check_conformance.py` | Design-system drift gate |
 | `scripts/mutation_changed.py` | Mutation testing scoped to changed files |
-| `scripts/backup.sh` | Prod DB + settings snapshot, before a promotion that could touch the database. Not nightly |
+| `scripts/backup.sh` | Prod DB + settings snapshot, before any promotion carrying a write-path change. Not nightly |
 
 Each of these is itself unit-tested (`tests/unit/test_check_test_traps.py`,
 `test_check_conformance.py`, `test_mutation_changed.py`, `test_backup_script.py`)

--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -472,15 +472,37 @@ independently-chosen one are both true of the same suite — reviewers found
 survivors this way twice. Treat a score as "these specific behaviours are pinned",
 never as "the tests are sufficient".
 
-Two manual steps, both on the server — neither is automated by this repo:
+**When to take one.** Before a promotion that could touch the database, and not
+otherwise. That means a schema change or migration, or a release carrying
+changes to `couchpotato/core/db/` or to a write path that runs unattended, such
+as the library scanner or the renamer. A UI-only, docs-only or packaging-only
+promotion does not need one.
 
-1. The server holds a compose + config directory, **not** a repo checkout, so
-   copy `scripts/backup.sh` there once (`scp scripts/backup.sh
-   homemedia:/var/lib/plexmediaserver/CouchPotato/scripts/`).
-2. Schedule it with `crontab -e`:
-   ```cron
-   0 3 * * * cd /var/lib/plexmediaserver/CouchPotato && ./scripts/backup.sh --retain 14 >> /var/log/couchpotato-backup.log 2>&1
-   ```
+The trigger is deliberately "could touch the database" rather than "changes the
+schema", because this project has already lost data the other way: the
+`_query_index` defects fixed in 2026-02 corrupted records during an ordinary
+library scan, with no migration involved. Ask what the release can write.
+
+**There is no nightly backup and none is wanted.** Snapshots are taken at the
+moment that makes them recoverable, which is immediately before a risky
+promotion, rather than on a schedule that drifts out of date and gets ignored.
+
+The server holds a compose + config directory, **not** a repo checkout, so copy
+the script there once:
+
+```bash
+scp scripts/backup.sh homemedia:/var/lib/plexmediaserver/CouchPotato/scripts/
+ssh homemedia 'cd /var/lib/plexmediaserver/CouchPotato && ./scripts/backup.sh'
+```
+
+**Verify the snapshot rather than trusting exit 0.** `PRAGMA integrity_check`
+does not check foreign keys, and this schema declares them, so run both:
+
+```bash
+sqlite3 <BACKUP_DIR>/<stamp>/couchpotato.db 'PRAGMA integrity_check; PRAGMA foreign_key_check;'
+```
+
+`integrity_check` must print `ok` and `foreign_key_check` must return no rows.
 
 ### Beta testers
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -2,9 +2,22 @@
 #
 # backup.sh — snapshot the CouchPotato SQLite database + settings.
 #
-# Run this BEFORE every prod promotion, and nightly from cron. A promotion is
-# only reversible if the database was captured first: `:latest` has already
-# moved by deploy time, so "re-pull the old image" does not recover data.
+# Run this before a promotion that could touch the database: a schema change or
+# migration, or any release carrying changes to the persistence layer
+# (`couchpotato/core/db/`) or to a write path that runs unattended, such as the
+# library scanner or the renamer. It is NOT run nightly and NOT run before every
+# deploy: a UI-only or docs-only promotion cannot damage data, and a backup
+# ritual applied to every release is one people stop taking seriously.
+#
+# The reason the trigger is "could touch the database" rather than "changes the
+# schema" is that this project has already lost data the other way. The
+# `_query_index` defects fixed in 2026-02 corrupted records during an ordinary
+# library scan, with no migration and no schema change involved. Ask what the
+# release can WRITE, not what it declares.
+#
+# When it does apply, it is not optional: a promotion is only reversible if the
+# database was captured first, because `:latest` has already moved by deploy
+# time, so "re-pull the old image" does not recover data.
 # Full procedure: docs/development-process.md → "Deploying to prod".
 #
 # The DB is copied with sqlite3's `.backup` (or Python's sqlite3 backup API when

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -2,26 +2,39 @@
 #
 # backup.sh — snapshot the CouchPotato SQLite database + settings.
 #
-# Run this before a promotion that could touch the database: a schema change or
-# migration, or any release carrying changes to the persistence layer
-# (`couchpotato/core/db/`) or to a write path that runs unattended, such as the
-# library scanner or the renamer. It is NOT run nightly and NOT run before every
-# deploy: a docs-only or packaging-only promotion cannot damage data, and a
-# backup ritual applied to every release is one people stop taking seriously.
+# Run this before any promotion that carries a change to a write path. NOT
+# nightly, and the trigger is a MECHANICAL test rather than a judgement about
+# how risky the release feels:
 #
-# "UI-only" is NOT on that safe list, and saying so was a defect in the first
-# draft of this policy. This project's UI calls destructive APIs directly:
-# `couchpotato/ui/templates/partials/movie_detail.html` fires `media.delete`,
-# and both `wizard.html` and the settings partial fire `settings.save`. A UI
-# change that sends the wrong id or the wrong value destroys library records or
-# corrupts configuration just as thoroughly as a migration would. Classify a UI
-# change by whether it can reach a write API, not by the fact that it is UI.
+#   Take the backup UNLESS every file changed since the last promotion is in
+#   the exempt set below. If anything else changed, take it.
 #
-# The reason the trigger is "could touch the database" rather than "changes the
-# schema" is that this project has already lost data the other way. The
-# `_query_index` defects fixed in 2026-02 corrupted records during an ordinary
-# library scan, with no migration and no schema change involved. Ask what the
-# release can WRITE, not what it declares.
+#   Exempt: docs (`docs/`, `specs/`, `*.md`), tests (`tests/`), CI and tooling
+#   config that does not ship in the image (`.github/`, lint and formatter
+#   config), and pure-presentation assets with no script in them.
+#
+# The rule is phrased as "unless" on purpose. An earlier draft asked the
+# operator to decide whether a release "could touch the database", and that
+# framing has one failure mode: the judgement is made by whoever wants to
+# deploy, under time pressure, and "this one is fine" is free to say and
+# expensive to be wrong about. Defaulting to taking it costs seconds.
+#
+# Two things the earlier draft got wrong, kept here because they are the
+# reason the exempt list is short:
+#
+#   "UI-only cannot damage data" is FALSE in this codebase. The UI calls
+#   destructive APIs directly: `ui/templates/partials/movie_detail.html` fires
+#   `media.delete`, and both `wizard.html` and the settings partial fire
+#   `settings.save`. A wrong id destroys library records as thoroughly as a
+#   migration would.
+#
+#   "No schema change" does not mean "cannot corrupt". The `_query_index`
+#   defects fixed in 2026-02 corrupted records during an ordinary library
+#   scan, with no migration involved.
+#
+# The reason the trigger is exempt-list-shaped rather than "changes the schema"
+# is that this project has already lost data the other way, and because the
+# person deciding is the person who wants to ship.
 #
 # Be honest about what that example does NOT establish, because it cuts both
 # ways. That corruption happened during NORMAL RUNNING, not during a promotion,
@@ -91,12 +104,10 @@ usage() {
   cat <<'USAGE'
 backup.sh — snapshot the CouchPotato SQLite database + settings.
 
-Run before a promotion that could touch the database: a schema change or
-migration, anything under couchpotato/core/db/, an unattended write path such as
-the scanner or renamer, or a UI change that can reach a destructive API (the UI
-calls media.delete and settings.save directly). NOT nightly, NOT before every
-deploy. Uses sqlite3 `.backup` (or Python's sqlite3 backup API) so the copy is
-safe against a live database.
+Run before any promotion carrying a change to a write path. The trigger is
+mechanical: take it UNLESS every file changed since the last promotion is docs,
+tests, or CI config. NOT nightly. Uses sqlite3 `.backup` (or Python's sqlite3
+backup API) so the copy is safe against a live database.
 
 Usage:
   ./scripts/backup.sh                 snapshot, keep everything

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -9,17 +9,23 @@
 #   Take the backup UNLESS every file changed since the last promotion is in
 #   the exempt set below. If anything else changed, take it.
 #
-#   Exempt: `docs/`, `specs/`, `*.md`, `tests/`, `.github/`, and lint or
-#   formatter config that does not ship in the image.
+#   Exempt: `docs/`, `specs/`, `*.md`, `tests/`, `.github/`
 #
-#   That list is deliberately identical to the one in
-#   docs/development-process.md, word for word. An earlier draft of this
-#   header also exempted "pure-presentation assets with no script in them",
-#   which the doc did not. Two problems with it, and either is enough:
-#   it reintroduced the judgement call this whole form exists to remove
-#   (who decides what counts as presentation, and as no script), and it was
-#   wrong anyway, because a template in this project can reach a write API.
-#   If these two lists ever disagree again, the shorter one wins.
+#   Get the file list mechanically rather than from memory. The last
+#   promotion is the newest stable tag, so:
+#
+#       git diff --name-only "$(git tag -l 'v*' | grep -v -- '-beta' | sort -V | tail -1)"..HEAD
+#
+#   That list is byte-identical to the one in docs/development-process.md and
+#   is checked by tests/unit/test_backup_policy_exempt_list.py, because prose
+#   alone has failed three times on this change alone. Two categories were
+#   proposed and removed, both for the same reason: "pure-presentation assets
+#   with no script in them" (who decides what counts as presentation, and a
+#   template here can reach a write API), and "lint or formatter config that
+#   does not ship in the image" (an EMPTY category, since ruff's config lives
+#   in pyproject.toml and the Dockerfile's `COPY . ${APP_DIR}/` ships the whole
+#   tree). A category that names nothing, or that needs a judgement to apply,
+#   belongs nowhere near a rule whose entire purpose is removing the judgement.
 #
 # The rule is phrased as "unless" on purpose. An earlier draft asked the
 # operator to decide whether a release "could touch the database", and that

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -6,8 +6,16 @@
 # migration, or any release carrying changes to the persistence layer
 # (`couchpotato/core/db/`) or to a write path that runs unattended, such as the
 # library scanner or the renamer. It is NOT run nightly and NOT run before every
-# deploy: a UI-only or docs-only promotion cannot damage data, and a backup
-# ritual applied to every release is one people stop taking seriously.
+# deploy: a docs-only or packaging-only promotion cannot damage data, and a
+# backup ritual applied to every release is one people stop taking seriously.
+#
+# "UI-only" is NOT on that safe list, and saying so was a defect in the first
+# draft of this policy. This project's UI calls destructive APIs directly:
+# `couchpotato/ui/templates/partials/movie_detail.html` fires `media.delete`,
+# and both `wizard.html` and the settings partial fire `settings.save`. A UI
+# change that sends the wrong id or the wrong value destroys library records or
+# corrupts configuration just as thoroughly as a migration would. Classify a UI
+# change by whether it can reach a write API, not by the fact that it is UI.
 #
 # The reason the trigger is "could touch the database" rather than "changes the
 # schema" is that this project has already lost data the other way. The
@@ -83,8 +91,12 @@ usage() {
   cat <<'USAGE'
 backup.sh — snapshot the CouchPotato SQLite database + settings.
 
-Run before every prod promotion, and nightly from cron. Uses sqlite3 `.backup`
-(or Python's sqlite3 backup API) so the copy is safe against a live database.
+Run before a promotion that could touch the database: a schema change or
+migration, anything under couchpotato/core/db/, an unattended write path such as
+the scanner or renamer, or a UI change that can reach a destructive API (the UI
+calls media.delete and settings.save directly). NOT nightly, NOT before every
+deploy. Uses sqlite3 `.backup` (or Python's sqlite3 backup API) so the copy is
+safe against a live database.
 
 Usage:
   ./scripts/backup.sh                 snapshot, keep everything
@@ -146,8 +158,10 @@ DB_SRC="$CP_DATA_DIR/database_v2/couchpotato.db"
 #   * DATA_DIR/../config.ini   — what the Docker image uses, where
 #                                `--config_file=/config/config.ini` sits one
 #                                level above `--data_dir=/data`
-# Picking the wrong one is invisible: the script warns and exits 0, so a nightly
-# cron reports success forever while never capturing settings.
+# Picking the wrong one is invisible: the script warns and exits 0, so every run
+# reports success while never capturing settings. That is why the documented
+# verification checks config.ini is PRESENT in the snapshot, not just that the
+# database opens.
 SETTINGS_SRC=""
 for candidate in "$CP_DATA_DIR/config.ini" "$CP_DATA_DIR/../config.ini"; do
   if [ -f "$candidate" ]; then
@@ -256,7 +270,7 @@ info "snapshot complete: $DEST"
 # still holds an UNPADDED `-N` directory from an older version of this script can
 # still mis-sort: with `<stamp>` and a legacy `<stamp>-2` present, `--retain 1`
 # keeps `-2` and prunes the fresh `<stamp>-02` (reproduced). Unreachable under
-# the documented usage — nightly `--retain 14` plus one manual pre-promotion run
+# the documented usage — `--retain N` on a pre-promotion run
 # would need 15+ snapshots inside a single second. If you ever hit it, delete or
 # rename the legacy unpadded directories once and it cannot recur.
 #
@@ -268,7 +282,7 @@ info "snapshot complete: $DEST"
 #   2. `set -o pipefail` + `head` closing the pipe early made the whole script
 #      exit 141 (SIGPIPE) on a *successful* backup once the snapshot list
 #      exceeded the pipe buffer (~1050 snapshots at the default path length), so
-#      cron reported failure for a good backup.
+#      the run reported failure for a good backup.
 # The array is already correct; sort and slice it in-process instead.
 prune_snapshots() {
   local keep="$1"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -9,9 +9,17 @@
 #   Take the backup UNLESS every file changed since the last promotion is in
 #   the exempt set below. If anything else changed, take it.
 #
-#   Exempt: docs (`docs/`, `specs/`, `*.md`), tests (`tests/`), CI and tooling
-#   config that does not ship in the image (`.github/`, lint and formatter
-#   config), and pure-presentation assets with no script in them.
+#   Exempt: `docs/`, `specs/`, `*.md`, `tests/`, `.github/`, and lint or
+#   formatter config that does not ship in the image.
+#
+#   That list is deliberately identical to the one in
+#   docs/development-process.md, word for word. An earlier draft of this
+#   header also exempted "pure-presentation assets with no script in them",
+#   which the doc did not. Two problems with it, and either is enough:
+#   it reintroduced the judgement call this whole form exists to remove
+#   (who decides what counts as presentation, and as no script), and it was
+#   wrong anyway, because a template in this project can reach a write API.
+#   If these two lists ever disagree again, the shorter one wins.
 #
 # The rule is phrased as "unless" on purpose. An earlier draft asked the
 # operator to decide whether a release "could touch the database", and that

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -119,8 +119,8 @@ usage() {
 backup.sh — snapshot the CouchPotato SQLite database + settings.
 
 Run before any promotion carrying a change to a write path. The trigger is
-mechanical: take it UNLESS every file changed since the last promotion is docs,
-tests, or CI config. NOT nightly. Uses sqlite3 `.backup` (or Python's sqlite3
+mechanical: take it UNLESS every file changed since the last promotion is in
+the exempt list in this script's header. NOT nightly. Uses sqlite3 `.backup` (or Python's sqlite3
 backup API) so the copy is safe against a live database.
 
 Usage:

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -15,6 +15,15 @@
 # library scan, with no migration and no schema change involved. Ask what the
 # release can WRITE, not what it declares.
 #
+# Be honest about what that example does NOT establish, because it cuts both
+# ways. That corruption happened during NORMAL RUNNING, not during a promotion,
+# so a promotion-gated snapshot would not have caught it either: a scan that
+# corrupts data three days after a deploy falls between backups under this
+# policy, where a nightly would have caught it. That residual risk is accepted
+# deliberately, on the owner's decision, and it is the thread to pull if this
+# policy ever needs revisiting. It is written down rather than left implicit so
+# the next reader inherits the decision and not just the rule.
+#
 # When it does apply, it is not optional: a promotion is only reversible if the
 # database was captured first, because `:latest` has already moved by deploy
 # time, so "re-pull the old image" does not recover data.

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -2585,121 +2585,62 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       several controls, and bundling it into a security fix would have made
       that fix harder to review for the thing it was actually for.
 
-- [ ] T56: the nightly backup the script documents does not exist on the host — state: queued (no deps) — **operability, data**
+- [x] T56: the backup policy said nightly, nothing ran nightly — state: **closed by decision** (2026-08-20) — **operability, data**
 
-      Found while taking the pre-promotion backup on 2026-08-20, which is the
-      only reason it was found at all.
+      Found while taking a pre-promotion backup on 2026-08-20. `backup.sh`'s
+      header said "Run this BEFORE every prod promotion, and nightly from
+      cron", and `docs/development-process.md` gave a `crontab -e` recipe as a
+      manual setup step. On the host there was no cron entry, no `cron.d` file
+      and no systemd timer. The newest snapshot was from 1 August, nineteen
+      days old, and all three that existed were taken by hand.
 
-      `scripts/backup.sh`'s own header says: "Run this BEFORE every prod
-      promotion, and nightly from cron." Measured on homemedia:
+      **Closed by an owner decision rather than by installing the schedule.**
+      The policy is now: take a snapshot before a promotion that could touch
+      the database, and not otherwise. No nightly. A backup ritual applied to
+      every release is one people stop taking seriously, and a nightly nobody
+      installed was never providing cover in the first place.
 
-          cron, /etc/cron.d and systemd timers -> no backup schedule of any kind
-          backups/                             -> 20260731-111800,
-                                                  20260731-121928,
-                                                  20260801-203328
+      One argument was put and answered rather than dropped, and it is why the
+      trigger is worded the way it is. "Changes the database" and "can damage
+      the database" are not the same set: the `_query_index` defects fixed in
+      2026-02 corrupted records during an ordinary library scan, with no
+      migration and no schema change. So the trigger is "could touch the
+      database" -- schema or migration, `couchpotato/core/db/`, or an
+      unattended write path such as the scanner or the renamer -- rather than
+      "declares a schema change".
 
-      (The full listings are deliberately not reproduced. They fingerprint the
-      distribution and name what else runs as root on the box, and this repo is
-      public. What is load-bearing for the task is the absence, not the rest of
-      the crontab.)
+      Landed in the same change: the `nightly from cron` claim removed from
+      `backup.sh` and `development-process.md`, `CLAUDE.md`'s command table
+      corrected from "run before every deploy", and the stale cron rationales
+      in `tests/unit/test_backup_script.py` reworded. Verification guidance
+      added too, since `PRAGMA integrity_check` does not check foreign keys and
+      this schema declares them: `foreign_key_check` must also return zero rows.
 
-      So the newest snapshot before today was 1 August, nineteen days old, and
-      every one of the three that exist was taken by hand. The nightly half of
-      that sentence has never been true, and the directory listing proves it
-      rather than merely suggesting it: the script landed 2026-07-31 in #214,
-      nineteen days of a `--retain 14` nightly would leave fourteen dated
-      directories, three exist, two of them from the day it landed, and not one
-      of the three is stamped 03:00.
+      What did NOT close, and is now T59: nobody has ever restored one.
 
-      Be precise about the shape, because it changes the fix. The repo did NOT
-      fail to tell anyone. `docs/development-process.md:475-483` says "Two
-      manual steps, both on the server — neither is automated by this repo",
-      and gives a copy-pasteable `crontab -e` recipe with `--retain 14`. So
-      this is a documented setup step that was never performed, not a false
-      claim in a header. What IS false is `backup.sh:5`, which states the
-      nightly as though it were a property of the system rather than something
-      the operator has to install.
+- [ ] T59: no backup has ever been restored, so recoverability is a hypothesis — state: queued (no deps) — **data**
 
-      It ranks high on the project's own data-risk ordering either way: the
-      database is irreplaceable, and the promotion procedure is only reversible
-      because a backup was taken first. The header sentence is exactly what
-      someone reads when deciding whether they still need to take one.
+      Split out of T56 rather than closed with it, because the owner's decision
+      changed WHEN backups are taken and not whether they work.
 
-      Five parts. (1) and (5) are the task; (2) to (4) are what makes the
-      answer believable next time:
+      Nothing in `docs/`, `scripts/backup.sh` or
+      `tests/unit/test_backup_script.py` mentions a restore rehearsal.
+      `docs/development-process.md` gives a restore recipe, but "confirmed
+      healthy" there refers to the pinned image, not to a restored database.
 
-      1. Install the schedule (systemd timer preferred over cron on this host,
-         since it gives a queryable last-run and a failure state) with
-         `--retain` set, so the backup directory does not grow without bound.
-      2. Verify a snapshot with a check that can see this schema's damage.
-         `PRAGMA integrity_check` does NOT check foreign keys, and
-         `couchpotato/core/db/schema.sql` declares them (`media_identifiers`
-         and `media_tags` both `REFERENCES documents(_id) ON DELETE CASCADE`,
-         with `PRAGMA foreign_keys = ON` set in `sqlite_adapter.py`). An
-         orphaned `media_identifiers` row is exactly the damage a row COUNT
-         cannot see and `integrity_check` will not report. The check is:
+      A backup verified only by reading it is a hypothesis about restore.
+      Reading cannot exercise the sidecar `-wal` left in the live directory,
+      file ownership under `su-exec`, or whether `config.ini` lands in the
+      layout the container expects -- `backup.sh` picks between two candidate
+      paths and warns-and-continues if it finds neither, which is precisely the
+      shape that produces a snapshot that looks complete and is not.
 
-             sqlite3 <snapshot>/couchpotato.db 'PRAGMA integrity_check; PRAGMA foreign_key_check;'
+      This matters MORE under the new policy, not less. Backups are now taken
+      only before risky promotions, so every one of them is load-bearing: there
+      is no nightly sitting behind it to fall back on.
 
-         `foreign_key_check` must return zero rows, and it works regardless of
-         the `foreign_keys` pragma setting. Run against `20260820-100129` after
-         this was raised: zero rows, and `quick_check` ok.
-
-      3. Rehearse a RESTORE, once. Nothing in `docs/`, `scripts/backup.sh` or
-         `tests/unit/test_backup_script.py` mentions one, and a backup verified
-         only by reading it is a hypothesis about restore rather than a test of
-         it. Reading cannot exercise the sidecar `-wal` left in the live
-         directory, file ownership under `su-exec`, or whether `config.ini`
-         lands in the layout the container expects (`backup.sh` picks between
-         two candidate paths and warns-and-continues if it finds neither).
-         Restore `20260820-100129` into a scratch data dir and boot against it.
-
-      4. Make the claim falsifiable rather than trusting it a second time.
-         A timer that fires and fails silently reproduces the current state
-         exactly, and nothing in the repo can see the host. The check belongs
-         where it can fail: the promotion path should refuse when the newest
-         snapshot is older than some threshold, rather than the runbook asking
-         a human to remember.
-
-      5. Update the two places that describe the schedule so they describe what
-         was actually installed: `backup.sh`'s header sentence, and
-         `docs/development-process.md`'s "Two manual steps" block, which
-         documents the `crontab -e` form. Whichever mechanism lands, only one of
-         them should be described anywhere. Skipping this part reproduces the
-         defect the task exists to fix, one file to the left, which is the whole
-         reason it is listed rather than left implied.
-
-      Until (1) lands, the pre-promotion backup stays a manual step and must be
-      taken and VERIFIED each time — exit 0 is not enough on a live SQLite
-      database.
-
-      Be exact about why, because the obvious summary welds together two
-      failure modes that are actually disjoint, and gets the dangerous one
-      backwards:
-
-      - **Stale.** `cp` of `couchpotato.db` alone, ignoring the sidecar WAL.
-        The result is internally consistent, opens cleanly and PASSES
-        `PRAGMA integrity_check`, while silently missing every commit still in
-        that WAL. On 2026-08-20 the WAL was 8.6 MB and eight hours newer than
-        the main file, so this is the live risk. **No integrity check can see
-        it**, precisely because it is not corruption.
-      - **Torn.** `cp` of the whole set while a writer or checkpointer is
-        running. That one `integrity_check` DOES catch.
-
-      So an `integrity_check` pass does not rule out a bad `cp`; it only rules
-      out the half that was never the quiet one.
-
-      By the same discipline, be honest about what the 2026-08-20 comparison
-      established. `sqlite3 .backup` reads through a connection, so it sees
-      WAL-resident commits BY CONSTRUCTION: equality with the live read is the
-      expected output of a working tool, not independent corroboration. It
-      falsifies "stale checkpoint" and nothing else. `max(rowid)` is not a row
-      count, and all three metrics are blind to an UPDATE, so a snapshot in
-      which every `documents.data` blob had been truncated would pass every one
-      of them. `backup.sh` refuses to fall
-      through to `cp` at all (see its "Never fall through to `cp`" note and the
-      `NO BACKUP WAS TAKEN` exit) rather than degrade, which is the right call
-      for the same reason.
+      Do it once, concretely: restore `20260820-100129` into a scratch data dir
+      and boot the app against it.
 
 - [ ] T57: the git-env denylist protecting the unit fixtures is enumerated on the wrong axis — state: queued (no deps) — **security, test-infrastructure**
 
@@ -2775,7 +2716,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       step at all. The fragility that killed the three attempts was the
       navigation, not the assertion.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T53, T54, T55, T56, T57, T58 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T53, T54, T55, T57, T58, T59 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
       **Add to its scope (2026-08-18):** citations that rot. This session
       converted three-line-number citations into a third-party package and
       several stale line references into symbol citations, for one reason:

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -1857,7 +1857,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       pass it. So the archive survives and the loss is recoverable by
       re-extracting. That is what keeps this off the irreplaceable tier.
 
-- [ ] T44: a single archive entry can decompress to an unbounded size — state: building (no deps) — **security, pre-existing**
+- [ ] T44: a single archive entry can decompress to an unbounded size — state: building, **premise corrected 2026-08-20** (no deps) — **security, pre-existing**
 
       Raised on #265 as explicitly non-blocking and correctly so: the read loop
       in `_extractOneAtomic` is untouched by that PR. Recorded because the file
@@ -1878,10 +1878,61 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       `sqlite3.OperationalError: disk I/O error`. Data at the top of the
       loss ranking sits behind a limit that does not exist.
 
-      The fix is a per-entry byte budget in the read loop, refusing the entry
-      when it exceeds what `info.file_size` claimed (plus a margin), and
-      treating the refusal exactly like the other entry-derived failures —
-      skip one entry, keep the archive, count it, cap the log.
+      **The premise above is WRONG against the pinned library, measured
+      2026-08-20, and the first implementation shipped a guard for a threat
+      that cannot happen.** `rarfile==4.5` already clamps every entry's stream
+      at the declared header size: `RarExtFile.read()` does
+      `elif n > self._remain: n = self._remain`, and `_open_extfile` sets
+      `self._remain = self._inf.file_size`. Driven with an underlying reader
+      willing to emit unlimited bytes:
+
+          declared file_size : 1024
+          bytes handed out   : 1024
+          _read calls        : [1024]
+
+      So `written <= declared` ALWAYS, and a cross-check of the form
+      `written > declared + margin` is unreachable. A header claiming a SMALL
+      size therefore costs the attacker nothing and gains them nothing: the
+      library truncates the stream, and the CRC mismatch is already counted as
+      `unreadable`.
+
+      **What IS reachable is entry COUNT, which nothing bounds.** The budget is
+      per entry with no archive-level total. Measured with 400 entries each
+      honestly declaring 256 KiB: 400 extracted, 100 MB written, no refusal.
+      RAR5 duplicate-file references (`RAR5_XREDIR_FILE_COPY`) let N distinct
+      names share one stored payload for the cost of N headers, so a few-MB
+      archive can request terabytes. The volume fills, the resulting `ENOSPC`
+      carries an errno not in `_ENTRY_DERIVED_ERRNOS`, and the archive aborts
+      AFTER the disk is full, on the volume that also holds the database.
+
+      So the fix is a whole-archive byte budget, plus the per-entry hard cap
+      kept explicitly as defence-in-depth against a future rarfile rather than
+      described as the fix. A FIXED constant, not a free-space-derived bound:
+      deterministic, unit-testable and free of operator surprise, which are the
+      same virtues that justify the per-entry cap.
+
+      **And the fixture must obey `RarExtFile.read()`'s clamping contract.** The
+      first implementation's stub reader had no `_remain`, so it was more
+      permissive than production, and three of its four tests passed because of
+      that rather than because of the code. An independent `min` -> `max`
+      mutation failed all four tests and was read as proof the guard was
+      load-bearing; it was measuring the stub. Until the fixture matches
+      production, no test on this branch can say whether the guard works. This
+      is the §11 incidentally-passing shape, found while explicitly defending
+      against it.
+
+      Two smaller findings from the same review, both to fix in the rework:
+      the 1000-entry test performs about 1 GiB of real I/O against the global
+      60s timeout and has already timed out once on a clean tree, so patch the
+      margin down rather than moving that much data; and the only reachable
+      refusal currently logs "wrote 3 MiB, exceeding its declared 4 MiB", which
+      is self-contradictory and would be every production refusal.
+
+      Superseded (kept because it is what the first attempt built): a per-entry
+      byte budget in the read loop, refusing the entry when it exceeds what
+      `info.file_size` claimed plus a margin, and treating the refusal exactly
+      like the other entry-derived failures — skip one entry, keep the archive,
+      count it, cap the log.
 
       Note `info.file_size` is attacker-supplied, so it bounds nothing on its
       own; it is useful only as a CROSS-CHECK against bytes actually written.

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -1857,7 +1857,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       pass it. So the archive survives and the loss is recoverable by
       re-extracting. That is what keeps this off the irreplaceable tier.
 
-- [ ] T44: a single archive entry can decompress to an unbounded size — state: building, **premise corrected 2026-08-20** (no deps) — **security, pre-existing**
+- [ ] T44: a single archive entry can decompress to an unbounded size — state: building, **reduced in scope by rule 11 after two failed designs** (no deps) — **security, pre-existing**
 
       Raised on #265 as explicitly non-blocking and correctly so: the read loop
       in `_extractOneAtomic` is untouched by that PR. Recorded because the file
@@ -1922,7 +1922,38 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       carries an errno not in `_ENTRY_DERIVED_ERRNOS`, and the archive aborts
       AFTER the disk is full, on the volume that also holds the database.
 
-      So the fix is a whole-archive byte budget, plus the per-entry hard cap
+      **Round two also shipped a guard that could not fire, and the task was
+      reduced rather than attempted a third time (rule 11).** The whole-archive
+      budget added in round two never advanced: `_extractOneAtomic` returned
+      bytes only on success, so a refused entry contributed nothing, and
+      because `_ARCHIVE_HARD_CAP = _ENTRY_HARD_CAP + 16 GiB` the entry cap
+      always tripped first. Measured at scaled constants: 26.7x the archive cap
+      written to disk with the running total still at zero. Two further leaks
+      in the same layer: the entry-derived `OSError` arm dropped bytes the same
+      way (10x the budget with no oversized entry at all), and the budget reset
+      every scan, so a large archive extracted in full across repeated scans
+      (measured: complete by scan 7, and `renamer.force_scan` runs every 2
+      hours by default).
+
+      **What shipped, and what did not.** Owner's call was to bank what works:
+      keep `_ENTRY_HARD_CAP`, which checks bytes actually written, does fire,
+      and is load-bearing under four independent mutations. Delete the archive
+      budget entirely rather than attempt a third variant of it.
+
+      **So the amplification is OPEN DEBT, not fixed.** The remaining guard
+      bounds ONE ENTRY at 128 GiB. N entries each just under it still write
+      N x 128 GiB, and each refused entry writes its full 128 GiB before being
+      unlinked. Anyone reopening this should note the frame that review
+      proposed and nobody has built: `read()` clamps to `file_size`, and
+      `file_redir` plus `getinfo()` resolve RAR5 copy and hard-link targets
+      FROM HEADERS ALONE, so the sum of resolved declared sizes is an exact
+      upper bound on what an archive can produce, computable before a single
+      byte is written. A pre-flight refusal on that sum closes all three leaks
+      at once because nothing is written to leak. That is a different shape
+      from a byte budget threaded through per-entry return values, which is
+      the shape that has now failed twice.
+
+      Superseded by the above: the fix is a whole-archive byte budget, plus the per-entry hard cap
       kept explicitly as defence-in-depth against a future rarfile rather than
       described as the fix. A FIXED constant, not a free-space-derived bound:
       deterministic, unit-testable and free of operator surprise, which are the

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -2903,7 +2903,56 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       produced false reds on this branch, and one reviewer had to re-derive a
       finding against a hash-verified pristine copy because of it.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T54, T55, T57, T58, T59, T60 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
+- [ ] T61: the archive extractor bounds one entry, not an archive — state: queued (no deps) — **security, carried over from T44**
+
+      Split out of T44 rather than left inside it, because T44 ticks when #280
+      merges and these two gaps would tick with it. Raised in review of #280,
+      which asked for exactly this: the residuals should not live only in a
+      code comment and a merged commit message.
+
+      What shipped in T44 bounds a SINGLE ENTRY at 128 GiB, against bytes
+      actually written. Two gaps remain, both measured:
+
+      1. **Archive-wide amplification.** N entries each honestly declaring a
+         size just under the cap still write N x 128 GiB in one archive, and
+         `extractFiles` loops over every archive in the folder. Measured during
+         the T44 rounds: 400 entries each declaring 256 KiB wrote 100 MB with
+         no refusal, and RAR5 duplicate-file references
+         (`RAR5_XREDIR_FILE_COPY`) let N distinct names share one stored
+         payload for the cost of N headers.
+
+      2. **The ENOSPC race on a constrained volume.** The cap is a fixed byte
+         count, not a function of free space, so on a volume with less than
+         128 GiB available a single hostile entry exhausts the disk before the
+         cap can fire. `ENOSPC` is not in `_ENTRY_DERIVED_ERRNOS`, so the
+         archive aborts, which is right but arrives after the damage.
+
+      **Severity, measured rather than inherited.** Extraction targets
+      `/downloads`, a NAS share with 1.9 TiB free, while the database sits on a
+      separate volume. So this is a download-share denial of service, not a
+      route to irrecoverable data loss, and (2) does not bite on this
+      deployment at all. It bites on a smaller volume and nothing detects that.
+
+      **The design to build, which two failed attempts point straight at.**
+      Do NOT thread a byte budget through per-entry return values; that shape
+      failed twice, once unreachable against `rarfile`'s clamp and once because
+      refused entries contributed nothing to the running total. Instead, refuse
+      PRE-FLIGHT on headers alone:
+
+          `read()` clamps to `file_size`, and `file_redir` plus `getinfo()`
+          resolve RAR5 copy and hard-link targets from headers, so the sum of
+          RESOLVED declared sizes is an exact upper bound on what the archive
+          can produce -- computable before a single byte is written.
+
+      Refusing on that sum, compared against both a fixed ceiling and free
+      space, closes both gaps at once because nothing is written to leak. It
+      also makes the free-space comparison safe to use, since it happens once
+      per archive rather than inside a hot read loop.
+
+      Whoever takes this: read T44's history first. Two guards shipped that
+      could not fire, and both looked correct in review.
+
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T54, T55, T57, T58, T59, T60, T61 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
       **Add to its scope (2026-08-18):** citations that rot. This session
       converted three-line-number citations into a third-party package and
       several stale line references into symbol citations, for one reason:

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -2600,6 +2600,19 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       every release is one people stop taking seriously, and a nightly nobody
       installed was never providing cover in the first place.
 
+      **The residual risk is recorded rather than glossed, because the evidence
+      cited for the trigger also argues against it.** The `_query_index`
+      corruption happened during NORMAL RUNNING, so a promotion-gated snapshot
+      would not have caught it: a write path that corrupts data days after a
+      deploy falls between backups under this policy, where a nightly would not
+      have. "Dropping nightly costs nothing because the nightly was never
+      installed" is true of the past and does not carry forward, since the
+      counterfactual is what a REAL nightly would provide. Accepted
+      deliberately on the owner's decision, and written down so the next reader
+      inherits the decision rather than only the rule. That is the thread to
+      pull if this is ever revisited, and T59 (nobody has restored a backup)
+      matters more because of it.
+
       One argument was put and answered rather than dropped, and it is why the
       trigger is worded the way it is. "Changes the database" and "can damage
       the database" are not the same set: the `_query_index` defects fixed in

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -2814,7 +2814,48 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       step at all. The fragility that killed the three attempts was the
       navigation, not the assertion.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T54, T55, T57, T58, T59 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
+- [ ] T60: two gate tests shell out to a whole-tree walk with no timeout — state: queued (no deps) — **flake**
+
+      Found by running the gate three times concurrently on 2026-08-20 and
+      watching it fail two different ways, neither of them a real defect.
+
+      `tests/unit/test_security.py:310` (`test_no_tenacity_imports_anywhere`)
+      runs `find . -name '*.py'` through `subprocess.run` with no `timeout=`,
+      then opens and reads every hit. Under load it exceeded pytest's global
+      60s cap and reported as a FAILED tenacity test, which is a diagnosis
+      pointing at the wrong thing entirely: there was no tenacity import, the
+      subprocess simply had not returned.
+
+      Measured on an idle machine: the walk takes 0.24s and finds 573 files.
+      So the 60s timeout represents roughly a 250x slowdown, and the immediate
+      cause was three heavy jobs sharing the box rather than the test. It is
+      still worth fixing, for two reasons.
+
+      First, the walk descends into `node_modules` (29,662 entries) and `.git`
+      (1,108) for nothing. `-not -path './.venv/*'` excludes one big tree and
+      not the bigger one. Excluding them is a one-line change that makes the
+      test strictly faster and no weaker.
+
+      Second, and the reason it is a task rather than a nit: this is §11's
+      flaky shape. It goes red under parallel load, someone re-runs it, it goes
+      green, and everyone learns that a red from this file means "run it
+      again". A real regression gets re-run away with it. The misleading
+      failure name makes that worse, not better.
+
+      The E2E worker-isolation pair (`isolation-a-mutate` /
+      `isolation-b-assert`) failed the same way for the same reason on the same
+      day: two `verify.sh` runs sharing the E2E data directory. That one is
+      arguably working as designed, since it exists to detect cross-worker
+      state leaking, but it cannot distinguish "the code leaked state" from
+      "another gate is running", and the message does not say so.
+
+      **The process half is not the repo's fault and is recorded so it is not
+      relearned:** do not run the gate concurrently with a sub-agent's gate,
+      and do not point two mutation-testing reviewers at one worktree. Both
+      produced false reds on this branch, and one reviewer had to re-derive a
+      finding against a hash-verified pristine copy because of it.
+
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T54, T55, T57, T58, T59, T60 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
       **Add to its scope (2026-08-18):** citations that rot. This session
       converted three-line-number citations into a third-party package and
       several stale line references into symbol citations, for one reason:

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -2655,6 +2655,32 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       Do it once, concretely: restore `20260820-100129` into a scratch data dir
       and boot the app against it.
 
+      **Isolate the automation BEFORE booting, or the rehearsal is itself a
+      destructive action.** Raised in review of #279 and confirmed against the
+      tree. The restored `config.ini` carries the production settings, and two
+      of them fire on `app.load`:
+
+          manage.py:58              `startup_scan` -> updateLibraryQuick
+          searcher.py:81            `run_on_launch` -> searchAll
+
+      plus the renamer scheduling its own scan. So a naive rehearsal walks the
+      real media paths, contacts the configured indexers and downloaders, and
+      can move or rename files. A drill meant to prove recoverability would be
+      mutating the thing it is protecting.
+
+      Neutralise it in the restored copy before the first boot rather than
+      trusting a flag: unset `manage.startup_scan`, `movie.searcher.run_on_launch`
+      and the renamer's `enabled` in the scratch `config.ini`, point every
+      library path at a throwaway directory, and clear the downloader and
+      indexer credentials so a mistake cannot reach a real service. Note
+      `manage.py:58` also short-circuits under `Env.get('dev')`, which is a
+      useful second layer but is NOT sufficient on its own -- it guards the
+      scan and not the searcher.
+
+      That requirement is the reason this is a task rather than a five-minute
+      job, and it is exactly the sort of thing that would have been discovered
+      the hard way at 2am.
+
 - [ ] T57: the git-env denylist protecting the unit fixtures is enumerated on the wrong axis — state: queued (no deps) — **security, test-infrastructure**
 
       Raised by a peer session working on the same harness, and confirmed here

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -1857,7 +1857,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       pass it. So the archive survives and the loss is recoverable by
       re-extracting. That is what keeps this off the irreplaceable tier.
 
-- [ ] T44: a single archive entry can decompress to an unbounded size — state: queued (no deps) — **security, pre-existing**
+- [ ] T44: a single archive entry can decompress to an unbounded size — state: building (no deps) — **security, pre-existing**
 
       Raised on #265 as explicitly non-blocking and correctly so: the read loop
       in `_extractOneAtomic` is untouched by that PR. Recorded because the file
@@ -2491,7 +2491,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       the real option declarations instead, which would make this class of
       drift impossible rather than fixed-once.
 
-- [ ] T53: the Trakt notifier reads a section that does not exist, so it can never authorise — state: pr-open (no deps)
+- [x] T53: the Trakt notifier reads a section that does not exist, so it can never authorise — state: **merged #278** (`8016eaa6`, 2026-08-20)
 
       Found by an adversarial reviewer while tracing T48's read paths, and
       unrelated to that work.
@@ -2716,7 +2716,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       step at all. The fragility that killed the three attempts was the
       navigation, not the assertion.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T53, T54, T55, T57, T58, T59 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T54, T55, T57, T58, T59 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
       **Add to its scope (2026-08-18):** citations that rot. This session
       converted three-line-number citations into a third-party package and
       several stale line references into symbol citations, for one reason:
@@ -5861,6 +5861,21 @@ Every audit finding maps to a PR or to the deferred table above.
   -> @puppeteer/browsers`, and `lhci` runs in neither CI nor `make verify` --
   only `npm run test:lighthouse` by hand. Revisit when a patch ships or when
   T47 changes that path, whichever comes first.
+- 2026-08-20 11:15 — RELEASED v3.65.0 to production. Promoted
+  `v3.65.0-beta.1` byte-for-byte after confirming CI, Beta Build and CodeQL
+  green on `4cc87966`; stable release cut, `:latest` re-pointed, host pulled
+  and recreated. Verified rather than assumed: the container reports
+  `VERSION = '3.65.0'`, health `healthy`, zero errors or tracebacks in the
+  startup logs, HTTP 302 externally. The previous prod image was 1 August, so
+  the jump is v3.25.0 -> v3.65.0. Pre-promotion backup `20260820-100129`
+  verified first.
+  Note for the next promotion: `/root/update.sh` runs `docker compose pull &&
+  up -d` daily at 01:00, so `:latest` is effectively the deploy trigger and a
+  promotion reaches the host within a day whether or not anyone deploys it.
+  T52 merged `4cc87966`, T53 merged `8016eaa6`, worktrees and branches
+  disposed. T44 delegated: the decompression bomb, chosen as the most
+  attacker-reachable item left, since the archive arrives from any indexer and
+  the volume it fills also holds the database.
 
 - 2026-08-20 10:05 — #277 (T52) CI fully green (16/16). Merge was still
   BLOCKED, and not by CI: two unresolved review threads on this very file.

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -2595,10 +2595,18 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       days old, and all three that existed were taken by hand.
 
       **Closed by an owner decision rather than by installing the schedule.**
-      The policy is now: take a snapshot before a promotion that could touch
-      the database, and not otherwise. No nightly. A backup ritual applied to
-      every release is one people stop taking seriously, and a nightly nobody
-      installed was never providing cover in the first place.
+      No nightly. The trigger went through two rounds, and the second is the
+      one that shipped:
+
+          first  "take one before a promotion that could touch the database"
+          final  "take one UNLESS every file changed since the last promotion
+                  is docs, tests or CI config"
+
+      The first form was rejected by the owner on the grounds that it asks the
+      person who wants to deploy to judge, under time pressure, whether their
+      own change is risky. "This one is fine" is free to say and expensive to
+      be wrong about. The exempt-list form removes the judgement without
+      reintroducing the nightly nobody installed.
 
       **The residual risk is recorded rather than glossed, because the evidence
       cited for the trigger also argues against it.** The `_query_index`

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -1872,11 +1872,28 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
               if not chunk: break
               target.write(chunk)
 
-      A hostile release therefore fills the disk. On this project that is worse
-      than it sounds: the same volume holds the SQLite database and settings,
-      and a full disk is exactly how this session lost a gate run to
-      `sqlite3.OperationalError: disk I/O error`. Data at the top of the
-      loss ranking sits behind a limit that does not exist.
+      A hostile release therefore fills the disk.
+
+      **Blast radius corrected by measurement on the real host, 2026-08-20.**
+      This entry said "the same volume holds the SQLite database and settings".
+      On production that is FALSE, and it inflated the severity:
+
+          /                     364G, 85G avail   <- database, settings, config.bak
+          /var/cache/sab (NAS)  44T,  1.9T avail  <- /downloads, where extraction writes
+          /var/media     (NAS)  44T,  1.9T avail  <- the library
+
+      The renamer's `from` is `/downloads/`, which is the NAS download share,
+      so a decompression bomb exhausts a 1.9 TiB share and does NOT reach the
+      volume carrying the database. It is a download-share denial of service,
+      not a route to irrecoverable data loss. Still worth fixing, and still
+      security-tagged, but it should not be ranked above things that can
+      actually destroy the library.
+
+      That correction also makes the shipped bound meaningful rather than
+      theatrical: a 144 GiB per-archive cap against 1.9 TiB free is a real
+      limit. Note it is PER ARCHIVE and `extractFiles` loops, so roughly
+      thirteen hostile archives still sum to the free space. Worth knowing
+      before anyone calls this closed.
 
       **The premise above is WRONG against the pinned library, measured
       2026-08-20, and the first implementation shipped a guard for a threat

--- a/tests/unit/test_backup_policy_exempt_list.py
+++ b/tests/unit/test_backup_policy_exempt_list.py
@@ -1,0 +1,126 @@
+"""The backup policy's exempt list must exist in exactly one form.
+
+This file exists because prose failed three times on a single change. The
+policy is stated in `scripts/backup.sh`'s header and mirrored in
+`docs/development-process.md`, and within three commits of being written the
+two copies had already diverged twice and `CLAUDE.md` had grown a third
+paraphrase:
+
+    round 1  backup.sh exempted "pure-presentation assets with no script in
+             them"; the doc did not
+    round 2  backup.sh exempted "lint or formatter config that does not ship
+             in the image", an EMPTY category (ruff's config is in
+             pyproject.toml and the Dockerfile ships the whole tree)
+    round 3  CLAUDE.md compressed the list to "docs, tests or CI config"
+
+Every one was caught by a reviewer reading carefully, which is exactly the
+thing that does not scale. Per this project's standard, a rule that can be a
+check should be a check: a weaker reader forgets prose, and cannot get past a
+command that exits non-zero.
+
+The guard is deliberately about AGREEMENT, not about the list's content. It
+does not care what the exempt set is, only that there is one of it. Changing
+the policy means changing both copies in the same commit, which is the whole
+point.
+"""
+import pathlib
+import re
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+BACKUP_SH = ROOT / 'scripts' / 'backup.sh'
+DEV_PROCESS = ROOT / 'docs' / 'development-process.md'
+CLAUDE_MD = ROOT / 'CLAUDE.md'
+
+#: The paths the policy exempts, as they appear in both copies. Backticked so
+#: an accidental prose mention ("see docs/") cannot masquerade as an entry.
+_ENTRY = re.compile(r'`([^`]+)`')
+
+
+def _exempt_entries(text, marker):
+    """The backticked paths on the `Exempt:` line of `text`.
+
+    Anchored on the marker line and its continuations rather than a fixed line
+    range: a hardcoded range silently desyncs the moment the surrounding
+    comment block changes length, which is the same defect `usage()` in
+    backup.sh already carries a note about.
+    """
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        if marker in line:
+            block = [line]
+            # Continuations: subsequent lines in the same comment or quote that
+            # are not blank once their prefix is stripped.
+            for nxt in lines[i + 1:]:
+                stripped = nxt.lstrip('#> ').strip()
+                if not stripped:
+                    break
+                block.append(nxt)
+            return _ENTRY.findall(' '.join(block))
+    return []
+
+
+@pytest.fixture(scope='module')
+def lists():
+    sh = _exempt_entries(BACKUP_SH.read_text(encoding='utf-8'), 'Exempt:')
+    doc = _exempt_entries(DEV_PROCESS.read_text(encoding='utf-8'), 'Exempt:')
+    return sh, doc
+
+
+class TestTheTwoCopiesAgree:
+
+    def test_the_sweep_found_a_real_list_in_both(self, lists):
+        """The vacuity guard, and it is not decoration.
+
+        If either extraction returns nothing, the equality assertion below
+        compares two empty lists and passes for ever while the copies drift
+        freely. That is the exact shape this repo has been bitten by more than
+        once: a guard whose coverage metric agrees with it right up until it
+        stops looking.
+        """
+        sh, doc = lists
+        assert len(sh) >= 4, (
+            f'only {len(sh)} exempt entries found in scripts/backup.sh -- the '
+            f'extraction has stopped seeing the list, so the comparison below '
+            f'cannot fail: {sh}'
+        )
+        assert len(doc) >= 4, (
+            f'only {len(doc)} exempt entries found in '
+            f'docs/development-process.md -- see above: {doc}'
+        )
+
+    def test_the_exempt_lists_are_identical(self, lists):
+        sh, doc = lists
+        assert sh == doc, (
+            'the backup policy\'s exempt list has drifted between its two '
+            'copies:\n'
+            f'  scripts/backup.sh          {sh}\n'
+            f'  docs/development-process.md {doc}\n'
+            'Change both in the same commit. If you are adding a category, '
+            'check first that it names anything real and that applying it '
+            'needs no judgement -- two proposed categories have already '
+            'failed one or both of those tests.'
+        )
+
+
+class TestNobodyElseRestatesIt:
+    """`CLAUDE.md` grew a third, compressed paraphrase and nobody noticed
+    until review. A pointer cannot drift; a copy can."""
+
+    def test_claude_md_points_rather_than_paraphrases(self):
+        row = [
+            line for line in CLAUDE_MD.read_text(encoding='utf-8').splitlines()
+            if 'scripts/backup.sh' in line and line.lstrip().startswith('|')
+        ]
+        assert row, 'the backup.sh row vanished from CLAUDE.md\'s command table'
+        assert len(row) == 1, f'more than one backup.sh row: {row}'
+        assert 'scripts/backup.sh`\'s header' in row[0] or 'header' in row[0], (
+            'CLAUDE.md\'s backup.sh row no longer points at the canonical '
+            'statement of the exempt list. Point at it; do not restate it. '
+            'A third copy is a third thing to drift, which is how this row '
+            'came to say "docs, tests or CI config" while the real list said '
+            'something else.'
+        )

--- a/tests/unit/test_backup_policy_exempt_list.py
+++ b/tests/unit/test_backup_policy_exempt_list.py
@@ -106,6 +106,71 @@ class TestTheTwoCopiesAgree:
         )
 
 
+#: A line that states the rule: "take it unless ... changed ...". Any such
+#: line must DEFER to the exempt list rather than enumerate it inline.
+_RULE_LINE = re.compile(r'unless\b.*\bchang', re.I)
+
+#: Words that mean someone has started enumerating the exempt set in prose.
+#: Deliberately crude: the point is to catch a paraphrase forming, not to
+#: validate its contents.
+_ENUMERATION = re.compile(r'\b(docs|tests|specs|CI config|config)\b\s*,', re.I)
+
+
+class TestNoFileRestatesTheRuleInPassing:
+    """The blind spot in the first version of this guard, found by review and
+    recorded because the shape matters more than the instance.
+
+    That version compared the two `Exempt:` lines and nothing else. It was
+    therefore blind to every RESTATEMENT elsewhere in the same files, and two
+    survived it in the copies an operator is most likely to read: `usage()`'s
+    heredoc in backup.sh, and the deploy runbook's step 1. Both said "docs,
+    tests or CI config", which silently drops `specs/` and compresses
+    `.github/`, so a promotion touching only `specs/` was exempt under the
+    canonical list and ambiguous under the paraphrase.
+
+    A guard that pins the canonical statement while ignoring every copy of it
+    is the same failure this project keeps finding elsewhere: it looks like
+    protection, it passes, and the thing it was built to prevent walks past it.
+
+    So the rule is now structural. Anywhere these files state the trigger, the
+    sentence must point at the exempt list instead of listing it again. There
+    is one place the list appears, and everywhere else defers to it.
+    """
+
+    @pytest.mark.parametrize('path', [BACKUP_SH, DEV_PROCESS, CLAUDE_MD],
+                             ids=lambda p: p.name)
+    def test_every_statement_of_the_rule_defers_to_the_list(self, path):
+        offenders = []
+        for n, line in enumerate(path.read_text(encoding='utf-8').splitlines(), 1):
+            if not _RULE_LINE.search(line):
+                continue
+            # The canonical statement is the one that hands off to the list.
+            if 'exempt' in line.lower():
+                continue
+            if _ENUMERATION.search(line):
+                offenders.append(f'{path.name}:{n}: {line.strip()}')
+        assert not offenders, (
+            'the backup trigger is restated with an inline enumeration '
+            'instead of deferring to the exempt list:\n  '
+            + '\n  '.join(offenders)
+            + '\n\nSay "in the exempt list" and point at it. Every inline '
+            'copy is another thing to drift, and two of them already did.'
+        )
+
+    def test_the_rule_is_actually_stated_somewhere(self):
+        """Vacuity guard. If the regex stops matching the rule at all, the
+        test above iterates over nothing and passes for ever."""
+        found = [
+            p.name for p in (BACKUP_SH, DEV_PROCESS)
+            if any(_RULE_LINE.search(l)
+                   for l in p.read_text(encoding='utf-8').splitlines())
+        ]
+        assert len(found) == 2, (
+            f'the rule statement was found in {found} but expected both files '
+            f'-- the pattern has stopped matching, so the check above is inert'
+        )
+
+
 class TestNobodyElseRestatesIt:
     """`CLAUDE.md` grew a third, compressed paraphrase and nobody noticed
     until review. A pointer cannot drift; a copy can."""

--- a/tests/unit/test_backup_script.py
+++ b/tests/unit/test_backup_script.py
@@ -114,7 +114,7 @@ def test_script_is_executable_and_has_a_shebang():
     assert BACKUP_SCRIPT.exists(), f"{BACKUP_SCRIPT} does not exist"
     assert BACKUP_SCRIPT.read_text().startswith("#!"), "missing shebang"
     mode = BACKUP_SCRIPT.stat().st_mode
-    assert mode & stat.S_IXUSR, "backup.sh must be executable (cron runs it directly)"
+    assert mode & stat.S_IXUSR, "backup.sh must be executable (it is invoked directly on the host)"
 
 
 def test_creates_one_timestamped_snapshot_with_db_and_settings(prod_layout):
@@ -227,7 +227,7 @@ def test_falls_back_to_python_when_the_sqlite3_cli_is_unusable(prod_layout, tmp_
 
     assert "written with Python" in (result.stdout + result.stderr), (
         "expected the Python success line, so a silently degraded backup path is "
-        "visible in the cron log"
+        "visible to whoever ran it"
     )
 
 
@@ -354,7 +354,7 @@ def test_retention_still_works_when_backup_dir_has_a_trailing_slash(prod_layout)
 
     `dirname` normalises the slash away while `$BACKUP_DIR` kept it, so every
     prune candidate was rejected: exit 0, no warning, and the disk grows forever
-    while cron reports success. A regression introduced by the very guard that was
+    while the run reports success. A regression introduced by the very guard that was
     meant to make `rm -rf` safer.
     """
     backup_dir = prod_layout["backup_dir"]
@@ -478,7 +478,7 @@ def test_retain_zero_or_negative_is_rejected_rather_than_deleting_everything(pro
 
 
 def test_fails_loudly_when_the_database_is_missing(prod_layout):
-    """A silent success with no DB is worse than no backup — it looks fine in cron.
+    """A silent success with no DB is worse than no backup — it reads as done.
 
     Asserting on the *diagnosis*, not just the exit code: without the up-front
     existence check the script still fails, but it fails several steps later with
@@ -515,8 +515,8 @@ def test_finds_config_ini_one_level_above_the_data_dir(prod_layout):
     """The Docker image puts config.ini at /config/config.ini with --data_dir=/data.
 
     Only looking in the data dir meant prod snapshots silently contained the
-    database alone — and since the script warns and exits 0, a nightly cron would
-    report success forever while never capturing settings.
+    database alone — and since the script warns and exits 0, every run would
+    report success while never capturing settings.
     """
     (prod_layout["data_dir"] / "config.ini").unlink()
     parent_config = prod_layout["data_dir"].parent / "config.ini"


### PR DESCRIPTION
Owner decision, recorded across every place that stated the old policy.

**New policy:** take a snapshot before a promotion that could touch the database, and not otherwise. No nightly.

**Why the trigger is not "changes the schema".** Those are not the same set, and this project has already lost data through the gap: the `_query_index` defects fixed in 2026-02 corrupted records during an ordinary library scan, with no migration and no schema change. So the trigger is "could touch the database" — schema or migration, `couchpotato/core/db/`, or an unattended write path such as the scanner or the renamer.

**Why dropping nightly costs nothing.** The nightly this repo documented was never installed. Measured on the host 2026-08-20: no cron entry, no `cron.d` file, no systemd timer, newest snapshot nineteen days old, all three that existed taken by hand. It was providing no cover to lose.

## Changes

- `scripts/backup.sh` header: nightly claim removed, trigger and its rationale stated
- `docs/development-process.md`: the `crontab -e` recipe replaced with the policy, plus a verification step
- `CLAUDE.md`: command table corrected from "run before every deploy"
- `tests/unit/test_backup_script.py`: five stale rationales that justified behaviour by "a nightly cron would…" reworded. No assertion changed; 30 passed
- `specs/REMEDIATION-2026-08.md`: T56 closed by decision, T59 split out

## Verification guidance added

`PRAGMA integrity_check` does not check foreign keys, and this schema declares them (`media_identifiers` and `media_tags` both `REFERENCES documents(_id)`). Both must be run, and `foreign_key_check` must return zero rows.

## What this deliberately does not close

Nobody has ever restored a backup. `docs/development-process.md` has a restore recipe, but "confirmed healthy" there refers to the pinned image, not a restored database. Tracked as T59, and it matters more under this policy rather than less: with no nightly behind them, every snapshot taken is load-bearing.

## Gate

`scripts/verify.sh` full run, exit 0: ruff clean, unit suite green, E2E 40 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc