### PR TITLE
ci(review): route non-blocking findings to the summary, not inline threads

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -76,6 +76,22 @@ jobs:
             If you are unsure which a finding is, ask yourself whether you would
             block the merge over it. If the answer is no, it is an observation.
 
+            OBSERVATIONS MUST SURVIVE A RE-RUN, and this needs deliberate work
+            because the summary is a STICKY comment: `use_sticky_comment: true`
+            means each run REWRITES the single summary comment rather than
+            adding one. An inline thread persists until somebody resolves it;
+            a sticky body does not. So an observation you do not re-emit is
+            silently deleted, which would make this routing lose findings
+            rather than relocate them.
+
+            Before writing the summary, READ the existing one (`gh pr view` or
+            the comment tool). Then carry forward every observation from it
+            that the current diff has NOT addressed, alongside anything new you
+            find. If an earlier observation no longer applies because the code
+            changed, drop it and say so in one line ("resolved since last
+            review: ..."), so the author can see it was dealt with rather than
+            forgotten. Never drop one silently.
+
             Two things that are NOT exceptions to this. A finding you are
             uncertain about is still an observation until you can name the
             failure it causes. And if you retract or correct an earlier comment

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -76,21 +76,27 @@ jobs:
             If you are unsure which a finding is, ask yourself whether you would
             block the merge over it. If the answer is no, it is an observation.
 
-            OBSERVATIONS MUST SURVIVE A RE-RUN, and this needs deliberate work
-            because the summary is a STICKY comment: `use_sticky_comment: true`
-            means each run REWRITES the single summary comment rather than
-            adding one. An inline thread persists until somebody resolves it;
-            a sticky body does not. So an observation you do not re-emit is
-            silently deleted, which would make this routing lose findings
-            rather than relocate them.
+            OBSERVATIONS MUST SURVIVE A RE-RUN. Write for both cases rather
+            than assuming which one you are in, because this repo has been
+            wrong about it in both directions.
 
-            Before writing the summary, READ the existing one (`gh pr view` or
-            the comment tool). Then carry forward every observation from it
-            that the current diff has NOT addressed, alongside anything new you
-            find. If an earlier observation no longer applies because the code
-            changed, drop it and say so in one line ("resolved since last
-            review: ..."), so the author can see it was dealt with rather than
-            forgotten. Never drop one silently.
+            MEASURED 2026-08-20: despite `use_sticky_comment: true`, runs on
+            #277 and #279 each produced FIVE separate comments with distinct
+            ids and `created == updated`. The setting is inert in practice,
+            probably because the summary goes out through `gh pr comment`
+            rather than the sticky tool. So today, earlier summaries persist.
+
+            - If you are ADDING a new comment (what happens today): do not
+              repeat observations an earlier comment already carries and that
+              still stand. Say "earlier observations still apply" and list only
+              what is new, plus a "resolved since last review" line for any the
+              current diff has fixed.
+            - If you are UPDATING an existing summary in place: carry forward
+              every observation the diff has NOT addressed, because a rewrite
+              deletes anything you do not re-emit, and note the resolved ones
+              the same way.
+
+            Never drop an observation silently under either shape.
 
             Two things that are NOT exceptions to this. A finding you are
             uncertain about is still an observation until you can name the

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,10 +55,33 @@ jobs:
             PR NUMBER: ${{ github.event.pull_request.number }}
 
             Review the changes in this pull request as a principal engineer for
-            CouchPotatoServer (Python 3.10+ FastAPI media server; see CLAUDE.md
-            and AGENTS.md for project rules). Post specific findings as inline PR
-            review comments (mcp__github_inline_comment__create_inline_comment),
-            grouped by severity.
+            CouchPotatoServer (Python 3.14 FastAPI media server; see CLAUDE.md
+            and AGENTS.md for project rules).
+
+            WHERE A FINDING GOES DEPENDS ON WHETHER IT MUST CHANGE, and this
+            matters more than it looks. `required_conversation_resolution` is
+            enabled on master, so EVERY inline review thread is a merge gate,
+            including one you label "nit" or "not blocking". A thread costs a
+            reply, a resolution and a full re-run of twelve checks.
+
+            - Something that MUST change before merge (correctness, security,
+              a test that cannot fail, a broken contract): post it as an inline
+              review comment (mcp__github_inline_comment__create_inline_comment)
+              at the exact line. Say what breaks and under what input.
+            - Everything else (nits, style, praise, "consider", "worth knowing",
+              anything you would label low or non-blocking): put it in the
+              SUMMARY COMMENT BODY as a short bulleted "Observations" section,
+              naming file:line. Do NOT open an inline thread for it.
+
+            If you are unsure which a finding is, ask yourself whether you would
+            block the merge over it. If the answer is no, it is an observation.
+
+            Two things that are NOT exceptions to this. A finding you are
+            uncertain about is still an observation until you can name the
+            failure it causes. And if you retract or correct an earlier comment
+            of your own, put the correction in the summary body rather than
+            opening a second thread, because both threads then have to be
+            resolved by hand.
 
             Focus on:
             - Correctness and edge cases, especially around the SQLite adapter
@@ -72,6 +95,10 @@ jobs:
 
             ALWAYS post a brief summary comment with an explicit overall verdict —
             start it with `✅ LGTM` or `⚠️ Changes requested` — even when there
-            are no issues, so the review is clearly visible. Be specific and
+            are no issues, so the review is clearly visible. Follow the verdict
+            with the "Observations" section if you have any. Be specific and
             actionable; if the change is safe and complete, say so plainly rather
             than inventing nits.
+
+            A review that blocks on nothing and observes three things is a good
+            review, not a lazy one.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -98,12 +98,22 @@ jobs:
 
             Never drop an observation silently under either shape.
 
-            Two things that are NOT exceptions to this. A finding you are
-            uncertain about is still an observation until you can name the
-            failure it causes. And if you retract or correct an earlier comment
-            of your own, put the correction in the summary body rather than
-            opening a second thread, because both threads then have to be
-            resolved by hand.
+            ONE CARVE-OUT, AND IT IS NOT OPTIONAL: an uncertain SECURITY,
+            PRIVACY or DATA-LOSS finding goes INLINE, not into observations.
+            Everywhere else, uncertainty downgrades to an observation until you
+            can name the failure it causes. Here it does the opposite, because
+            the cost is asymmetric: a wrong inline thread costs one reply, and
+            a missed credential leak or data-loss path costs the user something
+            they cannot get back. Measured on this repo, an inline thread is
+            the ONLY content-aware block on master -- there are zero required
+            approving reviews, and of twelve required contexts only this one
+            reads semantics -- so an observation is advisory and nothing else.
+            If you are unsure whether a finding is in this class, treat it as
+            though it is.
+
+            If you retract or correct an earlier comment of your own, put the
+            correction in the summary body rather than opening a second thread,
+            because both threads then have to be resolved by hand.
 
             Focus on:
             - Correctness and edge cases, especially around the SQLite adapter

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,16 @@ Review at minimum for:
 - Performance: avoid unnecessary client JavaScript, slow or unbounded queries, blocking startup work, excessive polling, expensive rendering, and changes that make the UI feel heavy on lower-powered home servers.
 - Deployment and operations: Docker, compose files, environment variables, health checks, persistent volumes, restart behaviour, release workflows, dependency submission, and production build compatibility.
 
+**A finding class that recurs across rounds is a mechanism request, not a review finding.**
+
+If the same KIND of defect comes back in a second or third round on one pull request, stop reporting instances and ask for the check instead. Standard 9 says a rule that can be a lint rule, a test or a guard script should be one, and a reviewer who keeps finding new instances of a class is the signal that it is not.
+
+Measured on #279, which is why this is written down. That change set out to stop a backup policy drifting between the two files that state it. Review then found the same class six times: a category in one copy and not the other, a third paraphrase in `CLAUDE.md`, a fourth in `usage()`'s heredoc, a fifth in the deploy runbook. Each was fixed by hand, each round cost a re-run of twelve checks, and it ended only when the seventh round produced a test asserting the copies agree. That test now catches all six forms, and would have caught them in round one.
+
+Four review rounds is the most expensive possible route to "this wants a mechanism". So: when you notice you are writing the same finding again in different words, say so explicitly, and propose the check that would make the class impossible rather than listing the next instance.
+
+The corollary matters too. A reviewer who finds one instance of a class should say whether they expect more, because "here is the third of these" is information the author does not have and the reviewer does.
+
 Treat these as high-priority review findings:
 
 - Any privacy leak, secret leak, or exposure of personal media paths, credentials, API keys, or local-network details.

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -2952,7 +2952,45 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       Whoever takes this: read T44's history first. Two guards shipped that
       could not fire, and both looked correct in review.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T54, T55, T57, T58, T59, T60, T61 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
+- [ ] T63: `claude-review` reports green on PRs where it never ran — state: queued (no deps) — **security, false green**
+
+      Found by `lens-operability` during the first `/review-cycle` run, and
+      confirmed by measurement on #281.
+
+      GitHub declines to run a workflow from a pull request that modifies that
+      workflow's own file. `claude-review` is a REQUIRED status check. So on
+      any PR touching `.github/workflows/claude-review.yml`, the check reports
+      success while the reviewer never executed:
+
+          #281 (edits claude-review.yml)  -> claude-review check: PASS
+          claude[bot] comments on #281    -> 0
+
+      That is a required gate returning green for a review that did not happen,
+      which is the precise shape this plan keeps recording. It is worse than
+      the usual instance because the gate is the thing that is supposed to
+      notice, and because the PRs it silently exempts are exactly the ones
+      changing the reviewer.
+
+      Two consequences worth separating. The obvious one is that no change to
+      the review prompt can ever be verified before it merges, so the first
+      real exercise of any prompt change is on the NEXT pull request. The
+      sharper one is that an attacker or a careless edit could weaken the
+      review prompt, and the check guarding that change would pass without
+      objection.
+
+      The fix is not to make the workflow run on itself, which is the security
+      property GitHub is deliberately enforcing. It is to make the false green
+      impossible to mistake for a real one: have the job detect that it is
+      running against a PR which edits its own definition and fail, or post an
+      explicit "review skipped, workflow modified by this PR" comment, so the
+      absence is visible rather than inferred. A skipped review must not be
+      indistinguishable from a clean one.
+
+      Note this is the same distinction the harness ledger got wrong on the
+      same day: "no trace" and "not looked" must be distinguishable in the
+      output, or the instrument reproduces the class it exists to detect.
+
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T54, T55, T57, T58, T59, T60, T61, T63 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
       **Add to its scope (2026-08-18):** citations that rot. This session
       converted three-line-number citations into a third-party package and
       several stale line references into symbol citations, for one reason:

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -2965,6 +2965,27 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
           #281 (edits claude-review.yml)  -> claude-review check: PASS
           claude[bot] comments on #281    -> 0
 
+      The job log carries the reason 568 lines in, where nobody looks:
+
+          ##[warning]Skipping action due to workflow validation: the workflow
+          file must exist and have identical content to the version on the
+          repository's default branch.
+          Exiting due to workflow validation skip
+
+      Runs on such a branch complete in 13-17 seconds against about four
+      minutes for a real review, which is the cheapest available tell and
+      nothing reads it.
+
+      **Recurring, not a one-off: four for four.** PRs #129, #132 and #149 each
+      edited this file and each carries ZERO `claude[bot]` comments, alongside
+      #281. Two of those were themselves fixes to the reviewer -- #129's
+      "always post a visible verdict" and #132's `permission_denials` fix --
+      so the changes least able to afford going unreviewed are precisely the
+      ones that did.
+
+      The behaviour is also undocumented: grepping `docs/`, `CLAUDE.md`,
+      `AGENTS.md` and this file for "workflow validation" returns nothing.
+
       That is a required gate returning green for a review that did not happen,
       which is the precise shape this plan keeps recording. It is worse than
       the usual instance because the gate is the thing that is supposed to
@@ -2980,11 +3001,19 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
 
       The fix is not to make the workflow run on itself, which is the security
       property GitHub is deliberately enforcing. It is to make the false green
-      impossible to mistake for a real one: have the job detect that it is
-      running against a PR which edits its own definition and fail, or post an
-      explicit "review skipped, workflow modified by this PR" comment, so the
-      absence is visible rather than inferred. A skipped review must not be
-      indistinguishable from a clean one.
+      impossible to mistake for a real one.
+
+      **And it must NOT simply fail the job.** Review raised that explicitly:
+      failing deadlocks every future edit to this workflow, since the only way
+      to fix the file would be a PR that the gate now blocks. The workable
+      shape is a step with `if: always()` after the action that detects the
+      skip -- by the validation warning, or by re-querying for a `claude[bot]`
+      comment on the head SHA -- and posts "claude-review was SKIPPED because
+      this PR edits the workflow file; review it by other means before merge".
+      Record the constraint beside the required-contexts list in
+      `docs/development-process.md`.
+
+      A skipped review must not be indistinguishable from a clean one.
 
       Note this is the same distinction the harness ledger got wrong on the
       same day: "no trace" and "not looked" must be distinguishable in the


### PR DESCRIPTION
## Why

Measured by a peer session across PRs 275-280, reading the comments rather than counting them:

| reviewer | high/P1 | med/P2 | nit / low / non-blocking | total |
|---|---|---|---|---|
| codex | 7 | 6 | 0 | 13 |
| claude[bot] | 4 | 11 | **29** | 51 |

`required_conversation_resolution` is enabled on master, so **every inline thread is a merge gate — including one labelled "not blocking".** Each costs a reply, a resolution, and a re-run of twelve checks.

The sharpest example is not cherry-picked: `couchpotato/core/settings.py:631` on #275 carries four separate blocking threads, three of them self-labelled "Low / informational — not blocking".

And the cycles are not buying detection. Across 19 merged PRs: **14 passed their first CI wave clean, yet 15 needed more than one wave (median 3, max 13), with a median of zero failed runs.** CI is re-confirming the same passing code while review threads iterate.

## What changed

The prompt splits on one question: **must this change before merge?**

- **Yes** → inline comment at the line, naming what breaks and under what input.
- **No** → an `Observations` bullet in the summary body, naming `file:line`. No thread.

Two specifics from observed cases: self-retractions go to the summary (#277 had a thread that existed solely because the reviewer retracted its own probe), and an explicit line that a review blocking on nothing while observing three things is a *good* review — without it, "put nits in the summary" reads as "find fewer things", swapping noise for blindness.

`AGENTS.md` also gains the rule that **a finding class recurring across rounds is a mechanism request, not a review finding**, with #279 as the worked example: six rounds of one policy list drifting, ended only when round seven produced a test that catches all six forms. Plus the corollary that matters more — whoever finds the *first* instance should say whether they expect others, since a rule that fires on recurrence cannot fire until round two, and round two is already the expensive one.

## Corrected after review

An earlier version of this description claimed "nothing is lost". **That was false and review caught it.** `use_sticky_comment: true` means the summary is a single comment *rewritten* each run, so an observation the next run does not independently rediscover is silently deleted — trading noisy-but-persistent for quiet-but-ephemeral, which is worse because it is invisible. `17dd39fa` fixes it: the reviewer must read the existing summary, carry forward every observation the diff has not addressed, and announce any it drops as "resolved since last review" rather than dropping it silently.

Also corrects the prompt's `Python 3.10+` to `3.14`, which is what production ships and the only version CI tests.

## What this deliberately does not do

It does not touch branch protection or move AI review before the PR. That changes what can merge to master and needs explicit agreement, not inference. On the evidence it may not be needed at all: if this routing drops CI waves toward 1-2 over the next several PRs, that recommendation closes rather than ships.

## Risk

Prompt and docs only, no logic. Reversible by reverting two commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc