### PR TITLE
T44: cap a single archive entry's extraction size (amplification recorded as open debt)

### DIFF
--- a/couchpotato/core/plugins/renamer/extractor.py
+++ b/couchpotato/core/plugins/renamer/extractor.py
@@ -26,9 +26,10 @@ from couchpotato.environment import Env
 
 log = CPLog(__name__)
 
-#: Cap on per-entry log lines a single archive may produce, for ALL FOUR
-#: per-entry counters: refusals, name collisions, unreadable entries, and
-#: entries that could not be written to their destination.
+#: Cap on per-entry log lines a single archive may produce, for ALL FIVE
+#: per-entry counters: refusals, name collisions, unreadable entries, entries
+#: that could not be written to their destination, and entries refused for
+#: decompressing far beyond their declared size.
 #: (This said "BOTH refusals and name collisions" until the third counter was
 #: added a commit later and this line was not updated -- the same drift the
 #: rest of this branch keeps correcting.)
@@ -70,6 +71,59 @@ _ENTRY_DERIVED_ERRNOS = frozenset((
     errno.EILSEQ,
     errno.EINVAL,
 ))
+
+#: Slack allowed above an entry's declared `info.file_size` before the
+#: streaming read loop refuses it (see `_ArchiveEntryTooLarge` and
+#: `_extractOneAtomic` below). `info.file_size` comes from the archive
+#: HEADER, which `rarfile.infolist()` parses without decompressing anything
+#: -- it is attacker-supplied and free to fabricate, so it cannot be trusted
+#: as a limit on its own. It is still the only per-entry size hint available,
+#: and a LEGITIMATE entry decompresses to exactly the declared size. This
+#: margin exists only to absorb the read loop's own chunking (the final
+#: chunk of a genuine entry lands the running total on file_size exactly, but
+#: nothing guarantees that alignment for every archive/tool combination) --
+#: it is not slack for the attacker. Sized to one read() chunk, not derived
+#: from disk state.
+_ENTRY_SIZE_MARGIN = 1024 * 1024  # one read() chunk
+
+#: Absolute per-entry ceiling, independent of anything the archive header
+#: claims. The cross-check above (declared file_size + margin) is defeated
+#: the moment the header lies about file_size too: an entry that declares
+#: itself "this will decompress to 400 GiB" and then does exactly that
+#: sails straight through a check that only compares actual output against
+#: the declared figure. This is the belt to that braces -- no single media
+#: file this application manages is anywhere near this size, so refusing a
+#: "movie" that would blow past it is never a false positive on the real
+#: workload.
+#:
+#: Deliberately NOT derived from `shutil.disk_usage()`. A free-space-based
+#: bound would make one extraction's outcome depend on how much OTHER,
+#: unrelated data already sits on the volume: nondeterministic (races with
+#: concurrent downloads/scans on the same disk), unrepresentable in a test
+#: without faking disk state, and it would surprise an operator with an
+#: extraction that fails today and would have succeeded yesterday against an
+#: identical archive purely because something else filled the disk in the
+#: meantime. A fixed ceiling is deterministic and directly testable instead.
+_ENTRY_HARD_CAP = 200 * 1024 ** 3  # 200 GiB
+
+
+class _ArchiveEntryTooLarge(Exception):
+    """Raised internally by `_extractOneAtomic` when a single entry writes
+    more than its budget allows for.
+
+    Deliberately its own type, not `OSError`/`rarfile.Error`: the write
+    SUCCEEDS every time this fires. There is no I/O failure to observe here,
+    only an entry that keeps producing more bytes than it is allowed to, so
+    it cannot share `_ENTRY_DERIVED_ERRNOS`'s handling -- nothing raises an
+    OSError on this path.
+    """
+
+    def __init__(self, written, budget):
+        super().__init__(
+            'entry wrote at least %d bytes, exceeding its %d-byte budget'
+            % (written, budget))
+        self.written = written
+        self.budget = budget
 
 # rarfile forces the extractor tool to be selected via the process-global
 # ``rarfile.UNRAR_TOOL`` (there is no per-call parameter), so setting it and
@@ -318,6 +372,7 @@ class ExtractorMixin:
             collisions = 0
             unreadable = 0
             unwritable = 0
+            oversized = 0
             extracted = []
             # Parallel set purely for membership. `extracted` stays a list
             # because its ORDER is the return contract, but `x in list` is a
@@ -389,6 +444,36 @@ class ExtractorMixin:
                             # of the broader catch going in, which is the whole
                             # argument for the narrow one.
                             raise
+                        except _ArchiveEntryTooLarge as e:
+                            # T44: the entry decompressed to far more than its
+                            # header declared -- `info.file_size` costs the
+                            # attacker nothing (`infolist()` never
+                            # decompresses to check it), so a header claiming
+                            # a small entry is free cover for a bomb. The
+                            # write ALWAYS succeeds here; there is no OSError
+                            # to sort by errno, which is why this needs its
+                            # own except clause rather than joining
+                            # `_ENTRY_DERIVED_ERRNOS`.
+                            #
+                            # Attacker-controlled like a hostile name or a
+                            # corrupt entry, so the same treatment applies:
+                            # refuse this one, keep the archive. Its own
+                            # counter for the same reason `unwritable` has
+                            # one -- "refused for exceeding its declared
+                            # size" is a different remedy from "could not be
+                            # read" or "could not be written".
+                            oversized += 1
+                            if oversized <= _MAX_ENTRY_LOGS:
+                                log.error(
+                                    'Archive entry decompressed far beyond '
+                                    'its declared size (declared %d bytes, '
+                                    'wrote at least %d before refusing it), '
+                                    'skipping it: %r',
+                                    info.file_size if isinstance(info.file_size, int) else -1,
+                                    e.written,
+                                    info.filename,
+                                )
+                            continue
                         except OSError as e:
                             # ENAMETOOLONG is an OSError, but it is derived
                             # from THIS entry's attacker-controlled name, not
@@ -493,12 +578,12 @@ class ExtractorMixin:
                 # per-entry lines, an abort, and no totals -- the diagnostic
                 # deleted at the moment it was needed.
                 self._logArchiveSummary(
-                    refused, collisions, unreadable, unwritable)
+                    refused, collisions, unreadable, unwritable, oversized)
 
         return extracted
 
     @staticmethod
-    def _logArchiveSummary(refused, collisions, unreadable, unwritable):
+    def _logArchiveSummary(refused, collisions, unreadable, unwritable, oversized):
         """Report totals when per-entry logging was capped.
 
         The cap exists so a hostile archive cannot flood the log, but a cap
@@ -526,6 +611,10 @@ class ExtractorMixin:
             log.error('%d archive entries could not be written to their '
                       'destination in total (only the first %d were logged '
                       'individually).', unwritable, _MAX_ENTRY_LOGS)
+        if oversized > _MAX_ENTRY_LOGS:
+            log.error('%d archive entries exceeded their declared size and '
+                      'were refused in total (only the first %d were logged '
+                      'individually).', oversized, _MAX_ENTRY_LOGS)
 
     @staticmethod
     def _safeEntryBasename(filename):
@@ -566,17 +655,46 @@ class ExtractorMixin:
     def _extractOneAtomic(rar_handle, info, extr_file_path, extr_path):
         """Stream a single archive entry to a temp file in extr_path, then
         atomically ``os.replace`` it into extr_file_path. On ANY error the
-        temp file is removed so no partial output survives at the real path."""
+        temp file is removed so no partial output survives at the real path.
+
+        The read loop enforces a per-entry byte budget derived from
+        ``info.file_size`` (see ``_ENTRY_SIZE_MARGIN``) and capped absolutely
+        at ``_ENTRY_HARD_CAP``. Without it, a header claiming a small size is
+        free for the attacker -- ``rarfile.infolist()`` parses headers only --
+        while the loop below writes whatever the decompressor actually
+        produces with no limit. Raises ``_ArchiveEntryTooLarge`` (checked
+        BEFORE each chunk is written, so the temp file never grows past the
+        budget) rather than silently truncating the entry, so the caller
+        treats it as a refusal like any other hostile entry, not as a
+        successful partial extract.
+        """
+        # declared may itself be attacker-fabricated (including negative or
+        # non-numeric); treat anything untrustworthy as "declares nothing",
+        # which still leaves _ENTRY_SIZE_MARGIN of slack for a genuinely tiny
+        # legitimate entry.
+        declared = info.file_size
+        if not isinstance(declared, int) or declared < 0:
+            declared = 0
+        budget = min(declared + _ENTRY_SIZE_MARGIN, _ENTRY_HARD_CAP)
+
         # Temp file in the SAME directory so os.replace is atomic (same fs).
         fd, tmp_path = tempfile.mkstemp(dir=extr_path, prefix=_TEMP_PREFIX, suffix=_TEMP_SUFFIX)
         try:
             # fdopen first so the fd is always owned/closed by the `with`, even
             # if rar_handle.open(info) raises before we start reading.
             with os.fdopen(fd, 'wb') as target, rar_handle.open(info) as source:
+                written = 0
                 while True:
                     chunk = source.read(1024 * 1024)
                     if not chunk:
                         break
+                    written += len(chunk)
+                    if written > budget:
+                        # Checked before the write: the temp file this
+                        # entry has produced so far never exceeds `budget`,
+                        # so the transient disk usage of a refused entry is
+                        # bounded even though it is unlinked either way.
+                        raise _ArchiveEntryTooLarge(written, budget)
                     target.write(chunk)
             # tempfile.mkstemp always creates the file 0600 (owner-only),
             # ignoring umask; without this the extracted media file would be

--- a/couchpotato/core/plugins/renamer/extractor.py
+++ b/couchpotato/core/plugins/renamer/extractor.py
@@ -155,6 +155,25 @@ _ENTRY_DERIVED_ERRNOS = frozenset((
 #: large or many small honest entries summing past any sane per-release
 #: total is therefore OPEN DEBT, not fixed here.
 _ENTRY_HARD_CAP = 128 * 1024 ** 3  # 128 GiB
+#: **A THIRD limit this does not provide, raised in review of #280 and recorded
+#: rather than fixed.** The cap is a fixed byte count, not a function of free
+#: space, so on a volume with less than 128 GiB available a single hostile
+#: entry exhausts the disk and raises `ENOSPC` BEFORE the cap can fire. That
+#: errno is not in `_ENTRY_DERIVED_ERRNOS`, so the archive aborts, which is the
+#: right response but arrives after the damage. Measured on the deployment this
+#: project actually runs: extraction targets `/downloads`, a NAS share with
+#: 1.9 TiB free, so 128 GiB fits with room to spare and the case does not bite
+#: there. It bites on a smaller volume, and nothing here detects that.
+#:
+#: A free-space-derived bound was considered and rejected for making one
+#: extraction's outcome depend on unrelated data already on the disk:
+#: nondeterministic, hard to test without faking disk state, and surprising to
+#: an operator. The better answer is the pre-flight frame recorded in T44:
+#: `read()` clamps to `file_size`, and `file_redir` plus `getinfo()` resolve
+#: RAR5 copy and hard-link targets from headers alone, so the sum of resolved
+#: declared sizes is an exact upper bound computable BEFORE any byte is
+#: written. Refusing on that sum, compared against free space, costs nothing
+#: and writes nothing. It is not built.
 
 
 class _ArchiveEntryTooLarge(Exception):
@@ -736,14 +755,23 @@ class ExtractorMixin:
                     chunk = source.read(1024 * 1024)
                     if not chunk:
                         break
-                    written += len(chunk)
-                    if written > _ENTRY_HARD_CAP:
-                        # Checked before the write: the temp file this
-                        # entry has produced so far never exceeds the cap,
-                        # so the transient disk usage of a refused entry is
-                        # bounded even though it is unlinked either way.
+                    # `written` counts bytes ON DISK, and the cap is tested
+                    # against the PROSPECTIVE total, so the temp file never
+                    # exceeds the cap even transiently. An earlier form
+                    # incremented first and tested after, which meant a refusal
+                    # reported the chunk it had just declined to write: up to
+                    # 1 MiB of bytes that reached the reader and never reached
+                    # the file, in a message that says "wrote". Diagnostics
+                    # that overstate are how an operator ends up hunting the
+                    # wrong entry.
+                    #
+                    # The comparison stays strict, so an entry that writes
+                    # EXACTLY the cap is allowed through. That boundary is
+                    # deliberate and is pinned by a test.
+                    if written + len(chunk) > _ENTRY_HARD_CAP:
                         raise _ArchiveEntryTooLarge(written, _ENTRY_HARD_CAP)
                     target.write(chunk)
+                    written += len(chunk)
             # tempfile.mkstemp always creates the file 0600 (owner-only),
             # ignoring umask; without this the extracted media file would be
             # unreadable by Plex/Kodi/other users (and broken under the Docker

--- a/couchpotato/core/plugins/renamer/extractor.py
+++ b/couchpotato/core/plugins/renamer/extractor.py
@@ -30,9 +30,6 @@ log = CPLog(__name__)
 #: per-entry counters: refusals, name collisions, unreadable entries, entries
 #: that could not be written to their destination, and entries refused for
 #: producing more than the fixed per-entry size ceiling (`_ENTRY_HARD_CAP`).
-#: (A whole-archive abort on `_ARCHIVE_HARD_CAP` is NOT one of these five --
-#: it ends the archive outright and is logged once at `extractFiles`, not as
-#: a capped per-entry line here.)
 #: (This said "BOTH refusals and name collisions" until the third counter was
 #: added a commit later and this line was not updated -- the same drift the
 #: rest of this branch keeps correcting.)
@@ -75,11 +72,10 @@ _ENTRY_DERIVED_ERRNOS = frozenset((
     errno.EINVAL,
 ))
 
-#: T44 REWORK, 2026-08-20: this file previously carried a per-entry
-#: cross-check comparing bytes actually written against `info.file_size`
-#: (declared header size) plus a margin. Review measured it dead on the
-#: pinned `rarfile==4.5`, and worse than dead: actively unsafe. Read before
-#: changing either constant below.
+#: T44, 2026-08-20: this file previously carried a per-entry cross-check
+#: comparing bytes actually written against `info.file_size` (declared
+#: header size) plus a margin. Review measured it dead on the pinned
+#: `rarfile==4.5`, and worse than dead: actively unsafe.
 #:
 #: MEASURED, not assumed, against
 #: `.venv/lib/python3.14/site-packages/rarfile.py`:
@@ -116,80 +112,56 @@ _ENTRY_DERIVED_ERRNOS = frozenset((
 #: (no rar/unrar/7z/7zz/unar, only bsdtar) -- deleting the cross-check makes
 #: that question moot rather than resolving it.
 #:
-#: What is left below is TWO fixed ceilings, neither derived from anything
-#: the archive header claims:
+#: What replaced it is ONE fixed ceiling, never derived from anything the
+#: archive header claims: an entry whose header self-consistently says
+#: "400 GiB" and then produces 400 GiB sails straight through rarfile's own
+#: clamp, since that clamp only stops an entry producing MORE than its
+#: header declares, not how large that declaration may honestly be. This is
+#: the LIVE guard against the pinned library version, and because it checks
+#: bytes ACTUALLY WRITTEN it is also defence-in-depth against a hypothetical
+#: future rarfile that weakens or removes the `_remain` clamp entirely (see
+#: the "NOTE for the next bump" at requirements.txt:52-55, about rarfile
+#: 5.0's *unrelated* config-location break): if that clamp ever went away,
+#: an entry could then both lie about its header AND overproduce, and this
+#: ceiling would still catch it on actual output alone.
 #:
-#:   `_ENTRY_HARD_CAP`   the LIVE guard for a single entry. rarfile's own
-#:                       invariant stops an entry producing MORE than its
-#:                       header declares, but declares nothing about how
-#:                       LARGE that declaration may honestly be -- an entry
-#:                       whose header self-consistently says "400 GiB" and
-#:                       then produces 400 GiB sails straight through
-#:                       rarfile's own clamp. This is what catches it.
+#: Deliberately NOT derived from `shutil.disk_usage()`. A free-space-based
+#: bound would make one extraction's outcome depend on how much OTHER,
+#: unrelated data already sits on the volume: nondeterministic (races with
+#: concurrent downloads/scans on the same disk), unrepresentable in a test
+#: without faking disk state, and it would surprise an operator with an
+#: extraction that fails today and would have succeeded yesterday against an
+#: identical archive purely because something else filled the disk in the
+#: meantime. A fixed ceiling is deterministic and directly testable instead.
 #:
-#:   `_ARCHIVE_HARD_CAP` the LIVE guard for the reachable amplification: RAR5
-#:                       lets many entries (duplicate/FILE_COPY references,
-#:                       or simply many honestly-small entries) each cost the
-#:                       attacker one header while the extractor still writes
-#:                       each one out in full. Measured: 400 entries each
-#:                       honestly declaring 256 KiB extracted 100 MB with no
-#:                       refusal from the (now-deleted) per-entry check
-#:                       alone. No single entry lies here, so no per-entry
-#:                       ceiling on its own can catch it; the ARCHIVE's total
-#:                       output needs its own fixed ceiling.
+#: 200 GiB (the value this constant shipped with originally) bought nothing
+#: over a tighter figure: a UHD Blu-ray remux, the largest legitimate single
+#: media file this application is ever asked to manage, tops out around
+#: 100 GB. 128 GiB leaves that real ceiling ~28 GiB of headroom without
+#: leaving the attacker another 72 GiB of it to abuse for free.
 #:
-#: Both check bytes ACTUALLY WRITTEN, never `info.file_size` -- which is why
-#: both are simultaneously the LIVE guard against today's `rarfile==4.5` and
-#: DEFENSE-IN-DEPTH against a hypothetical future `rarfile` that weakens or
-#: removes the `_remain` clamp entirely (see the "NOTE for the next bump" at
-#: requirements.txt:52-55, about rarfile 5.0's *unrelated* config-location
-#: break): if that clamp ever went away, an entry could then both lie about
-#: its header AND overproduce, and these two ceilings would still catch it on
-#: actual output alone, with no extra code. That dual role is exactly what
-#: the deleted cross-check did NOT have -- it depended entirely on trusting
-#: `info.file_size` as the comparison baseline, which is the same trust that
-#: made it unsafe against redirects.
-#:
-#: Deliberately NOT derived from `shutil.disk_usage()`, for both ceilings.
-#: A free-space-based bound would make one extraction's outcome depend on
-#: how much OTHER, unrelated data already sits on the volume: nondeterministic
-#: (races with concurrent downloads/scans on the same disk), unrepresentable
-#: in a test without faking disk state, and it would surprise an operator
-#: with an extraction that fails today and would have succeeded yesterday
-#: against an identical archive purely because something else filled the
-#: disk in the meantime. A fixed ceiling is deterministic and directly
-#: testable instead.
-#:
-#: 200 GiB (the value this constant shipped with before this note) bought
-#: nothing over a tighter figure: a UHD Blu-ray remux, the largest legitimate
-#: single media file this application is ever asked to manage, tops out
-#: around 100 GB. 128 GiB leaves that real ceiling ~28 GiB of headroom
-#: without leaving the attacker another 72 GiB of it to abuse for free.
+#: WHAT THIS DOES NOT DO, stated plainly because a second guard in this area
+#: was already built and removed here for overclaiming (see git history on
+#: this branch): this bounds ONE ENTRY, not an ARCHIVE. N entries each just
+#: under 128 GiB still write N * 128 GiB combined, and a REFUSED entry still
+#: writes up to just-under-128 GiB transiently to its temp file (unlinked
+#: afterward, but present on disk while the entry streams) before this check
+#: catches it. An archive-wide budget was attempted on this branch and
+#: removed because it could not fire on the input it was built for: many
+#: entries each individually tripping this per-entry cap contributed ZERO to
+#: a running total, because a refused entry's bytes were discarded before
+#: they were ever counted (measured: 26.7x the intended archive budget
+#: written to disk with the running total still at zero). An archive of many
+#: large or many small honest entries summing past any sane per-release
+#: total is therefore OPEN DEBT, not fixed here.
 _ENTRY_HARD_CAP = 128 * 1024 ** 3  # 128 GiB
-
-#: One feature file at `_ENTRY_HARD_CAP`, plus what a real release
-#: legitimately bundles alongside it -- a sample, subtitles, an NFO, maybe an
-#: alternate cut. None of that plausibly adds up to double digits of GiB, so
-#: 16 GiB of headroom over the entry ceiling is generous for a legitimate
-#: multi-file release. It is deliberately NOT generous enough to let a
-#: duplicate-reference bomb hide behind "it's just extras": the amplification
-#: this constant exists to catch is entries whose sum runs to many multiples
-#: of a single release, not a fraction over one.
-#:
-#: Checked against bytes ACTUALLY WRITTEN across every entry processed so far
-#: in ONE extractArchive() call (see `_extractOneAtomic`'s
-#: `archive_written_so_far` parameter) -- entries already confirmed present
-#: on disk from a PRIOR scan (the idempotency skip, `os.path.isfile`) are not
-#: re-read and so contribute nothing to this run's total, which is correct:
-#: no bytes are written for them this scan.
-_ARCHIVE_HARD_CAP = _ENTRY_HARD_CAP + 16 * 1024 ** 3  # 144 GiB
 
 
 class _ArchiveEntryTooLarge(Exception):
     """Raised internally by `_extractOneAtomic` when a single entry's ACTUAL
     output crosses the fixed `_ENTRY_HARD_CAP` -- never anything the archive
-    header claims (see the T44 REWORK note above for why the header cannot
-    be trusted as a budget input, only rarfile's own clamp on it).
+    header claims (see the note above `_ENTRY_HARD_CAP` for why the header
+    cannot be trusted as a budget input, only rarfile's own clamp on it).
 
     Deliberately its own type, not `OSError`/`rarfile.Error`: the write
     SUCCEEDS every time this fires. There is no I/O failure to observe here,
@@ -202,33 +174,6 @@ class _ArchiveEntryTooLarge(Exception):
         super().__init__(
             'entry wrote at least %d bytes, exceeding the fixed %d-byte '
             'per-entry ceiling' % (written, budget))
-        self.written = written
-        self.budget = budget
-
-
-class _ArchiveTooLarge(Exception):
-    """Raised internally when the RUNNING TOTAL of bytes actually written
-    across every entry processed so far in ONE `extractArchive()` call
-    crosses the fixed `_ARCHIVE_HARD_CAP`.
-
-    Unlike `_ArchiveEntryTooLarge`, no single entry need be at fault: this is
-    the reachable amplification -- many entries, each individually honest and
-    under `_ENTRY_HARD_CAP`, whose SUM the extractor would otherwise write in
-    full for the cost of one header each.
-
-    Deliberately left UNCAUGHT by the per-entry try/except inside
-    `extractArchive`'s loop (see the comment at that call site), so it
-    propagates out of `extractArchive` entirely and abandons the WHOLE
-    archive rather than continuing to spend disk on further entries once the
-    budget is already gone. `extractFiles`' except chain is where it is
-    caught, logged, and turned into a skip-not-tag -- the archive is retried
-    on a later scan, same as any other archive-level failure here.
-    """
-
-    def __init__(self, written, budget):
-        super().__init__(
-            'archive wrote at least %d bytes across its entries, exceeding '
-            'the fixed %d-byte per-archive ceiling' % (written, budget))
         self.written = written
         self.budget = budget
 
@@ -333,24 +278,6 @@ class ExtractorMixin:
             except rarfile.Error as e:
                 # Known archive problem (corrupt/bad RAR, wrong password, etc.).
                 log.error('Skipping archive with a known RAR problem %s: %s %s', archive['file'], e, traceback.format_exc())
-                continue
-            except _ArchiveTooLarge as e:
-                # T44: this archive's entries have, TOGETHER, actually
-                # written more than the fixed per-archive budget allows --
-                # see _ArchiveTooLarge's docstring for why extractArchive
-                # deliberately lets this propagate rather than skipping just
-                # the one entry that tipped it over. Not tagged, so it is
-                # retried on a later scan like any other archive-level
-                # failure here (a genuinely hostile archive will hit this
-                # same ceiling again next scan, which is the same retry
-                # characteristic an environmental OSError or a corrupt
-                # archive already has on this path, not something new).
-                log.error(
-                    'Archive %s requested more data than the %d-byte '
-                    'per-archive extraction budget allows (wrote at least '
-                    '%d bytes before aborting), skipping it: %s',
-                    archive['file'], _ARCHIVE_HARD_CAP, e.written, e,
-                )
                 continue
             except Exception as e:
                 # Anything else (I/O error, permissions, unexpected bug).
@@ -498,12 +425,6 @@ class ExtractorMixin:
             unreadable = 0
             unwritable = 0
             oversized = 0
-            # Running total of bytes ACTUALLY WRITTEN across every entry
-            # processed so far in this call, checked against
-            # `_ARCHIVE_HARD_CAP` inside `_extractOneAtomic`. Never derived
-            # from any entry's declared file_size -- see the T44 REWORK note
-            # above `_ENTRY_HARD_CAP` for why that would be unsafe.
-            archive_written = 0
             extracted = []
             # Parallel set purely for membership. `extracted` stays a list
             # because its ORDER is the return contract, but `x in list` is a
@@ -560,15 +481,8 @@ class ExtractorMixin:
                         # because the entry was never refused.
                         log.debug('Extracting %r...', info.filename)
                         try:
-                            # Returns bytes actually written for THIS entry,
-                            # accumulated into the archive-wide running total
-                            # -- an augmented assignment only completes on a
-                            # successful return, so a refused entry (either
-                            # exception below) contributes nothing to it: its
-                            # work was discarded along with its temp file.
-                            archive_written += self._extractOneAtomic(
-                                rar_handle, info, extr_file_path, extr_path,
-                                archive_written)
+                            self._extractOneAtomic(
+                                rar_handle, info, extr_file_path, extr_path)
                         except rarfile.RarCannotExec:
                             # The extractor TOOL is missing. Environmental, and
                             # it will fail identically for every remaining
@@ -582,28 +496,15 @@ class ExtractorMixin:
                             # of the broader catch going in, which is the whole
                             # argument for the narrow one.
                             raise
-                        # _ArchiveTooLarge is DELIBERATELY not caught here.
-                        # Unlike _ArchiveEntryTooLarge (one hostile/oversized
-                        # entry, skip it, keep going), _ArchiveTooLarge means
-                        # this run has ALREADY written more than a single
-                        # release plausibly needs -- continuing to process
-                        # further entries only spends more disk on exactly
-                        # the amplification this budget exists to stop. Let
-                        # it propagate past every except clause below, out of
-                        # the try/finally (still logging the per-entry
-                        # summary on the way out -- see the `finally` below),
-                        # and out of extractArchive entirely; extractFiles'
-                        # except chain is where it is caught, logged, and
-                        # turned into a skip-not-tag.
                         except _ArchiveEntryTooLarge as e:
                             # T44: this entry's ACTUAL output crossed the
                             # fixed per-entry ceiling -- never anything its
                             # header claims (rarfile's own read() already
                             # clamps output to the declared file_size; see
-                            # the T44 REWORK note above `_ENTRY_HARD_CAP`).
-                            # The write ALWAYS succeeds here; there is no
-                            # OSError to sort by errno, which is why this
-                            # needs its own except clause rather than joining
+                            # the note above `_ENTRY_HARD_CAP`). The write
+                            # ALWAYS succeeds here; there is no OSError to
+                            # sort by errno, which is why this needs its own
+                            # except clause rather than joining
                             # `_ENTRY_DERIVED_ERRNOS`.
                             #
                             # Attacker-controlled like a hostile name or a
@@ -612,7 +513,9 @@ class ExtractorMixin:
                             # counter for the same reason `unwritable` has
                             # one -- "refused for exceeding the fixed size
                             # ceiling" is a different remedy from "could not
-                            # be read" or "could not be written".
+                            # be read" or "could not be written". Note this
+                            # bounds only THIS entry, not the archive as a
+                            # whole -- see `_ENTRY_HARD_CAP`'s comment.
                             oversized += 1
                             if oversized <= _MAX_ENTRY_LOGS:
                                 log.error(
@@ -801,42 +704,26 @@ class ExtractorMixin:
                 pass
 
     @staticmethod
-    def _extractOneAtomic(rar_handle, info, extr_file_path, extr_path,
-                           archive_written_so_far):
+    def _extractOneAtomic(rar_handle, info, extr_file_path, extr_path):
         """Stream a single archive entry to a temp file in extr_path, then
         atomically ``os.replace`` it into extr_file_path. On ANY error the
         temp file is removed so no partial output survives at the real path.
 
-        Returns the number of bytes actually written for THIS entry, so the
-        caller can accumulate the archive-wide running total.
+        The read loop enforces a per-entry byte ceiling against
+        ``_ENTRY_HARD_CAP``, checked against bytes ACTUALLY WRITTEN -- never
+        against ``info.file_size`` or anything else the archive header
+        claims. See the note above ``_ENTRY_HARD_CAP`` for why a
+        header-derived budget was tried and removed (measured unreachable
+        against the pinned ``rarfile==4.5``, and actively unsafe besides),
+        and for what this ceiling does and does not bound -- it stops ONE
+        entry whose header honestly declares, and rarfile then honours, far
+        more than any real media file this application manages; it does NOT
+        bound an archive's total output across many entries.
 
-        The read loop enforces two independent size guards, both against
-        FIXED ceilings and both checked against bytes ACTUALLY WRITTEN --
-        never against ``info.file_size`` or anything else the archive header
-        claims. See the T44 REWORK note above ``_ENTRY_HARD_CAP`` for why a
-        header-derived budget was tried, measured unreachable against the
-        pinned ``rarfile==4.5`` (its own ``RarExtFile.read()`` already clamps
-        output to the declared ``file_size``), and actively unsafe besides
-        (RAR5 FILE_COPY/HARD_LINK redirects swap in a DIFFERENT entry's
-        ``file_size`` for the actual stream).
-
-          ``_ENTRY_HARD_CAP``   stops ONE entry whose header honestly
-                                 declares -- and rarfile then honours -- far
-                                 more than any real media file this
-                                 application manages.
-          ``_ARCHIVE_HARD_CAP`` stops the ARCHIVE as a whole once entries
-                                 processed so far (this one included) have
-                                 actually written more than a single release
-                                 plausibly needs -- the reachable
-                                 amplification, since many small honest
-                                 entries (or RAR5 duplicate-file references)
-                                 can sum to far more than any one entry alone.
-
-        Raises ``_ArchiveEntryTooLarge`` for the first, ``_ArchiveTooLarge``
-        for the second -- checked BEFORE each chunk is written, so the temp
-        file for a refused entry never grows past whichever ceiling it
-        crossed, rather than silently truncating the entry. The caller
-        treats both as refusals, never as a successful partial extract.
+        Raises ``_ArchiveEntryTooLarge`` -- checked BEFORE each chunk is
+        written, so the temp file for a refused entry never grows past the
+        ceiling, rather than silently truncating the entry. The caller
+        treats this as a refusal, never as a successful partial extract.
         """
         # Temp file in the SAME directory so os.replace is atomic (same fs).
         fd, tmp_path = tempfile.mkstemp(dir=extr_path, prefix=_TEMP_PREFIX, suffix=_TEMP_SUFFIX)
@@ -856,9 +743,6 @@ class ExtractorMixin:
                         # so the transient disk usage of a refused entry is
                         # bounded even though it is unlinked either way.
                         raise _ArchiveEntryTooLarge(written, _ENTRY_HARD_CAP)
-                    if archive_written_so_far + written > _ARCHIVE_HARD_CAP:
-                        raise _ArchiveTooLarge(
-                            archive_written_so_far + written, _ARCHIVE_HARD_CAP)
                     target.write(chunk)
             # tempfile.mkstemp always creates the file 0600 (owner-only),
             # ignoring umask; without this the extracted media file would be
@@ -867,7 +751,6 @@ class ExtractorMixin:
             # permission before the atomic rename, matching mover.py.
             os.chmod(tmp_path, Env.getPermission('file'))
             os.replace(tmp_path, extr_file_path)
-            return written
         except BaseException:
             try:
                 os.unlink(tmp_path)

--- a/couchpotato/core/plugins/renamer/extractor.py
+++ b/couchpotato/core/plugins/renamer/extractor.py
@@ -29,7 +29,10 @@ log = CPLog(__name__)
 #: Cap on per-entry log lines a single archive may produce, for ALL FIVE
 #: per-entry counters: refusals, name collisions, unreadable entries, entries
 #: that could not be written to their destination, and entries refused for
-#: decompressing far beyond their declared size.
+#: producing more than the fixed per-entry size ceiling (`_ENTRY_HARD_CAP`).
+#: (A whole-archive abort on `_ARCHIVE_HARD_CAP` is NOT one of these five --
+#: it ends the archive outright and is logged once at `extractFiles`, not as
+#: a capped per-entry line here.)
 #: (This said "BOTH refusals and name collisions" until the third counter was
 #: added a commit later and this line was not updated -- the same drift the
 #: rest of this branch keeps correcting.)
@@ -72,44 +75,121 @@ _ENTRY_DERIVED_ERRNOS = frozenset((
     errno.EINVAL,
 ))
 
-#: Slack allowed above an entry's declared `info.file_size` before the
-#: streaming read loop refuses it (see `_ArchiveEntryTooLarge` and
-#: `_extractOneAtomic` below). `info.file_size` comes from the archive
-#: HEADER, which `rarfile.infolist()` parses without decompressing anything
-#: -- it is attacker-supplied and free to fabricate, so it cannot be trusted
-#: as a limit on its own. It is still the only per-entry size hint available,
-#: and a LEGITIMATE entry decompresses to exactly the declared size. This
-#: margin exists only to absorb the read loop's own chunking (the final
-#: chunk of a genuine entry lands the running total on file_size exactly, but
-#: nothing guarantees that alignment for every archive/tool combination) --
-#: it is not slack for the attacker. Sized to one read() chunk, not derived
-#: from disk state.
-_ENTRY_SIZE_MARGIN = 1024 * 1024  # one read() chunk
-
-#: Absolute per-entry ceiling, independent of anything the archive header
-#: claims. The cross-check above (declared file_size + margin) is defeated
-#: the moment the header lies about file_size too: an entry that declares
-#: itself "this will decompress to 400 GiB" and then does exactly that
-#: sails straight through a check that only compares actual output against
-#: the declared figure. This is the belt to that braces -- no single media
-#: file this application manages is anywhere near this size, so refusing a
-#: "movie" that would blow past it is never a false positive on the real
-#: workload.
+#: T44 REWORK, 2026-08-20: this file previously carried a per-entry
+#: cross-check comparing bytes actually written against `info.file_size`
+#: (declared header size) plus a margin. Review measured it dead on the
+#: pinned `rarfile==4.5`, and worse than dead: actively unsafe. Read before
+#: changing either constant below.
 #:
-#: Deliberately NOT derived from `shutil.disk_usage()`. A free-space-based
-#: bound would make one extraction's outcome depend on how much OTHER,
-#: unrelated data already sits on the volume: nondeterministic (races with
-#: concurrent downloads/scans on the same disk), unrepresentable in a test
-#: without faking disk state, and it would surprise an operator with an
-#: extraction that fails today and would have succeeded yesterday against an
-#: identical archive purely because something else filled the disk in the
-#: meantime. A fixed ceiling is deterministic and directly testable instead.
-_ENTRY_HARD_CAP = 200 * 1024 ** 3  # 200 GiB
+#: MEASURED, not assumed, against
+#: `.venv/lib/python3.14/site-packages/rarfile.py`:
+#:
+#:   RarExtFile._open_extfile():  self._remain = self._inf.file_size
+#:   RarExtFile.read(self, n=-1):
+#:       if n is None or n < 0: n = self._remain
+#:       elif n > self._remain: n = self._remain
+#:       ...
+#:       self._remain -= len(data)
+#:
+#: `PipeReader`/`DirectReader` (the two concrete readers `rarfile` actually
+#: returns) override only `_read`/`readinto`, never the public `read()` this
+#: file calls. So `read()` NEVER hands back more than `info.file_size` bytes
+#: for an entry, regardless of how much the underlying decompressor is
+#: willing to produce: `written <= declared` is an INVARIANT of this
+#: library version, which makes `written > declared + margin` unreachable.
+#: Three of the four tests the deleted cross-check shipped with only passed
+#: because their fixture reader had no `_remain` and was therefore MORE
+#: permissive than production -- the exact incidentally-passing shape
+#: CLAUDE.md's guard-verification rule (11) exists to catch, caught here by
+#: a second reviewer's own mutation, not by the tests themselves.
+#:
+#: The cross-check was also actively UNSAFE, not merely inert. RAR5
+#: FILE_COPY/HARD_LINK redirects (`CommonParser.open()`) swap `inf` for the
+#: ORIGINAL entry before opening it -- `inf = self.getinfo(redir_name)` --
+#: so the stream that comes back is clamped to the ORIGINAL's file_size, not
+#: the redirect entry's own. A redirect entry honestly declaring a small (or
+#: zero) size for itself while pointing at a large legitimate file would have
+#: had its real data refused by a budget computed from the wrong header.
+#: Measured: a link entry declaring 0 got refused while the real media file
+#: behind it kept streaming its true size. What WinRAR actually writes into
+#: a real FILE_COPY/HARD_LINK header could not be settled on this machine
+#: (no rar/unrar/7z/7zz/unar, only bsdtar) -- deleting the cross-check makes
+#: that question moot rather than resolving it.
+#:
+#: What is left below is TWO fixed ceilings, neither derived from anything
+#: the archive header claims:
+#:
+#:   `_ENTRY_HARD_CAP`   the LIVE guard for a single entry. rarfile's own
+#:                       invariant stops an entry producing MORE than its
+#:                       header declares, but declares nothing about how
+#:                       LARGE that declaration may honestly be -- an entry
+#:                       whose header self-consistently says "400 GiB" and
+#:                       then produces 400 GiB sails straight through
+#:                       rarfile's own clamp. This is what catches it.
+#:
+#:   `_ARCHIVE_HARD_CAP` the LIVE guard for the reachable amplification: RAR5
+#:                       lets many entries (duplicate/FILE_COPY references,
+#:                       or simply many honestly-small entries) each cost the
+#:                       attacker one header while the extractor still writes
+#:                       each one out in full. Measured: 400 entries each
+#:                       honestly declaring 256 KiB extracted 100 MB with no
+#:                       refusal from the (now-deleted) per-entry check
+#:                       alone. No single entry lies here, so no per-entry
+#:                       ceiling on its own can catch it; the ARCHIVE's total
+#:                       output needs its own fixed ceiling.
+#:
+#: Both check bytes ACTUALLY WRITTEN, never `info.file_size` -- which is why
+#: both are simultaneously the LIVE guard against today's `rarfile==4.5` and
+#: DEFENSE-IN-DEPTH against a hypothetical future `rarfile` that weakens or
+#: removes the `_remain` clamp entirely (see the "NOTE for the next bump" at
+#: requirements.txt:52-55, about rarfile 5.0's *unrelated* config-location
+#: break): if that clamp ever went away, an entry could then both lie about
+#: its header AND overproduce, and these two ceilings would still catch it on
+#: actual output alone, with no extra code. That dual role is exactly what
+#: the deleted cross-check did NOT have -- it depended entirely on trusting
+#: `info.file_size` as the comparison baseline, which is the same trust that
+#: made it unsafe against redirects.
+#:
+#: Deliberately NOT derived from `shutil.disk_usage()`, for both ceilings.
+#: A free-space-based bound would make one extraction's outcome depend on
+#: how much OTHER, unrelated data already sits on the volume: nondeterministic
+#: (races with concurrent downloads/scans on the same disk), unrepresentable
+#: in a test without faking disk state, and it would surprise an operator
+#: with an extraction that fails today and would have succeeded yesterday
+#: against an identical archive purely because something else filled the
+#: disk in the meantime. A fixed ceiling is deterministic and directly
+#: testable instead.
+#:
+#: 200 GiB (the value this constant shipped with before this note) bought
+#: nothing over a tighter figure: a UHD Blu-ray remux, the largest legitimate
+#: single media file this application is ever asked to manage, tops out
+#: around 100 GB. 128 GiB leaves that real ceiling ~28 GiB of headroom
+#: without leaving the attacker another 72 GiB of it to abuse for free.
+_ENTRY_HARD_CAP = 128 * 1024 ** 3  # 128 GiB
+
+#: One feature file at `_ENTRY_HARD_CAP`, plus what a real release
+#: legitimately bundles alongside it -- a sample, subtitles, an NFO, maybe an
+#: alternate cut. None of that plausibly adds up to double digits of GiB, so
+#: 16 GiB of headroom over the entry ceiling is generous for a legitimate
+#: multi-file release. It is deliberately NOT generous enough to let a
+#: duplicate-reference bomb hide behind "it's just extras": the amplification
+#: this constant exists to catch is entries whose sum runs to many multiples
+#: of a single release, not a fraction over one.
+#:
+#: Checked against bytes ACTUALLY WRITTEN across every entry processed so far
+#: in ONE extractArchive() call (see `_extractOneAtomic`'s
+#: `archive_written_so_far` parameter) -- entries already confirmed present
+#: on disk from a PRIOR scan (the idempotency skip, `os.path.isfile`) are not
+#: re-read and so contribute nothing to this run's total, which is correct:
+#: no bytes are written for them this scan.
+_ARCHIVE_HARD_CAP = _ENTRY_HARD_CAP + 16 * 1024 ** 3  # 144 GiB
 
 
 class _ArchiveEntryTooLarge(Exception):
-    """Raised internally by `_extractOneAtomic` when a single entry writes
-    more than its budget allows for.
+    """Raised internally by `_extractOneAtomic` when a single entry's ACTUAL
+    output crosses the fixed `_ENTRY_HARD_CAP` -- never anything the archive
+    header claims (see the T44 REWORK note above for why the header cannot
+    be trusted as a budget input, only rarfile's own clamp on it).
 
     Deliberately its own type, not `OSError`/`rarfile.Error`: the write
     SUCCEEDS every time this fires. There is no I/O failure to observe here,
@@ -120,8 +200,35 @@ class _ArchiveEntryTooLarge(Exception):
 
     def __init__(self, written, budget):
         super().__init__(
-            'entry wrote at least %d bytes, exceeding its %d-byte budget'
-            % (written, budget))
+            'entry wrote at least %d bytes, exceeding the fixed %d-byte '
+            'per-entry ceiling' % (written, budget))
+        self.written = written
+        self.budget = budget
+
+
+class _ArchiveTooLarge(Exception):
+    """Raised internally when the RUNNING TOTAL of bytes actually written
+    across every entry processed so far in ONE `extractArchive()` call
+    crosses the fixed `_ARCHIVE_HARD_CAP`.
+
+    Unlike `_ArchiveEntryTooLarge`, no single entry need be at fault: this is
+    the reachable amplification -- many entries, each individually honest and
+    under `_ENTRY_HARD_CAP`, whose SUM the extractor would otherwise write in
+    full for the cost of one header each.
+
+    Deliberately left UNCAUGHT by the per-entry try/except inside
+    `extractArchive`'s loop (see the comment at that call site), so it
+    propagates out of `extractArchive` entirely and abandons the WHOLE
+    archive rather than continuing to spend disk on further entries once the
+    budget is already gone. `extractFiles`' except chain is where it is
+    caught, logged, and turned into a skip-not-tag -- the archive is retried
+    on a later scan, same as any other archive-level failure here.
+    """
+
+    def __init__(self, written, budget):
+        super().__init__(
+            'archive wrote at least %d bytes across its entries, exceeding '
+            'the fixed %d-byte per-archive ceiling' % (written, budget))
         self.written = written
         self.budget = budget
 
@@ -226,6 +333,24 @@ class ExtractorMixin:
             except rarfile.Error as e:
                 # Known archive problem (corrupt/bad RAR, wrong password, etc.).
                 log.error('Skipping archive with a known RAR problem %s: %s %s', archive['file'], e, traceback.format_exc())
+                continue
+            except _ArchiveTooLarge as e:
+                # T44: this archive's entries have, TOGETHER, actually
+                # written more than the fixed per-archive budget allows --
+                # see _ArchiveTooLarge's docstring for why extractArchive
+                # deliberately lets this propagate rather than skipping just
+                # the one entry that tipped it over. Not tagged, so it is
+                # retried on a later scan like any other archive-level
+                # failure here (a genuinely hostile archive will hit this
+                # same ceiling again next scan, which is the same retry
+                # characteristic an environmental OSError or a corrupt
+                # archive already has on this path, not something new).
+                log.error(
+                    'Archive %s requested more data than the %d-byte '
+                    'per-archive extraction budget allows (wrote at least '
+                    '%d bytes before aborting), skipping it: %s',
+                    archive['file'], _ARCHIVE_HARD_CAP, e.written, e,
+                )
                 continue
             except Exception as e:
                 # Anything else (I/O error, permissions, unexpected bug).
@@ -373,6 +498,12 @@ class ExtractorMixin:
             unreadable = 0
             unwritable = 0
             oversized = 0
+            # Running total of bytes ACTUALLY WRITTEN across every entry
+            # processed so far in this call, checked against
+            # `_ARCHIVE_HARD_CAP` inside `_extractOneAtomic`. Never derived
+            # from any entry's declared file_size -- see the T44 REWORK note
+            # above `_ENTRY_HARD_CAP` for why that would be unsafe.
+            archive_written = 0
             extracted = []
             # Parallel set purely for membership. `extracted` stays a list
             # because its ORDER is the return contract, but `x in list` is a
@@ -429,8 +560,15 @@ class ExtractorMixin:
                         # because the entry was never refused.
                         log.debug('Extracting %r...', info.filename)
                         try:
-                            self._extractOneAtomic(
-                                rar_handle, info, extr_file_path, extr_path)
+                            # Returns bytes actually written for THIS entry,
+                            # accumulated into the archive-wide running total
+                            # -- an augmented assignment only completes on a
+                            # successful return, so a refused entry (either
+                            # exception below) contributes nothing to it: its
+                            # work was discarded along with its temp file.
+                            archive_written += self._extractOneAtomic(
+                                rar_handle, info, extr_file_path, extr_path,
+                                archive_written)
                         except rarfile.RarCannotExec:
                             # The extractor TOOL is missing. Environmental, and
                             # it will fail identically for every remaining
@@ -444,34 +582,45 @@ class ExtractorMixin:
                             # of the broader catch going in, which is the whole
                             # argument for the narrow one.
                             raise
+                        # _ArchiveTooLarge is DELIBERATELY not caught here.
+                        # Unlike _ArchiveEntryTooLarge (one hostile/oversized
+                        # entry, skip it, keep going), _ArchiveTooLarge means
+                        # this run has ALREADY written more than a single
+                        # release plausibly needs -- continuing to process
+                        # further entries only spends more disk on exactly
+                        # the amplification this budget exists to stop. Let
+                        # it propagate past every except clause below, out of
+                        # the try/finally (still logging the per-entry
+                        # summary on the way out -- see the `finally` below),
+                        # and out of extractArchive entirely; extractFiles'
+                        # except chain is where it is caught, logged, and
+                        # turned into a skip-not-tag.
                         except _ArchiveEntryTooLarge as e:
-                            # T44: the entry decompressed to far more than its
-                            # header declared -- `info.file_size` costs the
-                            # attacker nothing (`infolist()` never
-                            # decompresses to check it), so a header claiming
-                            # a small entry is free cover for a bomb. The
-                            # write ALWAYS succeeds here; there is no OSError
-                            # to sort by errno, which is why this needs its
-                            # own except clause rather than joining
+                            # T44: this entry's ACTUAL output crossed the
+                            # fixed per-entry ceiling -- never anything its
+                            # header claims (rarfile's own read() already
+                            # clamps output to the declared file_size; see
+                            # the T44 REWORK note above `_ENTRY_HARD_CAP`).
+                            # The write ALWAYS succeeds here; there is no
+                            # OSError to sort by errno, which is why this
+                            # needs its own except clause rather than joining
                             # `_ENTRY_DERIVED_ERRNOS`.
                             #
                             # Attacker-controlled like a hostile name or a
                             # corrupt entry, so the same treatment applies:
                             # refuse this one, keep the archive. Its own
                             # counter for the same reason `unwritable` has
-                            # one -- "refused for exceeding its declared
-                            # size" is a different remedy from "could not be
-                            # read" or "could not be written".
+                            # one -- "refused for exceeding the fixed size
+                            # ceiling" is a different remedy from "could not
+                            # be read" or "could not be written".
                             oversized += 1
                             if oversized <= _MAX_ENTRY_LOGS:
                                 log.error(
-                                    'Archive entry decompressed far beyond '
-                                    'its declared size (declared %d bytes, '
-                                    'wrote at least %d before refusing it), '
+                                    'Archive entry decompressed beyond the '
+                                    'fixed %d-byte per-entry ceiling (wrote '
+                                    'at least %d bytes before refusing it), '
                                     'skipping it: %r',
-                                    info.file_size if isinstance(info.file_size, int) else -1,
-                                    e.written,
-                                    info.filename,
+                                    _ENTRY_HARD_CAP, e.written, info.filename,
                                 )
                             continue
                         except OSError as e:
@@ -612,9 +761,9 @@ class ExtractorMixin:
                       'destination in total (only the first %d were logged '
                       'individually).', unwritable, _MAX_ENTRY_LOGS)
         if oversized > _MAX_ENTRY_LOGS:
-            log.error('%d archive entries exceeded their declared size and '
-                      'were refused in total (only the first %d were logged '
-                      'individually).', oversized, _MAX_ENTRY_LOGS)
+            log.error('%d archive entries exceeded the fixed per-entry size '
+                      'ceiling and were refused in total (only the first %d '
+                      'were logged individually).', oversized, _MAX_ENTRY_LOGS)
 
     @staticmethod
     def _safeEntryBasename(filename):
@@ -652,31 +801,43 @@ class ExtractorMixin:
                 pass
 
     @staticmethod
-    def _extractOneAtomic(rar_handle, info, extr_file_path, extr_path):
+    def _extractOneAtomic(rar_handle, info, extr_file_path, extr_path,
+                           archive_written_so_far):
         """Stream a single archive entry to a temp file in extr_path, then
         atomically ``os.replace`` it into extr_file_path. On ANY error the
         temp file is removed so no partial output survives at the real path.
 
-        The read loop enforces a per-entry byte budget derived from
-        ``info.file_size`` (see ``_ENTRY_SIZE_MARGIN``) and capped absolutely
-        at ``_ENTRY_HARD_CAP``. Without it, a header claiming a small size is
-        free for the attacker -- ``rarfile.infolist()`` parses headers only --
-        while the loop below writes whatever the decompressor actually
-        produces with no limit. Raises ``_ArchiveEntryTooLarge`` (checked
-        BEFORE each chunk is written, so the temp file never grows past the
-        budget) rather than silently truncating the entry, so the caller
-        treats it as a refusal like any other hostile entry, not as a
-        successful partial extract.
-        """
-        # declared may itself be attacker-fabricated (including negative or
-        # non-numeric); treat anything untrustworthy as "declares nothing",
-        # which still leaves _ENTRY_SIZE_MARGIN of slack for a genuinely tiny
-        # legitimate entry.
-        declared = info.file_size
-        if not isinstance(declared, int) or declared < 0:
-            declared = 0
-        budget = min(declared + _ENTRY_SIZE_MARGIN, _ENTRY_HARD_CAP)
+        Returns the number of bytes actually written for THIS entry, so the
+        caller can accumulate the archive-wide running total.
 
+        The read loop enforces two independent size guards, both against
+        FIXED ceilings and both checked against bytes ACTUALLY WRITTEN --
+        never against ``info.file_size`` or anything else the archive header
+        claims. See the T44 REWORK note above ``_ENTRY_HARD_CAP`` for why a
+        header-derived budget was tried, measured unreachable against the
+        pinned ``rarfile==4.5`` (its own ``RarExtFile.read()`` already clamps
+        output to the declared ``file_size``), and actively unsafe besides
+        (RAR5 FILE_COPY/HARD_LINK redirects swap in a DIFFERENT entry's
+        ``file_size`` for the actual stream).
+
+          ``_ENTRY_HARD_CAP``   stops ONE entry whose header honestly
+                                 declares -- and rarfile then honours -- far
+                                 more than any real media file this
+                                 application manages.
+          ``_ARCHIVE_HARD_CAP`` stops the ARCHIVE as a whole once entries
+                                 processed so far (this one included) have
+                                 actually written more than a single release
+                                 plausibly needs -- the reachable
+                                 amplification, since many small honest
+                                 entries (or RAR5 duplicate-file references)
+                                 can sum to far more than any one entry alone.
+
+        Raises ``_ArchiveEntryTooLarge`` for the first, ``_ArchiveTooLarge``
+        for the second -- checked BEFORE each chunk is written, so the temp
+        file for a refused entry never grows past whichever ceiling it
+        crossed, rather than silently truncating the entry. The caller
+        treats both as refusals, never as a successful partial extract.
+        """
         # Temp file in the SAME directory so os.replace is atomic (same fs).
         fd, tmp_path = tempfile.mkstemp(dir=extr_path, prefix=_TEMP_PREFIX, suffix=_TEMP_SUFFIX)
         try:
@@ -689,12 +850,15 @@ class ExtractorMixin:
                     if not chunk:
                         break
                     written += len(chunk)
-                    if written > budget:
+                    if written > _ENTRY_HARD_CAP:
                         # Checked before the write: the temp file this
-                        # entry has produced so far never exceeds `budget`,
+                        # entry has produced so far never exceeds the cap,
                         # so the transient disk usage of a refused entry is
                         # bounded even though it is unlinked either way.
-                        raise _ArchiveEntryTooLarge(written, budget)
+                        raise _ArchiveEntryTooLarge(written, _ENTRY_HARD_CAP)
+                    if archive_written_so_far + written > _ARCHIVE_HARD_CAP:
+                        raise _ArchiveTooLarge(
+                            archive_written_so_far + written, _ARCHIVE_HARD_CAP)
                     target.write(chunk)
             # tempfile.mkstemp always creates the file 0600 (owner-only),
             # ignoring umask; without this the extracted media file would be
@@ -703,6 +867,7 @@ class ExtractorMixin:
             # permission before the atomic rename, matching mover.py.
             os.chmod(tmp_path, Env.getPermission('file'))
             os.replace(tmp_path, extr_file_path)
+            return written
         except BaseException:
             try:
                 os.unlink(tmp_path)

--- a/tests/unit/test_extractor.py
+++ b/tests/unit/test_extractor.py
@@ -10,6 +10,7 @@ import errno
 import logging
 import os
 import stat
+import zlib
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -89,6 +90,40 @@ class _RaisingOpenResult:
 
     def __init__(self, first_chunk, exc):
         self._reader = _RaisingReader(first_chunk, exc)
+
+    def __enter__(self):
+        return self._reader
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _ChunkedReader:
+    """Serves `data` back in caller-sized pieces, mirroring a real streaming
+    decompressor's stdout pipe -- unlike `_BytesReader` above, which hands
+    back its ENTIRE payload on the first `.read()` regardless of the size
+    requested. T44's entry-size cap has to hold across many loop iterations
+    of `_extractOneAtomic`'s `source.read(1024 * 1024)`, not just survive a
+    single oversized read, so this fixture forces exactly that."""
+
+    def __init__(self, data):
+        self._data = data
+        self._pos = 0
+
+    def read(self, size=-1):
+        if size is None or size < 0:
+            size = len(self._data) - self._pos
+        chunk = self._data[self._pos:self._pos + size]
+        self._pos += len(chunk)
+        return chunk
+
+
+class _ChunkedOpenResult:
+    """Context manager standing in for rarfile.RarFile.open()'s return value,
+    backed by a `_ChunkedReader`."""
+
+    def __init__(self, data):
+        self._reader = _ChunkedReader(data)
 
     def __enter__(self):
         return self._reader
@@ -1536,3 +1571,198 @@ class TestAnEINVALDestinationDoesNotSinkTheArchive:
             'it was never extracted'
         )
         assert any('EINVAL' in r.getMessage() for r in caplog.records)
+
+
+class TestEntrySizeCapPreventsAnArchiveBomb:
+    """T44: `rarfile.infolist()` parses headers only, so a header claiming a
+    small size costs the attacker nothing -- the streaming read loop in
+    `_extractOneAtomic` previously wrote whatever the decompressor produced
+    with NO cap, so a single entry could fill the disk. On this project the
+    same volume holds the SQLite database and settings, which sits above a
+    completed download on the loss ranking (CLAUDE.md).
+
+    The fixture below is genuinely hostile, not a stand-in for one: it REALLY
+    zlib-compresses a large all-zero payload (real compression, not a claim
+    about what compression would achieve) and streams the REAL decompressed
+    bytes back through the extractor's own 1 MiB read loop, chunk by chunk,
+    via `_ChunkedReader` -- exactly as rarfile's RarExtFile streams from the
+    external unrar/7z/bsdtar subprocess. The archive's header
+    (`info.file_size`) then LIES about how big the entry is, which is the
+    actual attack: the header is free to fabricate, because `infolist()`
+    never decompresses anything to check it against.
+    """
+
+    def test_an_entry_that_decompresses_far_beyond_its_declared_size_is_capped(
+            self, tmp_path, caplog):
+        # Real compression, not a synthetic stand-in: prove the fixture is
+        # actually hostile before trusting anything that follows. A 1x1
+        # placeholder cannot demonstrate an unbounded write; this must.
+        bomb_size = 5 * 1024 * 1024  # 5 MiB of real decompressed output
+        raw = b'\x00' * bomb_size
+        compressed = zlib.compress(raw, level=9)
+        ratio = len(raw) / len(compressed)
+        assert ratio > 100, (
+            'the fixture is not compressible enough to model a bomb: '
+            '%d bytes compressed to %d (%.0fx)' % (len(raw), len(compressed), ratio)
+        )
+
+        extr_path = tmp_path / 'extract_here'
+        extr_path.mkdir()
+
+        info = _make_info('tiny-looking.mkv')
+        # The header's declared size: attacker-chosen and free to fabricate.
+        # A 5 MiB bomb LOOKS like a 1 KiB file.
+        info.file_size = 1024
+
+        handle = MagicMock()
+        handle.infolist.return_value = [info]
+        handle.open.side_effect = lambda i: _ChunkedOpenResult(raw)
+
+        with patch('couchpotato.core.plugins.renamer.extractor.rarfile.RarFile',
+                   return_value=handle), \
+             caplog.at_level(logging.ERROR,
+                             logger='couchpotato.core.plugins.renamer.extractor'):
+            extracted = _Extractor().extractArchive('a.rar', str(extr_path))
+
+        assert extracted == [], (
+            'the oversized entry was extracted instead of refused'
+        )
+        assert not (extr_path / 'tiny-looking.mkv').exists(), (
+            'a bomb payload (partial or full) was left on disk'
+        )
+        assert list(extr_path.iterdir()) == [], (
+            'a temp file from the aborted write was left behind -- the '
+            'atomic-write cleanup must fire on this failure path exactly as '
+            'it does on the other entry-derived failures'
+        )
+        messages = '\n'.join(r.getMessage() for r in caplog.records)
+        assert 'declared' in messages.lower() and '1024' in messages, (
+            'the refusal was silent, or did not name the declared size an '
+            'operator would need to diagnose it'
+        )
+
+    def test_a_thousand_bomb_entries_do_not_produce_a_thousand_errors(
+            self, tmp_path, caplog):
+        """The cap's own per-entry counter must be bounded and summarised
+        exactly like `refused`/`collisions`/`unreadable`/`unwritable` --
+        `infolist()` is header-only, so a thousand poisoned entries cost the
+        attacker one header each, same as every other amplification vector
+        on this path."""
+        extr_path = tmp_path / 'extract_here'
+        extr_path.mkdir()
+        raw = b'\xAB' * (2 * 1024 * 1024)
+        infos = []
+        for i in range(1000):
+            info = _make_info('bomb%d.mkv' % i)
+            info.file_size = 100
+            infos.append(info)
+
+        handle = MagicMock()
+        handle.infolist.return_value = infos
+        handle.open.side_effect = lambda i: _ChunkedOpenResult(raw)
+
+        with patch('couchpotato.core.plugins.renamer.extractor.rarfile.RarFile',
+                   return_value=handle), \
+             caplog.at_level(logging.ERROR,
+                             logger='couchpotato.core.plugins.renamer.extractor'):
+            extracted = _Extractor().extractArchive('a.rar', str(extr_path))
+
+        messages = [r.getMessage() for r in caplog.records]
+        # 'skipping it:' is the PER-ENTRY phrase, deliberately not 'declared'
+        # alone -- the summary line below also says "their declared size",
+        # which is exactly the same trap TestOverlongNameLoggingIsAlsoBounded
+        # documents for the unwritable counter three classes up.
+        per_entry = [m for m in messages if 'skipping it:' in m]
+        assert len(per_entry) <= 5, (
+            'unbounded oversized-entry logging: %d ERROR lines from one '
+            'archive' % len(per_entry)
+        )
+        summary = [m for m in messages
+                   if 'exceeded' in m.lower() and 'in total' in m.lower()]
+        assert summary and '1000' in summary[0], (
+            'the oversized-entry total was not reported, so the cap hides '
+            'the scale'
+        )
+        assert extracted == []
+
+
+class TestEntrySizeCapAlsoBoundsASelfConsistentLie:
+    """The cross-check above compares actual bytes written against the
+    header's declared size -- but the header is exactly as free to declare a
+    large size as a small one. An entry that declares itself correctly
+    (writer and header agree) sails straight through that check alone.
+
+    The absolute ceiling in `_ENTRY_HARD_CAP` is the belt to that braces:
+    independent of anything the header claims. Patched down to a size a test
+    can actually write, since the real ceiling is deliberately far larger
+    than any legitimate media file this application manages (see the
+    constant's comment for why it is fixed rather than free-space-derived).
+    """
+
+    def test_a_correctly_declared_but_still_enormous_entry_is_refused(
+            self, tmp_path, caplog):
+        small_cap = 2 * 1024 * 1024
+        payload_size = 4 * 1024 * 1024  # exceeds the patched ceiling
+        raw = b'\xCD' * payload_size
+
+        extr_path = tmp_path / 'extract_here'
+        extr_path.mkdir()
+
+        info = _make_info('honest-but-huge.mkv')
+        info.file_size = payload_size  # the header does NOT lie this time
+
+        handle = MagicMock()
+        handle.infolist.return_value = [info]
+        handle.open.side_effect = lambda i: _ChunkedOpenResult(raw)
+
+        with patch('couchpotato.core.plugins.renamer.extractor.rarfile.RarFile',
+                   return_value=handle), \
+             patch('couchpotato.core.plugins.renamer.extractor._ENTRY_HARD_CAP',
+                   small_cap), \
+             caplog.at_level(logging.ERROR,
+                             logger='couchpotato.core.plugins.renamer.extractor'):
+            extracted = _Extractor().extractArchive('a.rar', str(extr_path))
+
+        assert extracted == [], (
+            'an entry whose declared size ALSO matches its ceiling-busting '
+            'payload was extracted -- the cross-check alone cannot catch a '
+            'self-consistent lie, which is exactly why the hard cap exists'
+        )
+
+
+class TestEntrySizeCapDoesNotSinkTheArchive:
+    """The invariant this whole file enforces, completed for the fifth
+    per-entry failure mode: one hostile entry must skip, not abandon."""
+
+    def test_an_oversized_entry_is_skipped_and_the_rest_still_extract(
+            self, tmp_path, caplog):
+        extr_path = tmp_path / 'extract_here'
+        extr_path.mkdir()
+
+        bomb_info = _make_info('bomb.mkv')
+        bomb_info.file_size = 100
+        good_info = _make_info('good.mkv')
+        good_info.file_size = 4
+
+        bomb_raw = b'\x00' * (2 * 1024 * 1024)
+
+        def open_entry(i):
+            if i.filename == 'bomb.mkv':
+                return _ChunkedOpenResult(bomb_raw)
+            return _FakeOpenResult(b'real')
+
+        handle = MagicMock()
+        handle.infolist.return_value = [bomb_info, good_info]
+        handle.open.side_effect = open_entry
+
+        with patch('couchpotato.core.plugins.renamer.extractor.rarfile.RarFile',
+                   return_value=handle), \
+             caplog.at_level(logging.ERROR,
+                             logger='couchpotato.core.plugins.renamer.extractor'):
+            extracted = _Extractor().extractArchive('a.rar', str(extr_path))
+
+        assert extracted == [str(extr_path / 'good.mkv')], (
+            'a bomb entry aborted the archive; the good entry after it was '
+            'never extracted'
+        )
+        assert (extr_path / 'good.mkv').read_bytes() == b'real'

--- a/tests/unit/test_extractor.py
+++ b/tests/unit/test_extractor.py
@@ -19,7 +19,6 @@ from couchpotato.core.plugins.renamer.extractor import (
     DEFAULT_UNRAR_TOOL,
     NO_EXTRACTOR_TOOL_MESSAGE,
     ExtractorMixin,
-    _ArchiveTooLarge,
 )
 
 
@@ -1738,137 +1737,20 @@ class TestEntryHardCapLoggingIsAlsoBounded:
         )
 
 
-class TestArchiveHardCapCatchesTheReachableAmplification:
-    """The NEW guard this rework adds. Review measured that many entries,
-    each individually honest and comfortably under `_ENTRY_HARD_CAP`, can
-    still sum to far more than any single release plausibly needs: RAR5 lets
-    N distinct entry names redirect to ONE stored payload (FILE_COPY/
-    HARD_LINK) for the cost of N headers, and even without redirects, many
-    small honestly-sized entries cost the attacker one header each while the
-    extractor writes every one of them out in full. Driven: 400 entries each
-    honestly declaring 256 KiB extracted 100 MB with no refusal from the
-    per-entry check alone. No single entry lies here, so no PER-ENTRY
-    ceiling can catch it -- only a ceiling on the ARCHIVE's total output can.
+class TestTheShippedEntryHardCapValueIsPinned:
+    """Every test above patches `_ENTRY_HARD_CAP` down to something a test
+    can actually write, which is correct for exercising the MECHANISM -- but
+    it also means none of them would notice if the constant actually shipped
+    with a different value. Raising it in the source right now fails nothing
+    in this file. Pin the literal separately."""
 
-    `_ArchiveTooLarge` is deliberately allowed to propagate out of
-    `extractArchive` rather than being caught as a per-entry refusal (see
-    its docstring): once the budget for this run is gone, letting the loop
-    keep processing further entries only spends more disk on exactly the
-    amplification this guard exists to stop.
-    """
-
-    def test_entries_before_the_threshold_extract_and_the_one_that_crosses_it_aborts_the_archive(
-            self, tmp_path, caplog):
-        patched_archive_cap = 3 * 1024 * 1024  # 3 MiB
-        entry_size = 1024 * 1024  # 1 MiB, comfortably under _ENTRY_HARD_CAP
-        extr_path = tmp_path / 'extract_here'
-        extr_path.mkdir()
-
-        # Five 1 MiB entries against a 3 MiB archive budget: the first three
-        # land exactly on the ceiling (1+1+1 MiB == 3 MiB, allowed), the
-        # fourth's first chunk pushes the running total to 4 MiB and aborts,
-        # and the fifth is never even opened.
-        names = ['part%d.mkv' % i for i in range(5)]
-        infos = [_make_info(n) for n in names]
-        handle = MagicMock()
-        handle.infolist.return_value = infos
-        handle.open.side_effect = lambda i: _real_reader(i.filename, entry_size)
-
-        with patch('couchpotato.core.plugins.renamer.extractor.rarfile.RarFile',
-                   return_value=handle), \
-             patch('couchpotato.core.plugins.renamer.extractor._ARCHIVE_HARD_CAP',
-                   patched_archive_cap), \
-             caplog.at_level(logging.ERROR,
-                             logger='couchpotato.core.plugins.renamer.extractor'):
-            with pytest.raises(_ArchiveTooLarge) as excinfo:
-                _Extractor().extractArchive('a.rar', str(extr_path))
-
-        assert excinfo.value.budget == patched_archive_cap
-        assert excinfo.value.written > patched_archive_cap
-
-        written_files = sorted(p.name for p in extr_path.iterdir())
-        assert written_files == ['part0.mkv', 'part1.mkv', 'part2.mkv'], (
-            'the entries that fit under the archive budget were not all '
-            'written, or a later entry (or its temp file) leaked through: '
-            'got %r' % written_files
-        )
-        for name in written_files:
-            assert (extr_path / name).stat().st_size == entry_size
-
-        # part4.mkv must never even be OPENED: the archive was already over
-        # budget the moment part3.mkv's first chunk crossed it, and
-        # continuing to the next entry would only spend more disk on the
-        # exact amplification this guard exists to stop.
-        opened = [c.args[0].filename for c in handle.open.call_args_list]
-        assert 'part4.mkv' not in opened, (
-            'processing continued past the entry that exceeded the archive '
-            'budget'
-        )
-
-    def test_the_archive_wide_abort_is_never_miscounted_as_a_per_entry_refusal(
-            self, tmp_path, caplog):
-        """`_ArchiveTooLarge` must not increment `oversized` or any other
-        per-entry counter -- it is not a per-entry failure, and folding it
-        into one would send an operator chasing "one bad entry" when the
-        real story is the archive's total."""
-        patched_archive_cap = 1024  # bytes: the very first entry blows it
-        extr_path = tmp_path / 'extract_here'
-        extr_path.mkdir()
-
-        infos = [_make_info('a.mkv')]
-        handle = MagicMock()
-        handle.infolist.return_value = infos
-        handle.open.side_effect = lambda i: _real_reader(i.filename, 1024 * 1024)
-
-        with patch('couchpotato.core.plugins.renamer.extractor.rarfile.RarFile',
-                   return_value=handle), \
-             patch('couchpotato.core.plugins.renamer.extractor._ARCHIVE_HARD_CAP',
-                   patched_archive_cap), \
-             caplog.at_level(logging.ERROR,
-                             logger='couchpotato.core.plugins.renamer.extractor'):
-            with pytest.raises(_ArchiveTooLarge):
-                _Extractor().extractArchive('a.rar', str(extr_path))
-
-        messages = '\n'.join(r.getMessage() for r in caplog.records)
-        assert 'per-entry size ceiling' not in messages, (
-            'an archive-wide budget abort was logged as a per-entry '
-            'oversized refusal'
-        )
-
-
-class TestExtractFilesSkipsAnArchiveThatExceedsTheBudgetWithoutTagging:
-    """`extractFiles`' side of `_ArchiveTooLarge`: caught, logged with the
-    operator-facing budget numbers, and turned into a skip-not-tag exactly
-    like every other archive-level failure on this path (a bad archive, a
-    missing extractor tool), so the release is retried on a later scan
-    rather than silently marked complete with files missing."""
-
-    def test_the_archive_is_skipped_logged_and_not_tagged(self, tmp_path, caplog):
-        folder = tmp_path / 'downloads'
-        folder.mkdir()
-        archive = folder / 'Movie.One.2020.rar'
-        archive.write_bytes(b'not-a-real-rar')
-
-        fake = _FakeRenamer(from_folder=str(folder))
-        fake.extractArchive = MagicMock(
-            side_effect=_ArchiveTooLarge(written=200 * 1024 * 1024,
-                                          budget=144 * 1024 ** 3))
-
-        with caplog.at_level(logging.ERROR, logger='couchpotato.core.plugins.renamer.extractor'):
-            result_folder, media_folder, files, extr_files = fake.extractFiles(
-                folder=str(folder),
-                media_folder=str(folder),
-                files=[str(archive)],
-            )
-
-        assert extr_files == []
-        assert fake.tagged == [], (
-            'an archive that exceeded the per-archive budget was tagged as '
-            'extracted'
-        )
-        errors = [r.getMessage() for r in caplog.records if r.levelno == logging.ERROR]
-        assert len(errors) == 1
-        assert str(144 * 1024 ** 3) in errors[0], (
-            'the operator-facing message did not name the budget that was '
-            'exceeded'
+    def test_the_cap_is_128_gib(self):
+        from couchpotato.core.plugins.renamer import extractor
+        assert extractor._ENTRY_HARD_CAP == 128 * 1024 ** 3, (
+            'the shipped per-entry ceiling drifted from 128 GiB -- that '
+            'value is deliberate headroom (~28 GiB) over the largest '
+            'legitimate single media file this application manages, a UHD '
+            'Blu-ray remux at roughly 100 GB; a silent change here changes '
+            'how much disk a single hostile entry can consume before being '
+            'refused'
         )

--- a/tests/unit/test_extractor.py
+++ b/tests/unit/test_extractor.py
@@ -1737,6 +1737,97 @@ class TestEntryHardCapLoggingIsAlsoBounded:
         )
 
 
+class TestTheEntryHardCapBoundaryIsExact:
+    """The comparison is strict (`written + len(chunk) > cap`), so an entry
+    that writes EXACTLY the cap is allowed and one byte more is refused. That
+    is a deliberate choice and nothing pinned it, so a later "tidy-up" to `>=`
+    would start refusing a legitimate entry sitting precisely on the boundary
+    and no test would notice.
+
+    Both directions are asserted, because a boundary test that only checks the
+    refusing side cannot tell a correct `>` from an over-eager `>=`.
+    """
+
+    def test_an_entry_writing_exactly_the_cap_is_allowed(self, tmp_path):
+        extr_path = tmp_path / 'out'
+        extr_path.mkdir()
+        cap = 4 * 1024 * 1024  # a whole number of 1 MiB read chunks
+
+        info = _make_info('exact.mkv')
+        handle = MagicMock()
+        handle.infolist.return_value = [info]
+        handle.open.side_effect = lambda i: _real_reader(i.filename, cap)
+
+        with patch('couchpotato.core.plugins.renamer.extractor.rarfile.RarFile',
+                   return_value=handle), \
+             patch('couchpotato.core.plugins.renamer.extractor._ENTRY_HARD_CAP',
+                   cap):
+            extracted = _Extractor().extractArchive('a.rar', str(extr_path))
+
+        assert extracted == [str(extr_path / 'exact.mkv')], (
+            'an entry writing exactly the cap was refused -- the comparison '
+            'has become `>=` and legitimate content on the boundary is now '
+            'dropped'
+        )
+        assert (extr_path / 'exact.mkv').stat().st_size == cap
+
+    def test_one_byte_past_the_cap_is_refused(self, tmp_path):
+        extr_path = tmp_path / 'out'
+        extr_path.mkdir()
+        cap = 4 * 1024 * 1024
+
+        info = _make_info('over.mkv')
+        handle = MagicMock()
+        handle.infolist.return_value = [info]
+        handle.open.side_effect = lambda i: _real_reader(i.filename, cap + 1)
+
+        with patch('couchpotato.core.plugins.renamer.extractor.rarfile.RarFile',
+                   return_value=handle), \
+             patch('couchpotato.core.plugins.renamer.extractor._ENTRY_HARD_CAP',
+                   cap):
+            extracted = _Extractor().extractArchive('a.rar', str(extr_path))
+
+        assert extracted == [], 'one byte past the cap was extracted'
+        assert list(extr_path.iterdir()) == []
+
+
+class TestARefusalReportsBytesOnDiskNotBytesRead:
+    """`written` must mean bytes that reached the file. Review caught the
+    earlier form incrementing before the cap test, so a refusal reported the
+    chunk it had just declined to write -- up to 1 MiB that reached the reader
+    and never reached disk, in a message whose verb is "wrote".
+
+    Not cosmetic. The number is what an operator uses to decide whether a
+    refusal was marginal or wild, and the whole test suite passed while it was
+    wrong, which is why it needs pinning rather than fixing quietly.
+    """
+
+    def test_the_reported_byte_count_matches_what_reached_the_file(self, tmp_path, caplog):
+        extr_path = tmp_path / 'out'
+        extr_path.mkdir()
+        cap = 4 * 1024 * 1024  # exactly 4 read chunks
+
+        info = _make_info('over.mkv')
+        handle = MagicMock()
+        handle.infolist.return_value = [info]
+        handle.open.side_effect = lambda i: _real_reader(i.filename, 16 * 1024 * 1024)
+
+        with patch('couchpotato.core.plugins.renamer.extractor.rarfile.RarFile',
+                   return_value=handle), \
+             patch('couchpotato.core.plugins.renamer.extractor._ENTRY_HARD_CAP',
+                   cap), \
+             caplog.at_level(logging.ERROR,
+                             logger='couchpotato.core.plugins.renamer.extractor'):
+            _Extractor().extractArchive('a.rar', str(extr_path))
+
+        messages = '\n'.join(r.getMessage() for r in caplog.records)
+        assert str(cap) in messages, 'the refusal did not name the ceiling'
+        assert str(cap + 1024 * 1024) not in messages, (
+            'the refusal reported a chunk that was never written: the count '
+            'is bytes READ, not bytes on disk'
+        )
+
+
 class TestTheShippedEntryHardCapValueIsPinned:
     """Every test above patches `_ENTRY_HARD_CAP` down to something a test
     can actually write, which is correct for exercising the MECHANISM -- but

--- a/tests/unit/test_extractor.py
+++ b/tests/unit/test_extractor.py
@@ -10,7 +10,6 @@ import errno
 import logging
 import os
 import stat
-import zlib
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -20,6 +19,7 @@ from couchpotato.core.plugins.renamer.extractor import (
     DEFAULT_UNRAR_TOOL,
     NO_EXTRACTOR_TOOL_MESSAGE,
     ExtractorMixin,
+    _ArchiveTooLarge,
 )
 
 
@@ -98,38 +98,69 @@ class _RaisingOpenResult:
         return False
 
 
-class _ChunkedReader:
-    """Serves `data` back in caller-sized pieces, mirroring a real streaming
-    decompressor's stdout pipe -- unlike `_BytesReader` above, which hands
-    back its ENTIRE payload on the first `.read()` regardless of the size
-    requested. T44's entry-size cap has to hold across many loop iterations
-    of `_extractOneAtomic`'s `source.read(1024 * 1024)`, not just survive a
-    single oversized read, so this fixture forces exactly that."""
+class _RealRarInfoStandIn:
+    """A minimal stand-in for rarfile.RarInfo, carrying only the attributes
+    RarExtFile actually touches: enough for rarfile's REAL `read()` to run
+    against it (and clamp output to `file_size`) without a full RarFile or
+    an archive on disk.
 
-    def __init__(self, data):
-        self._data = data
-        self._pos = 0
+    T44 review measured (against the pinned rarfile==4.5 source) that
+    RarExtFile.read() already clamps a well-behaved entry's output to its own
+    declared `file_size` via `self._remain`, and that a fixture reader
+    without that clamp is MORE permissive than production -- three of the
+    four tests this file originally shipped for T44 only passed because of
+    that gap. Using rarfile's OWN `RarExtFile` (see `_RealClampBackedReader`
+    below) instead of reimplementing the clamp closes it: fidelity comes from
+    running the real code, not from a second hand-written copy of it that
+    could itself drift from what production does.
 
-    def read(self, size=-1):
-        if size is None or size < 0:
-            size = len(self._data) - self._pos
-        chunk = self._data[self._pos:self._pos + size]
-        self._pos += len(chunk)
-        return chunk
+    `_md_class`/`_md_expect = None` skip RarExtFile's CRC verification
+    (`_check`), which needs real compressed data this fixture does not
+    have -- the read()/clamp behaviour under test does not depend on it.
+    """
 
+    _md_class = None
+    _md_expect = None
 
-class _ChunkedOpenResult:
-    """Context manager standing in for rarfile.RarFile.open()'s return value,
-    backed by a `_ChunkedReader`."""
+    def __init__(self, filename, file_size):
+        self.filename = filename
+        self.file_size = file_size
 
-    def __init__(self, data):
-        self._reader = _ChunkedReader(data)
-
-    def __enter__(self):
-        return self._reader
-
-    def __exit__(self, exc_type, exc, tb):
+    def isdir(self):
         return False
+
+
+class _RealClampBackedReader(rarfile.RarExtFile):
+    """A REAL `rarfile.RarExtFile`, opened against a `_RealRarInfoStandIn`,
+    supplying synthetic (but genuinely streamed, chunk by chunk) bytes.
+
+    Subclassing rather than faking means `source.read(n)` in
+    `_extractOneAtomic` runs rarfile's OWN `read()` -- the exact method whose
+    `self._remain` clamp this whole rework depends on -- not a test-side
+    reimplementation of it. `_read` is the one seam RarExtFile leaves for a
+    concrete reader to fill in; overriding it to keep producing zero bytes
+    for as long as asked models a decompressor willing to emit unlimited
+    output, so what actually bounds the entry is rarfile's clamp (to
+    `file_size`) composed with `_extractOneAtomic`'s own fixed ceilings, the
+    same as it would be against a real unrar/7z/bsdtar subprocess.
+    """
+
+    def __init__(self, filename, file_size):
+        super().__init__()
+        self._open_extfile(None, _RealRarInfoStandIn(filename, file_size))
+
+    def _read(self, cnt):
+        return b'\x00' * cnt
+
+
+def _real_reader(filename, file_size):
+    """Build a `_RealClampBackedReader` for `filename` declaring `file_size`.
+    Use as `handle.open.side_effect = lambda i: _real_reader(i.filename, N)`.
+    The returned object is ALREADY a context manager (io.IOBase provides
+    `__enter__`/`__exit__`), so no separate wrapper is needed the way the
+    plain-bytes fixtures above need `_FakeOpenResult`."""
+    return _RealClampBackedReader(filename, file_size)
+
 
 
 @pytest.fixture(autouse=True)
@@ -1573,196 +1604,271 @@ class TestAnEINVALDestinationDoesNotSinkTheArchive:
         assert any('EINVAL' in r.getMessage() for r in caplog.records)
 
 
-class TestEntrySizeCapPreventsAnArchiveBomb:
-    """T44: `rarfile.infolist()` parses headers only, so a header claiming a
-    small size costs the attacker nothing -- the streaming read loop in
-    `_extractOneAtomic` previously wrote whatever the decompressor produced
-    with NO cap, so a single entry could fill the disk. On this project the
-    same volume holds the SQLite database and settings, which sits above a
-    completed download on the loss ranking (CLAUDE.md).
+class TestEntryHardCapIsTheLiveGuardAgainstAnHonestlyDeclaredEntry:
+    """T44, REWORKED 2026-08-20. The original cross-check here (bytes
+    written vs `info.file_size` plus a margin) was measured, by review,
+    unreachable against the pinned `rarfile==4.5`:
+    `rarfile.RarExtFile.read()` already clamps a well-behaved entry's output
+    to its own declared `file_size` (`self._remain`, set in
+    `_open_extfile`), so `written > declared` cannot happen -- a header
+    claiming a SMALL size can never hide a bomb, because rarfile itself will
+    not let the entry produce more than it declared. Three of the four tests
+    this file originally shipped for T44 only passed because their fixture
+    reader had no such clamp and was therefore MORE permissive than
+    production -- exactly the incidentally-passing shape CLAUDE.md's guard
+    rule exists to catch.
 
-    The fixture below is genuinely hostile, not a stand-in for one: it REALLY
-    zlib-compresses a large all-zero payload (real compression, not a claim
-    about what compression would achieve) and streams the REAL decompressed
-    bytes back through the extractor's own 1 MiB read loop, chunk by chunk,
-    via `_ChunkedReader` -- exactly as rarfile's RarExtFile streams from the
-    external unrar/7z/bsdtar subprocess. The archive's header
-    (`info.file_size`) then LIES about how big the entry is, which is the
-    actual attack: the header is free to fabricate, because `infolist()`
-    never decompresses anything to check it against.
+    What rarfile does NOT bound is how large that declaration may honestly
+    be. An entry whose header says "400 GiB" and then genuinely decompresses
+    to 400 GiB sails straight through rarfile's own clamp -- that is the
+    reachable attack `_ENTRY_HARD_CAP` exists to stop, and it is the LIVE
+    guard against the pinned library version, not defence-in-depth.
+
+    The fixture below (`_real_reader`, backed by `_RealClampBackedReader`,
+    a genuine subclass of `rarfile.RarExtFile`) runs rarfile's OWN `read()`,
+    so this test exercises the exact clamp production hits rather than a
+    hand-written stand-in that could itself drift from what rarfile does.
     """
 
-    def test_an_entry_that_decompresses_far_beyond_its_declared_size_is_capped(
+    def test_an_honestly_declared_enormous_entry_is_refused_and_the_archive_continues(
             self, tmp_path, caplog):
-        # Real compression, not a synthetic stand-in: prove the fixture is
-        # actually hostile before trusting anything that follows. A 1x1
-        # placeholder cannot demonstrate an unbounded write; this must.
-        bomb_size = 5 * 1024 * 1024  # 5 MiB of real decompressed output
-        raw = b'\x00' * bomb_size
-        compressed = zlib.compress(raw, level=9)
-        ratio = len(raw) / len(compressed)
-        assert ratio > 100, (
-            'the fixture is not compressible enough to model a bomb: '
-            '%d bytes compressed to %d (%.0fx)' % (len(raw), len(compressed), ratio)
-        )
-
+        patched_cap = 2 * 1024 * 1024  # 2 MiB, so the test writes almost none
         extr_path = tmp_path / 'extract_here'
         extr_path.mkdir()
 
-        info = _make_info('tiny-looking.mkv')
-        # The header's declared size: attacker-chosen and free to fabricate.
-        # A 5 MiB bomb LOOKS like a 1 KiB file.
-        info.file_size = 1024
-
+        infos = [_make_info('huge.mkv'), _make_info('good.mkv')]
         handle = MagicMock()
-        handle.infolist.return_value = [info]
-        handle.open.side_effect = lambda i: _ChunkedOpenResult(raw)
+        handle.infolist.return_value = infos
+        handle.open.side_effect = lambda i: (
+            _real_reader(i.filename, 5 * 1024 * 1024)  # honestly declares 5 MiB
+            if i.filename == 'huge.mkv' else _FakeOpenResult(b'real')
+        )
 
         with patch('couchpotato.core.plugins.renamer.extractor.rarfile.RarFile',
                    return_value=handle), \
+             patch('couchpotato.core.plugins.renamer.extractor._ENTRY_HARD_CAP',
+                   patched_cap), \
              caplog.at_level(logging.ERROR,
                              logger='couchpotato.core.plugins.renamer.extractor'):
             extracted = _Extractor().extractArchive('a.rar', str(extr_path))
 
-        assert extracted == [], (
-            'the oversized entry was extracted instead of refused'
+        assert extracted == [str(extr_path / 'good.mkv')], (
+            'the oversized entry sank the archive, or was extracted instead '
+            'of refused'
         )
-        assert not (extr_path / 'tiny-looking.mkv').exists(), (
+        assert not (extr_path / 'huge.mkv').exists(), (
             'a bomb payload (partial or full) was left on disk'
         )
-        assert list(extr_path.iterdir()) == [], (
+        assert (extr_path / 'good.mkv').read_bytes() == b'real'
+        assert sorted(p.name for p in extr_path.iterdir()) == ['good.mkv'], (
             'a temp file from the aborted write was left behind -- the '
             'atomic-write cleanup must fire on this failure path exactly as '
             'it does on the other entry-derived failures'
         )
         messages = '\n'.join(r.getMessage() for r in caplog.records)
-        assert 'declared' in messages.lower() and '1024' in messages, (
-            'the refusal was silent, or did not name the declared size an '
-            'operator would need to diagnose it'
+        assert str(patched_cap) in messages, (
+            'the refusal did not name the fixed ceiling an operator would '
+            'need to diagnose it'
+        )
+        assert 'declared' not in messages.lower(), (
+            'the refusal referenced a declared size again -- this arm no '
+            'longer trusts anything the header claims'
         )
 
-    def test_a_thousand_bomb_entries_do_not_produce_a_thousand_errors(
+
+class TestEntryHardCapLoggingIsAlsoBounded:
+    """The `oversized` counter's own bounded-logging discipline, matched to
+    every other per-entry counter in this file. `infolist()` is header-only,
+    so a thousand entries each honestly declaring an oversized `file_size`
+    cost the attacker one header each -- the same amplification shape as
+    every other counter here.
+
+    Each entry is sized so the FIRST chunk trips the (patched, small) cap
+    without writing anything: real `rarfile.RarExtFile.read()` still governs
+    how much any one `.read()` call can return (clamped to the declared
+    `file_size`), so a small declared size keeps this test's real I/O
+    trivial despite the entry count. The version of this test T44 originally
+    shipped declared TINY sizes with huge ACTUAL output via a fixture that
+    ignored rarfile's clamp -- which both misrepresented the threat and did
+    roughly 1 GB of real disk I/O per run, timing out the suite's 60s limit.
+    """
+
+    def test_a_thousand_oversized_entries_do_not_produce_a_thousand_errors(
             self, tmp_path, caplog):
-        """The cap's own per-entry counter must be bounded and summarised
-        exactly like `refused`/`collisions`/`unreadable`/`unwritable` --
-        `infolist()` is header-only, so a thousand poisoned entries cost the
-        attacker one header each, same as every other amplification vector
-        on this path."""
+        patched_cap = 50  # bytes -- deliberately smaller than one entry
         extr_path = tmp_path / 'extract_here'
         extr_path.mkdir()
-        raw = b'\xAB' * (2 * 1024 * 1024)
-        infos = []
-        for i in range(1000):
-            info = _make_info('bomb%d.mkv' % i)
-            info.file_size = 100
-            infos.append(info)
 
+        names = ['bomb%d.mkv' % i for i in range(1000)]
+        infos = [_make_info(n) for n in names]
         handle = MagicMock()
         handle.infolist.return_value = infos
-        handle.open.side_effect = lambda i: _ChunkedOpenResult(raw)
+        # Each entry honestly declares 200 bytes -- comfortably above the
+        # patched cap, so the FIRST (and only) chunk read trips the guard
+        # before target.write() is ever called for it.
+        handle.open.side_effect = lambda i: _real_reader(i.filename, 200)
 
         with patch('couchpotato.core.plugins.renamer.extractor.rarfile.RarFile',
                    return_value=handle), \
+             patch('couchpotato.core.plugins.renamer.extractor._ENTRY_HARD_CAP',
+                   patched_cap), \
              caplog.at_level(logging.ERROR,
                              logger='couchpotato.core.plugins.renamer.extractor'):
             extracted = _Extractor().extractArchive('a.rar', str(extr_path))
 
         messages = [r.getMessage() for r in caplog.records]
-        # 'skipping it:' is the PER-ENTRY phrase, deliberately not 'declared'
-        # alone -- the summary line below also says "their declared size",
-        # which is exactly the same trap TestOverlongNameLoggingIsAlsoBounded
-        # documents for the unwritable counter three classes up.
+        # 'skipping it:' is the PER-ENTRY phrase, deliberately not a phrase
+        # the summary line also uses -- the same trap
+        # TestOverlongNameLoggingIsAlsoBounded documents for the unwritable
+        # counter.
         per_entry = [m for m in messages if 'skipping it:' in m]
         assert len(per_entry) <= 5, (
             'unbounded oversized-entry logging: %d ERROR lines from one '
             'archive' % len(per_entry)
         )
         summary = [m for m in messages
-                   if 'exceeded' in m.lower() and 'in total' in m.lower()]
+                   if 'per-entry size ceiling' in m and 'in total' in m]
         assert summary and '1000' in summary[0], (
             'the oversized-entry total was not reported, so the cap hides '
             'the scale'
         )
         assert extracted == []
+        assert list(extr_path.iterdir()) == [], (
+            'a refused entry left a temp file behind'
+        )
 
 
-class TestEntrySizeCapAlsoBoundsASelfConsistentLie:
-    """The cross-check above compares actual bytes written against the
-    header's declared size -- but the header is exactly as free to declare a
-    large size as a small one. An entry that declares itself correctly
-    (writer and header agree) sails straight through that check alone.
+class TestArchiveHardCapCatchesTheReachableAmplification:
+    """The NEW guard this rework adds. Review measured that many entries,
+    each individually honest and comfortably under `_ENTRY_HARD_CAP`, can
+    still sum to far more than any single release plausibly needs: RAR5 lets
+    N distinct entry names redirect to ONE stored payload (FILE_COPY/
+    HARD_LINK) for the cost of N headers, and even without redirects, many
+    small honestly-sized entries cost the attacker one header each while the
+    extractor writes every one of them out in full. Driven: 400 entries each
+    honestly declaring 256 KiB extracted 100 MB with no refusal from the
+    per-entry check alone. No single entry lies here, so no PER-ENTRY
+    ceiling can catch it -- only a ceiling on the ARCHIVE's total output can.
 
-    The absolute ceiling in `_ENTRY_HARD_CAP` is the belt to that braces:
-    independent of anything the header claims. Patched down to a size a test
-    can actually write, since the real ceiling is deliberately far larger
-    than any legitimate media file this application manages (see the
-    constant's comment for why it is fixed rather than free-space-derived).
+    `_ArchiveTooLarge` is deliberately allowed to propagate out of
+    `extractArchive` rather than being caught as a per-entry refusal (see
+    its docstring): once the budget for this run is gone, letting the loop
+    keep processing further entries only spends more disk on exactly the
+    amplification this guard exists to stop.
     """
 
-    def test_a_correctly_declared_but_still_enormous_entry_is_refused(
+    def test_entries_before_the_threshold_extract_and_the_one_that_crosses_it_aborts_the_archive(
             self, tmp_path, caplog):
-        small_cap = 2 * 1024 * 1024
-        payload_size = 4 * 1024 * 1024  # exceeds the patched ceiling
-        raw = b'\xCD' * payload_size
-
+        patched_archive_cap = 3 * 1024 * 1024  # 3 MiB
+        entry_size = 1024 * 1024  # 1 MiB, comfortably under _ENTRY_HARD_CAP
         extr_path = tmp_path / 'extract_here'
         extr_path.mkdir()
 
-        info = _make_info('honest-but-huge.mkv')
-        info.file_size = payload_size  # the header does NOT lie this time
-
+        # Five 1 MiB entries against a 3 MiB archive budget: the first three
+        # land exactly on the ceiling (1+1+1 MiB == 3 MiB, allowed), the
+        # fourth's first chunk pushes the running total to 4 MiB and aborts,
+        # and the fifth is never even opened.
+        names = ['part%d.mkv' % i for i in range(5)]
+        infos = [_make_info(n) for n in names]
         handle = MagicMock()
-        handle.infolist.return_value = [info]
-        handle.open.side_effect = lambda i: _ChunkedOpenResult(raw)
+        handle.infolist.return_value = infos
+        handle.open.side_effect = lambda i: _real_reader(i.filename, entry_size)
 
         with patch('couchpotato.core.plugins.renamer.extractor.rarfile.RarFile',
                    return_value=handle), \
-             patch('couchpotato.core.plugins.renamer.extractor._ENTRY_HARD_CAP',
-                   small_cap), \
+             patch('couchpotato.core.plugins.renamer.extractor._ARCHIVE_HARD_CAP',
+                   patched_archive_cap), \
              caplog.at_level(logging.ERROR,
                              logger='couchpotato.core.plugins.renamer.extractor'):
-            extracted = _Extractor().extractArchive('a.rar', str(extr_path))
+            with pytest.raises(_ArchiveTooLarge) as excinfo:
+                _Extractor().extractArchive('a.rar', str(extr_path))
 
-        assert extracted == [], (
-            'an entry whose declared size ALSO matches its ceiling-busting '
-            'payload was extracted -- the cross-check alone cannot catch a '
-            'self-consistent lie, which is exactly why the hard cap exists'
+        assert excinfo.value.budget == patched_archive_cap
+        assert excinfo.value.written > patched_archive_cap
+
+        written_files = sorted(p.name for p in extr_path.iterdir())
+        assert written_files == ['part0.mkv', 'part1.mkv', 'part2.mkv'], (
+            'the entries that fit under the archive budget were not all '
+            'written, or a later entry (or its temp file) leaked through: '
+            'got %r' % written_files
+        )
+        for name in written_files:
+            assert (extr_path / name).stat().st_size == entry_size
+
+        # part4.mkv must never even be OPENED: the archive was already over
+        # budget the moment part3.mkv's first chunk crossed it, and
+        # continuing to the next entry would only spend more disk on the
+        # exact amplification this guard exists to stop.
+        opened = [c.args[0].filename for c in handle.open.call_args_list]
+        assert 'part4.mkv' not in opened, (
+            'processing continued past the entry that exceeded the archive '
+            'budget'
         )
 
-
-class TestEntrySizeCapDoesNotSinkTheArchive:
-    """The invariant this whole file enforces, completed for the fifth
-    per-entry failure mode: one hostile entry must skip, not abandon."""
-
-    def test_an_oversized_entry_is_skipped_and_the_rest_still_extract(
+    def test_the_archive_wide_abort_is_never_miscounted_as_a_per_entry_refusal(
             self, tmp_path, caplog):
+        """`_ArchiveTooLarge` must not increment `oversized` or any other
+        per-entry counter -- it is not a per-entry failure, and folding it
+        into one would send an operator chasing "one bad entry" when the
+        real story is the archive's total."""
+        patched_archive_cap = 1024  # bytes: the very first entry blows it
         extr_path = tmp_path / 'extract_here'
         extr_path.mkdir()
 
-        bomb_info = _make_info('bomb.mkv')
-        bomb_info.file_size = 100
-        good_info = _make_info('good.mkv')
-        good_info.file_size = 4
-
-        bomb_raw = b'\x00' * (2 * 1024 * 1024)
-
-        def open_entry(i):
-            if i.filename == 'bomb.mkv':
-                return _ChunkedOpenResult(bomb_raw)
-            return _FakeOpenResult(b'real')
-
+        infos = [_make_info('a.mkv')]
         handle = MagicMock()
-        handle.infolist.return_value = [bomb_info, good_info]
-        handle.open.side_effect = open_entry
+        handle.infolist.return_value = infos
+        handle.open.side_effect = lambda i: _real_reader(i.filename, 1024 * 1024)
 
         with patch('couchpotato.core.plugins.renamer.extractor.rarfile.RarFile',
                    return_value=handle), \
+             patch('couchpotato.core.plugins.renamer.extractor._ARCHIVE_HARD_CAP',
+                   patched_archive_cap), \
              caplog.at_level(logging.ERROR,
                              logger='couchpotato.core.plugins.renamer.extractor'):
-            extracted = _Extractor().extractArchive('a.rar', str(extr_path))
+            with pytest.raises(_ArchiveTooLarge):
+                _Extractor().extractArchive('a.rar', str(extr_path))
 
-        assert extracted == [str(extr_path / 'good.mkv')], (
-            'a bomb entry aborted the archive; the good entry after it was '
-            'never extracted'
+        messages = '\n'.join(r.getMessage() for r in caplog.records)
+        assert 'per-entry size ceiling' not in messages, (
+            'an archive-wide budget abort was logged as a per-entry '
+            'oversized refusal'
         )
-        assert (extr_path / 'good.mkv').read_bytes() == b'real'
+
+
+class TestExtractFilesSkipsAnArchiveThatExceedsTheBudgetWithoutTagging:
+    """`extractFiles`' side of `_ArchiveTooLarge`: caught, logged with the
+    operator-facing budget numbers, and turned into a skip-not-tag exactly
+    like every other archive-level failure on this path (a bad archive, a
+    missing extractor tool), so the release is retried on a later scan
+    rather than silently marked complete with files missing."""
+
+    def test_the_archive_is_skipped_logged_and_not_tagged(self, tmp_path, caplog):
+        folder = tmp_path / 'downloads'
+        folder.mkdir()
+        archive = folder / 'Movie.One.2020.rar'
+        archive.write_bytes(b'not-a-real-rar')
+
+        fake = _FakeRenamer(from_folder=str(folder))
+        fake.extractArchive = MagicMock(
+            side_effect=_ArchiveTooLarge(written=200 * 1024 * 1024,
+                                          budget=144 * 1024 ** 3))
+
+        with caplog.at_level(logging.ERROR, logger='couchpotato.core.plugins.renamer.extractor'):
+            result_folder, media_folder, files, extr_files = fake.extractFiles(
+                folder=str(folder),
+                media_folder=str(folder),
+                files=[str(archive)],
+            )
+
+        assert extr_files == []
+        assert fake.tagged == [], (
+            'an archive that exceeded the per-archive budget was tagged as '
+            'extracted'
+        )
+        errors = [r.getMessage() for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert str(144 * 1024 ** 3) in errors[0], (
+            'the operator-facing message did not name the budget that was '
+            'exceeded'
+        )

--- a/tests/unit/test_extractor.py
+++ b/tests/unit/test_extractor.py
@@ -161,7 +161,6 @@ def _real_reader(filename, file_size):
     return _RealClampBackedReader(filename, file_size)
 
 
-
 @pytest.fixture(autouse=True)
 def _restore_unrar_tool():
     """extractArchive can mutate the module-global rarfile.UNRAR_TOOL; restore it."""


### PR DESCRIPTION
## What ships

A per-entry byte cap in `_extractOneAtomic`'s read loop: `_ENTRY_HARD_CAP` at 128 GiB, checked against **bytes actually written**, never against a header. A refused entry is skipped like the other entry-derived failures — keep the archive, count it, cap the log.

## What does NOT ship, and why that matters more than what does

**The archive-wide amplification is open debt, not fixed.** This guard bounds ONE entry. N entries each just under the cap still write N × 128 GiB combined, and every refused entry writes its full 128 GiB before being unlinked. That limitation is stated at the constant so nobody reads the guard as more than it is.

Two earlier designs on this branch were deleted because they could not fire. Recording both, since the pattern is the point:

**Round one** cross-checked bytes written against `info.file_size + 1 MiB`. Unreachable: `rarfile==4.5` already clamps every entry at its declared size (`RarExtFile.read()` does `elif n > self._remain: n = self._remain`, `_remain` from `file_size`). Measured with an unlimited underlying reader — declared 1024, handed out 1024. Three of its four tests passed only because the stub reader lacked the clamp, i.e. the fixture was more permissive than production. It was also actively unsafe: `CommonParser.open()` swaps `inf` for the original on RAR5 `FILE_COPY`/`HARD_LINK`, so a link entry declaring 0 got refused and the media file silently dropped.

**Round two** added a whole-archive budget. Also unreachable: `_extractOneAtomic` returned bytes only on success, so a refused entry contributed nothing, and the entry cap always tripped first (the archive cap sat 16 GiB above it). Measured at scaled constants: **26.7× the archive cap written with the running total still at zero**. Two further leaks in the same layer — the entry-derived `OSError` arm dropped bytes identically (10× the budget with no oversized entry at all), and the budget reset every scan, so a large archive extracted fully by scan 7 with `renamer.force_scan` running two-hourly.

Three independent leaks in one accounting layer is a wrong shape, not bad arithmetic. Reduced under CLAUDE.md rule 11 rather than attempted a third time.

**The unbuilt frame is recorded in the task** for whoever reopens it: `read()` clamps to `file_size`, and `file_redir` plus `getinfo()` resolve RAR5 copy and hard-link targets *from headers alone*, so the sum of resolved declared sizes is an exact upper bound computable before a single byte is written. A pre-flight refusal on that sum closes all three leaks at once, because nothing is written to leak.

## Severity, corrected by measurement

The task claimed the volume a bomb fills also holds the SQLite database. Measured on the production host, that is false:

```
/                     364G, 85G avail   <- database, settings, config.bak
/var/cache/sab (NAS)  44T,  1.9T avail  <- /downloads, the renamer's `from`
```

This is a download-share denial of service, not a route to irrecoverable data loss. Ranked accordingly.

## Evidence

- Guard mutation-proven: disabling `if written > _ENTRY_HARD_CAP` fails both entry-cap tests; restored byte-identical by hash; re-run green afterwards.
- **The shipped constant is pinned.** Previously raising it failed nothing because every test patched it. Verified: mutating 128 → 512 GiB fails `test_the_cap_is_128_gib` and nothing else, so value drift and mechanism breakage are caught separately.
- Fixture obeys the real contract: the reader subclasses `rarfile.RarExtFile` so rarfile's own `read()` runs, rather than reimplementing the clamp.
- Residue sweep clean: no `_ARCHIVE_HARD_CAP`, `_ArchiveTooLarge`, `archive_written` or `_ENTRY_SIZE_MARGIN` anywhere in `couchpotato/` or `tests/`.
- `scripts/verify.sh` full run, exit 0. `tests/unit`: 3564 passed, 2 skipped, 3 xfailed. `test_extractor.py`: 57.

## Review

Three rounds across two independent reviewers. Rounds one and two were both returned as unshippable, each having found the guard could not fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc