### PR TITLE
T57: strip git's whole GIT_* namespace in the test fixtures, instead of a six-name denylist

### DIFF
--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -3019,46 +3019,108 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       same day: "no trace" and "not looked" must be distinguishable in the
       output, or the instrument reproduces the class it exists to detect.
 
-- [ ] T62: the pre-push hook gates a commit that may not be the one pushed — state: queued (no deps) — **process, undermines hard rule 2**
+- [ ] T62: the pre-push gate validates the working tree, not the commit being pushed — state: queued (no deps) — **process, weakens hard rule 2**
 
-      Observed twice on 2026-08-20, on the same branch, and reproducible.
+      **Reframed 2026-08-24 after review disproved the original mechanism, and
+      the disproof is worth more than the entry was.** This was first recorded
+      as "git sends whatever the ref resolves to at send time", so a commit
+      made during the twenty-minute hook would be pushed ungated. That is
+      false. Measured directly: a bare origin, a `pre-push` that records its
+      stdin and sleeps, a commit made while it slept.
 
-      `git push` reported `ee3ea2af..6dc67488` while the remote ended up at
-      `4a0a405b`. The earlier occurrence was the same shape:
-      `b51d10db...23705812` reported, `810f7c5d` on the remote. Both times the
-      extra commit was made WHILE the hook was still running, which on this
-      repo is a twenty-minute window because the gate includes E2E.
+          commit before the push started : 439fe10c
+          commit made DURING the hook     : d4cdde2d
+          hook stdin saw                  : 439fe10c
+          remote ended at                 : 439fe10c
 
-      **Mechanism, measured rather than guessed.** Git passes each ref being
-      pushed to `pre-push` on stdin as
-      `<local ref> <local sha> <remote ref> <remote sha>`. `.githooks/pre-push`
-      never reads stdin: `grep -n "stdin\|while read"` returns nothing, and its
-      only ref handling is `git rev-parse --show-toplevel`. So it gates the
-      working tree as it stands when the hook runs, and git then sends whatever
-      the ref resolves to at send time. Those are the same commit only if
-      nothing lands in between.
+      Git snapshots the update before invoking `pre-push` and pushes that
+      snapshot. The later commit stayed local. Credit to the codex reviewer on
+      #282, who reproduced the same result independently on git 2.43.0 and
+      said so against a plan entry asserting the opposite.
 
-      **Why this matters more than it looks.** CLAUDE.md rule 2 says the gate
-      must pass locally before every push, and the hook is what makes that
-      enforced rather than remembered. A gate that validates a different commit
-      from the one it lets through is the exact shape this plan keeps
-      recording: it looks like protection, it exits zero, and the thing it
-      exists to stop goes past it. Both observed instances were docs-only and
-      harmless, which is luck, not design. Committing during a twenty-minute
-      hook is a completely ordinary thing to do.
+      **The observed symptom therefore still has no explanation.** Two pushes
+      on 2026-08-20 reported one range and left the remote at a different sha
+      (`ee3ea2af..6dc67488` reported, `4a0a405b` on the remote;
+      `b51d10db...23705812` reported, `810f7c5d` on the remote). Whatever
+      caused that, it is not this. Do not close this task by re-testing the
+      disproved mechanism and finding it absent. Candidate causes worth
+      checking first: a second push racing from another session or worktree
+      (several share this checkout), a `--force-with-lease` retry, or the
+      branch being updated server-side by a squash merge between the report
+      and the observation.
 
-      The fix is to gate what is actually being pushed. Read the sha from
-      stdin, or capture `git rev-parse HEAD` at hook start and refuse the push
-      if HEAD has moved by the time the gate finishes. The second is cruder and
-      may be the better fit here, since the gate runs against the working tree
-      rather than an arbitrary commit, and "HEAD moved under the gate" is a
-      clearer refusal than silently re-running.
+      **What IS wrong, and is the reason this stays open.** `.githooks/pre-push`
+      never reads its stdin (`grep -n "stdin\|while read"` returns nothing;
+      its only ref handling is `git rev-parse --show-toplevel` at line 11). It
+      runs `make verify` against the WORKING TREE as it stands while the hook
+      runs. The commit being pushed is fixed at that moment, but the working
+      tree is not: an edit or a commit during the twenty-minute gate means
+      `verify` tested content that is not what is being sent, and a dirty tree
+      means it never was. The gate passes and reports on something other than
+      the artefact. That is a weaker claim than the original entry made, and
+      unlike the original it is true.
 
-      Prove it by reproducing: start a push, commit during the hook, and assert
-      the push is refused. A guard for this that has not been watched to fail
-      is worth nothing, which is the whole reason this entry exists.
+      The fix is to gate the thing being pushed: read the sha from stdin and
+      verify that, or capture `git rev-parse HEAD` plus a dirty-tree check at
+      hook start and refuse if either moved by the time the gate finishes.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T54, T55, T58, T59, T60, T61, T62, T63 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
+      Prove it by reproducing: start a push, modify the tree during the hook,
+      and assert the push is refused. A guard for this that has not been
+      watched to fail is worth nothing.
+
+- [ ] T64: the fixture scrub discards untrusted git config without installing trusted config — state: queued (no deps) — **security, carried over from T57**
+
+      Raised as P1 and P2 by the codex reviewer on #282 and split out rather
+      than fixed there, deliberately, under CLAUDE.md rule 11: T57 had already
+      had three fix rounds, and this is a NEW CLASS rather than another
+      instance of the one being fixed. Rule 11 says that is the signal to
+      re-open the approach, not to spend a fourth round.
+
+      T57 made the fixtures strip git's whole `GIT_*` namespace, keeping only
+      the commit-identity prefixes. The axis for that allowlist was "does this
+      change what a commit RECORDS, or where it LANDS / what it RUNS". That
+      question cannot see a third category: variables that PROTECT.
+
+      `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_NOSYSTEM=1` are how a
+      caller isolates git from `~/.gitconfig` and `/etc/gitconfig`. Both start
+      with `GIT_`, so the namespace strip deletes them. A suite launched WITH
+      those protections loses them at import, and subsequent fixture commits
+      then read ambient global and system config again -- including a global
+      `core.hooksPath`, which the reviewer reproduced executing after importing
+      the conftest even though the same hook was suppressed before it.
+
+      Note carefully what this is and is not. It does NOT make the suite worse
+      than before T57: nothing in this repo sets those variables today, and the
+      six-name denylist did not preserve them either. It is a gap T57 declined
+      to close, not one it opened. But the whole argument for a namespace rule
+      is that it is right about variables nobody has thought of yet, and this
+      is a class it is wrong about.
+
+      The fix is the reviewer's, and it is one line of principle: after
+      discarding untrusted `GIT_*` values, INSTALL trusted ones. Set
+      `GIT_CONFIG_GLOBAL=/dev/null`, `GIT_CONFIG_NOSYSTEM=1` (and the XDG path)
+      on the way out of the scrub, so the fixtures run in a known configuration
+      rather than merely a known-empty environment.
+
+      **Second instance, same root, in the tests rather than the code.** The
+      positive control in `tests/unit/test_git_env_namespace_scrub.py` carries
+      the ambient `HOME` on purpose, so it can still detect a platform that
+      declines to run hooks. The cost is that a developer or CI account with a
+      global `core.hooksPath` sees the control fail for an environmental reason
+      unrelated to the change. Both reviewers are right and they are answering
+      different questions: the control SHOULD be loud about hooks being
+      disabled, and it should NOT be at the mercy of whoever's account runs it.
+      Installing trusted config resolves both, because the control can then
+      assert on a configuration it set rather than one it inherited. Fix the
+      two together; fixing either alone will look complete and will not be.
+
+      The control's environment has now been rewritten three times on #282
+      (raw ambient, then sanitised, then a literal dict). Whoever takes this
+      should read that history before touching it a fourth time, and should
+      change the axis rather than the values.
+
+
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T54, T55, T58, T59, T60, T61, T62, T63, T64 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
       **Add to its scope (2026-08-18):** citations that rot. This session
       converted three-line-number citations into a third-party package and
       several stale line references into symbol citations, for one reason:

--- a/specs/REMEDIATION-2026-08.md
+++ b/specs/REMEDIATION-2026-08.md
@@ -2788,7 +2788,7 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       job, and it is exactly the sort of thing that would have been discovered
       the hard way at 2am.
 
-- [ ] T57: the git-env denylist protecting the unit fixtures is enumerated on the wrong axis — state: queued (no deps) — **security, test-infrastructure**
+- [x] T57: the git-env denylist protecting the unit fixtures is enumerated on the wrong axis — state: **fixed** (2026-08-23) — **security, test-infrastructure**
 
       Raised by a peer session working on the same harness, and confirmed here
       by measurement rather than taken on report.
@@ -3019,7 +3019,46 @@ Conductor checklist. States: `queued -> building -> pr-open #N -> awaiting-ci #N
       same day: "no trace" and "not looked" must be distinguishable in the
       output, or the instrument reproduces the class it exists to detect.
 
-- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T54, T55, T57, T58, T59, T60, T61, T63 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
+- [ ] T62: the pre-push hook gates a commit that may not be the one pushed — state: queued (no deps) — **process, undermines hard rule 2**
+
+      Observed twice on 2026-08-20, on the same branch, and reproducible.
+
+      `git push` reported `ee3ea2af..6dc67488` while the remote ended up at
+      `4a0a405b`. The earlier occurrence was the same shape:
+      `b51d10db...23705812` reported, `810f7c5d` on the remote. Both times the
+      extra commit was made WHILE the hook was still running, which on this
+      repo is a twenty-minute window because the gate includes E2E.
+
+      **Mechanism, measured rather than guessed.** Git passes each ref being
+      pushed to `pre-push` on stdin as
+      `<local ref> <local sha> <remote ref> <remote sha>`. `.githooks/pre-push`
+      never reads stdin: `grep -n "stdin\|while read"` returns nothing, and its
+      only ref handling is `git rev-parse --show-toplevel`. So it gates the
+      working tree as it stands when the hook runs, and git then sends whatever
+      the ref resolves to at send time. Those are the same commit only if
+      nothing lands in between.
+
+      **Why this matters more than it looks.** CLAUDE.md rule 2 says the gate
+      must pass locally before every push, and the hook is what makes that
+      enforced rather than remembered. A gate that validates a different commit
+      from the one it lets through is the exact shape this plan keeps
+      recording: it looks like protection, it exits zero, and the thing it
+      exists to stop goes past it. Both observed instances were docs-only and
+      harmless, which is luck, not design. Committing during a twenty-minute
+      hook is a completely ordinary thing to do.
+
+      The fix is to gate what is actually being pushed. Read the sha from
+      stdin, or capture `git rev-parse HEAD` at hook start and refuse the push
+      if HEAD has moved by the time the gate finishes. The second is cruder and
+      may be the better fit here, since the gate runs against the working tree
+      rather than an arbitrary commit, and "HEAD moved under the gate" is a
+      clearer refusal than silently re-running.
+
+      Prove it by reproducing: start a push, commit during the hook, and assert
+      the push is refused. A guard for this that has not been watched to fail
+      is worth nothing, which is the whole reason this entry exists.
+
+- [ ] T18: a final sweep for dead code, dead docs and dead instructions — state: queued (needs: **every other open task** — T6, T7, T8, T11, T15, T20, T21, T23, T25, T32, T34, T37, T38, T39, T40, T41, T43, T44, T45, T47, T49, T50, T54, T55, T58, T59, T60, T61, T62, T63 — because each adds residue and several rewrite the code this would sweep. Deliberately phrased as "every other open task" FIRST and enumerated second: the list has now gone stale FOUR times by enumeration alone (count reconciled 2026-08-19; the running total in this clause had itself gone stale, which review caught). T19 was omitted by the very commit that wrote this line; T20, T21 and T22 were then added by later tasks and omitted again, caught in review of #249 — which is the same failure this parenthesis already described, reproduced while describing it. T13, T14, T17, T19 and T22 have since merged and are dropped from the list. T29 and T30 closed by removal (2026-08-12), not by a fix, and are dropped too. **Third incident, 2026-08-19, and both directions at once:** the commit that ticked T36 left it named here as open, and the same commit added T45 without listing it. Caught in review, not by the author — which is the third time this parenthesis has been proved right by the commit editing it. The enumeration is the defect; the phrase "every other open task" is the contract, and any reader should trust that phrase over the list that follows it. **That advice is now out of date in one direction and worth reading with the correction:** since 2026-08-19 the list is the machine-checked artefact, pinned in both directions by `tests/unit/test_plan_needs_list.py`, while the phrase is the half nothing verifies. The task-line format `- [ ] Tn:` is load-bearing to that check, so anyone reformatting a task line must change the test in the same commit or silently blind it.)
       **Add to its scope (2026-08-18):** citations that rot. This session
       converted three-line-number citations into a third-party package and
       several stale line references into symbol citations, for one reason:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,20 @@ import os as _os
 # it ambiently -- every commit this suite scripts today sets identity
 # explicitly via `git config user.*` or `-c`, so the allowlist is a floor
 # for a future caller, not a fix for an existing dependency.
+#
+# What that carve-out COSTS, recorded because review measured it rather than
+# leaving it implied. `git commit` exports GIT_AUTHOR_NAME/EMAIL/DATE into
+# its own hook environment, and for git, environment beats `git config`. So
+# in that one scenario the allowlist lets an ambient identity OVERRIDE the
+# identity a fixture set explicitly, and an ambient malformed
+# GIT_COMMITTER_DATE fails every scripted commit outright. Neither is live:
+# `.githooks/` holds only `pre-push`, no test asserts on author, committer
+# or date, and nothing in the tree sets these. The strict alternative --
+# strip GIT_* with no exception at all -- is one rule instead of a rule plus
+# an exception, and closes the last GIT_* class that can alter a fixture
+# commit. It is not taken here because T57 specified the identity carve-out
+# and it is the honest reading of the axis this rule is built on, but the
+# trade is real and belongs in writing rather than in a reviewer's head.
 GIT_IDENTITY_ENV_PREFIXES = (
     'GIT_AUTHOR_',
     'GIT_COMMITTER_',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,8 +68,12 @@ import os as _os
 # in that one scenario the allowlist lets an ambient identity OVERRIDE the
 # identity a fixture set explicitly, and an ambient malformed
 # GIT_COMMITTER_DATE fails every scripted commit outright. Neither is live:
-# `.githooks/` holds only `pre-push`, no test asserts on author, committer
-# or date, and nothing in the tree sets these. The strict alternative --
+# `.githooks/` holds only `pre-push`, nothing in the tree sets these, and no
+# test asserts on the author, committer or date of a commit made by `git`.
+# `test_updater.py:112` does assert on `author_time`, which looks like a
+# counter-example and is not: that commit is made by dulwich in-process with
+# author and committer passed explicitly, and dulwich was measured ignoring
+# the ambient values outright. The strict alternative --
 # strip GIT_* with no exception at all -- is one rule instead of a rule plus
 # an exception, and closes the last GIT_* class that can alter a fixture
 # commit. It is not taken here because T57 specified the identity carve-out

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,9 @@
 import os as _os
 
 # ---------------------------------------------------------------------------
-# Remove git's location variables from the ENTIRE test process, once, before
-# anything is collected.
+# Remove git's entire GIT_* namespace from the ENTIRE test process, once,
+# before anything is collected -- except the commit-identity variables in
+# GIT_IDENTITY_ENV_PREFIXES.
 #
 # This is the layer that actually closes the class, and it exists because
 # per-call sanitisation did not. Git exports GIT_DIR into hook subprocesses
@@ -23,22 +24,50 @@ import os as _os
 # So remove the hazard instead of policing the callers. With these unset in
 # `os.environ`, every subprocess inherits a clean environment by construction,
 # whatever shape the call takes and whether or not its author ever heard of
-# this module. `sanitized_git_env()` and the AST guard remain as defence in
-# depth, not as the primary protection.
+# this module. `sanitized_git_env()` (in `tests/unit/conftest.py`) and the
+# AST guard remain as defence in depth, not as the primary protection.
 #
-# Safe to do unconditionally: nothing in this suite reads GIT_DIR, and git
+# T57 follow-up: this loop originally denied the same six "location"
+# variables `sanitized_git_env()` used to deny, on the same wrong axis --
+# "what redirects the repository". That missed GIT_CONFIG_PARAMETERS
+# (exported by `git -c foo=bar <cmd>` into every subprocess it spawns) and
+# GIT_TEMPLATE_DIR (arbitrary code execution via a hook copied from the
+# template dir and run during the next commit -- not a location variable at
+# all, so no denylist on that axis would ever have named it). See the T57
+# comment in `tests/unit/conftest.py` above GIT_IDENTITY_ENV_PREFIXES for the
+# full argument and the measurement behind it.
+#
+# The rule -- strip the whole GIT_* namespace, keep only commit identity --
+# is defined ONCE, in GIT_IDENTITY_ENV_PREFIXES below, and both this
+# process-wide pop and `sanitized_git_env()`'s per-call copy apply it. The
+# two APPLICATIONS stay separate on purpose: this one mutates `os.environ`
+# directly for the whole process and must run before anything else is
+# imported or collected, while `sanitized_git_env()` returns a fresh copy on
+# each call for an explicit `env=`. Forcing them into one shared function
+# would make one of the two shapes wrong; sharing the tuple is what actually
+# matters, because that is the part that would otherwise drift.
+#
+# Safe to do unconditionally: nothing in this suite reads ANY GIT_* variable
+# -- swept 2026-08-20 across the whole tree with
+# `grep -rn "GIT_" --include='*.py' --include='*.sh' --include='*.yml' \
+#   --include='*.yaml' .`, excluding `.venv`/`.git`, and again with no
+# extension filter at all; every hit outside the conftest/guard files
+# themselves is documentation in `specs/REMEDIATION-2026-08.md` -- and git
 # falls back to discovery from `cwd`, which is what every call already
 # intends. Tests that mean to query the real repo pass `cwd=REPO_ROOT` and
-# keep working.
-for _var in (
-    'GIT_DIR',
-    'GIT_WORK_TREE',
-    'GIT_INDEX_FILE',
-    'GIT_OBJECT_DIRECTORY',
-    'GIT_COMMON_DIR',
-    'GIT_ALTERNATE_OBJECT_DIRECTORIES',
-):
-    _os.environ.pop(_var, None)
+# keep working. Commit identity is kept back because the RULE says it is
+# safe to (it changes what a commit records, not where an operation lands or
+# what runs), not because anything currently measured relies on inheriting
+# it ambiently -- every commit this suite scripts today sets identity
+# explicitly via `git config user.*` or `-c`, so the allowlist is a floor
+# for a future caller, not a fix for an existing dependency.
+GIT_IDENTITY_ENV_PREFIXES = (
+    'GIT_AUTHOR_',
+    'GIT_COMMITTER_',
+)
+for _var in list(_os.environ):
+    if _var.startswith('GIT_') and not _var.startswith(GIT_IDENTITY_ENV_PREFIXES):
+        _os.environ.pop(_var, None)
 
 import json
 import os

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,11 +11,11 @@ import pytest
 
 from couchpotato.core.logger import reset_log_suppression
 
-# Git sets GIT_DIR (and its siblings below) in the environment of hook
-# subprocesses launched from a `git worktree` checkout -- but not from the
-# main checkout. `pre-push` runs `make verify`, which runs this suite, so a
-# push made from a worktree hands every test process a GIT_DIR naming that
-# worktree's real `.git`.
+# Git sets GIT_DIR (and its siblings) in the environment of hook subprocesses
+# launched from a `git worktree` checkout -- but not from the main checkout.
+# `pre-push` runs `make verify`, which runs this suite, so a push made from a
+# worktree hands every test process a GIT_DIR naming that worktree's real
+# `.git`.
 #
 # Any test that shells out to `git init`/`commit`/`checkout -b` inside a
 # throwaway `tmp_path` MUST strip these first: with GIT_DIR set, `git init`
@@ -25,17 +25,51 @@ from couchpotato.core.logger import reset_log_suppression
 # developer checkout got a fixture branch, two fixture commits, and
 # `core.bare` flipped to true.
 #
+# T57 follow-up: the original fix here was a DENYLIST of six "location"
+# variables -- GIT_DIR and its siblings -- built on the axis "what redirects
+# the repository". That is the wrong axis, and it missed two real escapes:
+#
+#   1. GIT_CONFIG_PARAMETERS. `git -c foo=bar <cmd>` EXPORTS this into the
+#      environment of every subprocess it spawns, so `git -c ... push` run
+#      from a worktree hands the suite arbitrary config, which then rides
+#      into every later git call the suite makes -- same trigger as the
+#      GIT_DIR leak above, one name the six-item list never had.
+#
+#   2. GIT_TEMPLATE_DIR is not a location variable at all -- it names a
+#      directory whose `hooks/` are COPIED into every repo `git init`
+#      creates from that template, and then RUN. No denylist built on "what
+#      redirects the repository" would ever have contained it, because
+#      redirection was never the axis that made it dangerous. Measured, not
+#      reasoned: a template dir with an executable `hooks/pre-commit`, then
+#      `GIT_TEMPLATE_DIR=../tmpl git init -q .` followed by a seed commit,
+#      copied the hook into the new repo AND EXECUTED it during that commit.
+#      Every throwaway repo this suite creates would have run it.
+#
+# The property that actually matters is not "what redirects the repository",
+# and not quite "what git exports" either -- GIT_TEMPLATE_DIR is dangerous
+# and git does not export it, the operator (or an attacker) sets it. The
+# property is what git READS from the environment, which is a superset of
+# both. A denylist on that axis can never be finished: it is wrong again the
+# day git adds a new variable, and nothing announces that a new one shipped.
+# A namespace rule excludes the new one automatically, the day it ships,
+# with no update required here.
+#
+# So `sanitized_git_env()` now strips the WHOLE `GIT_*` namespace and allows
+# back only the commit-identity variables named in
+# GIT_IDENTITY_ENV_PREFIXES below. Those change what a commit RECORDS
+# (author/committer name, email, date), never where an operation LANDS or
+# what git EXECUTES, which is the distinction that makes them safe to let
+# through.
+#
 # Deliberately a plain function, not a fixture and not autouse: importing it
 # is each caller's explicit choice, so it carries none of the blast radius
 # the autouse fixtures above do across this file's ~150+ dependents. See
-# `tests/unit/test_fixtures_do_not_leak_gitdir.py`.
-GIT_LOCATION_ENV_VARS = (
-    'GIT_DIR',
-    'GIT_WORK_TREE',
-    'GIT_INDEX_FILE',
-    'GIT_OBJECT_DIRECTORY',
-    'GIT_COMMON_DIR',
-    'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+# `tests/unit/test_fixtures_do_not_leak_gitdir.py` (the GIT_DIR leak and the
+# call-site audit) and `tests/unit/test_git_env_namespace_scrub.py` (this
+# namespace rule).
+GIT_IDENTITY_ENV_PREFIXES = (
+    'GIT_AUTHOR_',
+    'GIT_COMMITTER_',
 )
 
 
@@ -84,13 +118,22 @@ def assert_git_dir_is(directory, env=None):
 
 
 def sanitized_git_env():
-    """A copy of the current environment with git's location variables
-    removed -- pass as `env=` to any subprocess `git` call (or any script
-    that itself shells out to `git`, e.g. `needs_e2e.sh`) that must operate
-    on an explicit `cwd` rather than wherever the ambient GIT_DIR points."""
+    """A copy of the current environment with git's entire `GIT_*` namespace
+    removed, except the commit-identity variables in
+    GIT_IDENTITY_ENV_PREFIXES -- pass as `env=` to any subprocess `git` call
+    (or any script that itself shells out to `git`, e.g. `needs_e2e.sh`) that
+    must operate on an explicit `cwd` rather than wherever the ambient
+    environment redirects or configures it to.
+
+    A namespace strip, not a denylist of known-dangerous names: see the
+    comment above GIT_IDENTITY_ENV_PREFIXES for why the axis matters and what
+    a fixed list of names misses -- concretely, GIT_CONFIG_PARAMETERS and
+    GIT_TEMPLATE_DIR, neither of which a "what redirects the repository"
+    denylist would ever have named."""
     env = os.environ.copy()
-    for var in GIT_LOCATION_ENV_VARS:
-        env.pop(var, None)
+    for key in list(env):
+        if key.startswith('GIT_') and not key.startswith(GIT_IDENTITY_ENV_PREFIXES):
+            env.pop(key, None)
     return env
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,6 +10,7 @@ import os
 import pytest
 
 from couchpotato.core.logger import reset_log_suppression
+from tests.conftest import GIT_IDENTITY_ENV_PREFIXES
 
 # Git sets GIT_DIR (and its siblings) in the environment of hook subprocesses
 # launched from a `git worktree` checkout -- but not from the main checkout.
@@ -56,21 +57,27 @@ from couchpotato.core.logger import reset_log_suppression
 #
 # So `sanitized_git_env()` now strips the WHOLE `GIT_*` namespace and allows
 # back only the commit-identity variables named in
-# GIT_IDENTITY_ENV_PREFIXES below. Those change what a commit RECORDS
-# (author/committer name, email, date), never where an operation LANDS or
-# what git EXECUTES, which is the distinction that makes them safe to let
-# through.
+# GIT_IDENTITY_ENV_PREFIXES, imported above from `tests/conftest.py` rather
+# than redefined here. Those change what a commit RECORDS (author/committer
+# name, email, date), never where an operation LANDS or what git EXECUTES,
+# which is the distinction that makes them safe to let through.
+#
+# Imported, not redefined, because `tests/conftest.py` holds the OTHER
+# application of this same rule -- a process-wide `os.environ` pop that runs
+# before collection -- and T57's own argument is that a rule stated twice
+# goes stale the moment one copy is updated and the other is not. That
+# import is safe: pytest collects the root conftest before this one, and
+# both `tests/` and `tests/unit/` are packages via `__init__.py`, so
+# `import tests.conftest` here resolves to the module pytest already loaded
+# rather than re-running its module-level scrub. See that file's own comment
+# for the process-wide pop this constant also drives.
 #
 # Deliberately a plain function, not a fixture and not autouse: importing it
 # is each caller's explicit choice, so it carries none of the blast radius
 # the autouse fixtures above do across this file's ~150+ dependents. See
 # `tests/unit/test_fixtures_do_not_leak_gitdir.py` (the GIT_DIR leak and the
 # call-site audit) and `tests/unit/test_git_env_namespace_scrub.py` (this
-# namespace rule).
-GIT_IDENTITY_ENV_PREFIXES = (
-    'GIT_AUTHOR_',
-    'GIT_COMMITTER_',
-)
+# namespace rule, both layers).
 
 
 def assert_git_dir_is(directory, env=None):

--- a/tests/unit/test_git_env_namespace_scrub.py
+++ b/tests/unit/test_git_env_namespace_scrub.py
@@ -280,13 +280,34 @@ class TestTheTemplateDirEscapeIsClosed:
         #
         # A literal dict depends on neither layer, so the control keeps
         # working when either or both regress -- which is the point of a
-        # control. HOME is aimed at tmp_path as well, so a developer's global
-        # `init.templateDir` cannot influence the result either.
-        # `_seed_commit` sets user.email/user.name locally, so nothing
-        # further is needed.
+        # control. `_seed_commit` sets user.email/user.name locally, so
+        # nothing further is needed.
+        #
+        # HOME is carried from the ambient environment ON PURPOSE, and an
+        # earlier revision of this test got that wrong in a way worth
+        # recording. Aiming HOME at `tmp_path` looks like extra isolation and
+        # is really a hole: git reads GLOBAL config from HOME, and a global
+        # `core.hooksPath` copies a template hook into a new repo while
+        # SUPPRESSING its execution. Measured: hook copied YES, hook executed
+        # NO. That is precisely "this platform silently declines to run
+        # hooks", the condition the assertion below exists to announce, and a
+        # synthetic HOME hides it -- the negative test then passes because
+        # hooks are globally off rather than because anything stripped
+        # GIT_TEMPLATE_DIR, and this control cannot tell you so. The control
+        # must share the global-config regime of the test it validates.
+        #
+        # The isolation that change claimed to buy did not exist: an explicit
+        # GIT_TEMPLATE_DIR overrides a global `init.templateDir` anyway,
+        # because environment beats config. Measured both ways.
+        #
+        # Neither PATH nor HOME is in the GIT_* namespace, so carrying them
+        # keeps this dict independent of both scrub layers. Note the residual
+        # limit: HOME covers global config only, so a SYSTEM-level
+        # (`/etc/gitconfig`) `core.hooksPath` is still caught here, since no
+        # GIT_CONFIG_NOSYSTEM is set.
         raw_env = {
-            'PATH': os.environ['PATH'],
-            'HOME': str(tmp_path),
+            'PATH': os.environ.get('PATH', ''),
+            'HOME': os.environ.get('HOME', str(tmp_path)),
             'GIT_TEMPLATE_DIR': str(template),
         }
 
@@ -297,8 +318,9 @@ class TestTheTemplateDirEscapeIsClosed:
             'nothing stripping it -- this platform/git version does not '
             'exercise the attack this guard exists to close, so the test '
             'below would pass for the wrong reason. Look at git version and '
-            'core.hooksPath, NOT at the ambient environment: this test does '
-            'not read it'
+            'core.hooksPath (global config is deliberately in scope here), '
+            'NOT at an ambient GIT_* variable: this test reads only PATH and '
+            'HOME from the environment'
         )
 
     def test_a_hook_in_a_poisoned_template_dir_never_runs(

--- a/tests/unit/test_git_env_namespace_scrub.py
+++ b/tests/unit/test_git_env_namespace_scrub.py
@@ -1,4 +1,4 @@
-"""`sanitized_git_env()` strips git's whole `GIT_*` namespace, not a list of
+r"""`sanitized_git_env()` strips git's whole `GIT_*` namespace, not a list of
 names (T57).
 
 `tests/unit/conftest.py` used to deny six specific "location" variables --
@@ -28,12 +28,48 @@ back to a six-name denylist. `TestTheNamespaceIsStrippedNotAList` below is
 written to fail that same way: it asserts against variable names git has
 never defined and never will, which no list of REAL names -- however long --
 can ever satisfy.
+
+TWO LAYERS apply this rule, and both are covered here.
+`tests/unit/conftest.py`'s `sanitized_git_env()` returns a sanitised COPY for
+an explicit `env=`, tested by `TestTheNamespaceIsStrippedNotAList` and the
+rest of the classes above `TestTheRootProcessWideScrubAppliesTheSameRule`.
+`tests/conftest.py` also pops the same namespace directly out of
+`os.environ`, once, for the WHOLE test process, before anything is
+collected -- a denylist reverted there would leave `sanitized_git_env()`
+correct while every subprocess that never calls it (the whole point of that
+layer, per its own comment) stayed exposed. `TestTheRootProcessWideScrubAppliesTheSameRule`
+proves that layer independently, in a subprocess, because its scrub runs
+once at import time, before any test in THIS process starts -- there is no
+way to poison `os.environ` and re-trigger it from inside a running test.
+
+The whole-tree sweep for anything that reads a `GIT_*` variable (the claim
+`tests/conftest.py`'s "safe to do unconditionally" comment rests on,
+widened from GIT_DIR alone to the full namespace for T57's follow-up):
+
+    grep -rn "GIT_" --include='*.py' --include='*.sh' --include='*.yml' \
+      --include='*.yaml' . | grep -v '\.venv' | grep -v '/\.git/'
+
+and, with no extension filter at all, to catch anything outside those
+extensions:
+
+    grep -rn "GIT_" . | grep -vE '\.venv/|/\.git/|node_modules/|\.pytest_cache/|__pycache__/|/\.next/|/dist/|/build/'
+
+Every hit outside this file, `tests/conftest.py`, `tests/unit/conftest.py`,
+`test_fixtures_do_not_leak_gitdir.py`, `test_hybrid_gate.py` and
+`test_mutation_changed.py` (all already accounted for above) is
+documentation in `specs/REMEDIATION-2026-08.md`. Nothing reads a `GIT_*`
+variable, so nothing depends on inheriting one outside the identity
+allowlist.
 """
 import os
 import stat
 import subprocess
+import sys
+from pathlib import Path
 
 from tests.unit.conftest import GIT_IDENTITY_ENV_PREFIXES, sanitized_git_env
+
+REPO = Path(__file__).resolve().parents[2]
 
 
 class TestTheNamespaceIsStrippedNotAList:
@@ -244,4 +280,88 @@ class TestTheTemplateDirEscapeIsClosed:
             'EXECUTED during the fixture\'s own seed commit -- '
             'sanitized_git_env() did not strip GIT_TEMPLATE_DIR from the '
             'environment handed to git'
+        )
+
+
+class TestTheRootProcessWideScrubAppliesTheSameRule:
+    """`tests/conftest.py` pops the same `GIT_*` namespace directly out of
+    `os.environ`, once, for the whole test process, before collection --
+    the layer `test_fixtures_do_not_leak_gitdir.py`'s
+    `test_the_process_scrub_protects_a_file_that_never_heard_of_the_helper`
+    already exercises for the GIT_DIR leak specifically. This class is the
+    T57 equivalent of that test: it proves the ROOT scrub applies the
+    namespace rule, not a list, independently of `sanitized_git_env()`.
+
+    Every case here runs a fresh Python subprocess rather than poisoning
+    `os.environ` in-process. `tests/conftest.py`'s scrub is a MODULE-LEVEL
+    side effect that fires once, the moment the module is first imported --
+    by the time any test in this file runs, that has already happened in
+    THIS process, using whatever `os.environ` looked like at collection
+    start. Setting a variable now and re-importing would hit Python's module
+    cache and run nothing. A subprocess is the only way to observe the
+    scrub actually firing.
+    """
+
+    @staticmethod
+    def _import_conftest_and_report(env_vars):
+        """Run `import tests.conftest` in a fresh subprocess with the given
+        environment, and report which of `env_vars` survived into
+        `os.environ` afterwards -- one name per output line, in the same
+        order as `env_vars`, so the caller can assert on each independently
+        without a second subprocess round-trip per variable."""
+        poisoned = os.environ.copy()
+        poisoned.update(env_vars)
+        probe = (
+            'import tests.conftest, os\n'
+            + '\n'.join(
+                "print('PRESENT' if %r in os.environ else 'ABSENT')" % name
+                for name in env_vars
+            )
+        )
+        result = subprocess.run(
+            [sys.executable, '-c', probe], cwd=str(REPO), env=poisoned,
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0, (
+            'importing tests.conftest failed outright, which proves nothing '
+            'about the scrub: stdout=%s stderr=%s'
+            % (result.stdout, result.stderr)
+        )
+        lines = result.stdout.strip().splitlines()
+        assert len(lines) == len(env_vars), (
+            'expected one PRESENT/ABSENT line per probed variable, got: %r'
+            % result.stdout
+        )
+        return dict(zip(env_vars, lines))
+
+    def test_an_unknown_GIT_variable_does_not_survive_process_start(self):
+        report = self._import_conftest_and_report(
+            {'GIT_NOT_A_REAL_VARIABLE_47B3F9': 'anything'},
+        )
+        assert report['GIT_NOT_A_REAL_VARIABLE_47B3F9'] == 'ABSENT', (
+            'an unrecognised GIT_* variable survived importing '
+            'tests.conftest -- the root scrub is pinning specific names '
+            'again, not the namespace'
+        )
+
+    def test_commit_identity_variables_survive_process_start(self):
+        report = self._import_conftest_and_report({
+            'GIT_AUTHOR_NAME': 'Test Author',
+            'GIT_COMMITTER_NAME': 'Test Committer',
+        })
+        assert report['GIT_AUTHOR_NAME'] == 'PRESENT', (
+            'GIT_AUTHOR_NAME did not survive the root scrub -- a scripted '
+            'commit relying on ambient author identity would silently lose it'
+        )
+        assert report['GIT_COMMITTER_NAME'] == 'PRESENT', (
+            'GIT_COMMITTER_NAME did not survive the root scrub'
+        )
+
+    def test_an_unrelated_variable_survives_process_start(self):
+        report = self._import_conftest_and_report(
+            {'COUCHPOTATO_TEST_UNRELATED_VAR': 'kept'},
+        )
+        assert report['COUCHPOTATO_TEST_UNRELATED_VAR'] == 'PRESENT', (
+            'a variable outside the GIT_* namespace was removed by the root '
+            'scrub -- it is too broad, not just too narrow'
         )

--- a/tests/unit/test_git_env_namespace_scrub.py
+++ b/tests/unit/test_git_env_namespace_scrub.py
@@ -56,7 +56,7 @@ extensions:
 
 Every hit outside this file, `tests/conftest.py`, `tests/unit/conftest.py`,
 `test_fixtures_do_not_leak_gitdir.py`, `test_mutation_changed.py` and
-`test_mutation_changed.py` (all already accounted for above) is
+`test_hybrid_gate.py` (all already accounted for above) is
 documentation in `specs/REMEDIATION-2026-08.md`. Nothing reads a `GIT_*`
 variable, so nothing depends on inheriting one outside the identity
 allowlist.
@@ -244,7 +244,7 @@ class TestTheTemplateDirEscapeIsClosed:
             'not just the assertion under test'
         )
 
-    def test_the_attack_is_real_without_the_scrub(self, tmp_path, monkeypatch):
+    def test_the_attack_is_real_without_the_scrub(self, tmp_path):
         """Positive control, run FIRST so the negative result below means
         something: proves the sentinel-presence/absence assertion is
         actually pinned on the scrub, not on this platform or git version
@@ -256,39 +256,49 @@ class TestTheTemplateDirEscapeIsClosed:
         repo_dir = tmp_path / 'repo'
         repo_dir.mkdir()
 
-        monkeypatch.setenv('GIT_TEMPLATE_DIR', str(template))
-        # GIT_TEMPLATE_DIR ONLY, carried on an otherwise-sanitised
-        # environment. It is tempting to hand git the raw ambient
-        # `os.environ.copy()` here, on the reasoning that the control should
-        # reproduce what a fixture would face with no scrub at all -- and
-        # that is what this test did until review measured the cost. An
-        # ambient GIT_DIR (exactly what git exports into a `pre-push` hook
-        # from a worktree, which is the leak this whole file exists to close)
-        # would redirect every command below into the developer's REAL
+        # An environment built from NOTHING, carrying only what git needs to
+        # run plus the single variable under test. Not `os.environ.copy()`,
+        # and not `sanitized_git_env()` either, and the difference between
+        # those two rejected options is the whole point.
+        #
+        # The raw ambient copy is what this test used until review measured
+        # the cost. An ambient GIT_DIR -- exactly what git exports into a
+        # `pre-push` hook from a worktree, which is the leak this file exists
+        # to close -- redirects every command below into the developer's REAL
         # repository, and `assert sentinel.exists()` says nothing about where
         # the commit landed, so it reports PASS while doing it. Measured on a
-        # victim repo with the root scrub removed: a stray commit, `user.name`
-        # overwritten, a tracked file dropped from the index, test green.
+        # victim repo with the root scrub regressed: a stray commit,
+        # `user.name` overwritten, a tracked file dropped from the index,
+        # test green.
         #
-        # The control's safety must not be borrowed from the root scrub in
-        # `tests/conftest.py`, because this test is one of the things that
-        # has to keep working when that layer regresses -- and it is defined
-        # BEFORE the tests covering that layer, so on exactly the run where
-        # it regressed, the damage would land before the red appeared.
+        # `sanitized_git_env()` fixes that single fault and was the first fix
+        # taken here, but it only MOVES the dependency: this test would then
+        # be safe because of a function that this same file exists to prove
+        # can regress, and a second review measured a double fault (root
+        # scrub regressed AND the sanitiser no-oped) still damaging the
+        # victim while reporting PASS.
         #
-        # Poisoning the single variable under test is what the control
-        # actually needs: the hook still gets copied and still runs, which is
-        # the whole claim being proved.
-        raw_env = sanitized_git_env()
-        raw_env['GIT_TEMPLATE_DIR'] = str(template)
+        # A literal dict depends on neither layer, so the control keeps
+        # working when either or both regress -- which is the point of a
+        # control. HOME is aimed at tmp_path as well, so a developer's global
+        # `init.templateDir` cannot influence the result either.
+        # `_seed_commit` sets user.email/user.name locally, so nothing
+        # further is needed.
+        raw_env = {
+            'PATH': os.environ['PATH'],
+            'HOME': str(tmp_path),
+            'GIT_TEMPLATE_DIR': str(template),
+        }
 
         self._seed_commit(repo_dir, raw_env)
 
         assert sentinel.exists(), (
-            'the hook did not run even against the raw, unsanitised ambient '
-            'environment -- this platform/git version does not exercise the '
-            'attack this guard exists to close, so the test below would '
-            'pass for the wrong reason'
+            'the hook did not run even with GIT_TEMPLATE_DIR set and '
+            'nothing stripping it -- this platform/git version does not '
+            'exercise the attack this guard exists to close, so the test '
+            'below would pass for the wrong reason. Look at git version and '
+            'core.hooksPath, NOT at the ambient environment: this test does '
+            'not read it'
         )
 
     def test_a_hook_in_a_poisoned_template_dir_never_runs(
@@ -399,12 +409,24 @@ class TestTheRootProcessWideScrubAppliesTheSameRule:
         )
 
     def test_an_unrelated_variable_survives_process_start(self):
+        # LEGIT_UNRELATED_TOKEN contains "GIT_" at index 2, so it also pins
+        # the containment direction at THIS layer. The per-call class has
+        # covered that since the first commit; this layer did not, which left
+        # the higher-leverage of the two scrubs able to delete a non-git
+        # variable from the whole test process with every test still green.
         report = self._import_conftest_and_report(
-            {'COUCHPOTATO_TEST_UNRELATED_VAR': 'kept'},
+            {
+                'COUCHPOTATO_TEST_UNRELATED_VAR': 'kept',
+                'LEGIT_UNRELATED_TOKEN': 'kept',
+            },
         )
         assert report['COUCHPOTATO_TEST_UNRELATED_VAR'] == 'PRESENT', (
             'a variable outside the GIT_* namespace was removed by the root '
             'scrub -- it is too broad, not just too narrow'
+        )
+        assert report['LEGIT_UNRELATED_TOKEN'] == 'PRESENT', (
+            'a variable merely CONTAINING "GIT_" was removed by the root '
+            'scrub -- it is matching containment, not a leading namespace'
         )
 
     def test_a_variable_beginning_GIT_without_the_separator_survives_process_start(self):

--- a/tests/unit/test_git_env_namespace_scrub.py
+++ b/tests/unit/test_git_env_namespace_scrub.py
@@ -1,0 +1,247 @@
+"""`sanitized_git_env()` strips git's whole `GIT_*` namespace, not a list of
+names (T57).
+
+`tests/unit/conftest.py` used to deny six specific "location" variables --
+`GIT_DIR` and its siblings -- built on the axis "what redirects the repo".
+That axis missed two real escapes: `GIT_CONFIG_PARAMETERS` (which `git -c
+foo=bar <cmd>` EXPORTS into the environment of every subprocess it spawns,
+so `git -c ... push` run from a worktree hands the suite arbitrary config)
+and `GIT_TEMPLATE_DIR` (arbitrary code execution via a hook copied from the
+template dir into the new repo and then RUN -- and not a location variable
+at all, so no denylist built on that axis would ever have named it). See the
+comment above `GIT_IDENTITY_ENV_PREFIXES` in `conftest.py` for the full
+argument and the measurement behind it.
+
+This file is deliberately separate from `test_fixtures_do_not_leak_gitdir.py`,
+which polices CALL SITES (does every `git` subprocess call in the tree pass
+`env=sanitized_git_env()`?) and the `GIT_DIR` location leak specifically.
+This file polices what `sanitized_git_env()` itself removes -- a different
+question, answered once, about one function -- and sits alongside that file
+rather than folding into it, because the two guards fail for unrelated
+reasons and a shared file would blur which one a red run is naming.
+
+A previous attempt at this same guard, elsewhere, was proved vacuous: it
+named `GIT_TEMPLATE_DIR` and `GIT_CONFIG_COUNT` explicitly, so it pinned two
+real variables while its docstring claimed to pin the PROPERTY, and it
+stayed green through three separate mutations, including a revert straight
+back to a six-name denylist. `TestTheNamespaceIsStrippedNotAList` below is
+written to fail that same way: it asserts against variable names git has
+never defined and never will, which no list of REAL names -- however long --
+can ever satisfy.
+"""
+import os
+import stat
+import subprocess
+
+from tests.unit.conftest import GIT_IDENTITY_ENV_PREFIXES, sanitized_git_env
+
+
+class TestTheNamespaceIsStrippedNotAList:
+    """The load-bearing assertion a denylist can never satisfy.
+
+    If `sanitized_git_env()` is genuinely a namespace rule, an unrecognised
+    `GIT_*` variable is removed whether or not anyone has ever heard of it.
+    If it is secretly still a list of known names, an unrecognised variable
+    survives -- and a test that only ever probes `GIT_TEMPLATE_DIR` or
+    `GIT_CONFIG_PARAMETERS` cannot tell the two apart, because both
+    implementations pass it.
+    """
+
+    def test_an_unknown_GIT_variable_is_stripped(self, monkeypatch):
+        monkeypatch.setenv('GIT_NOT_A_REAL_VARIABLE_47B3F9', 'anything')
+        env = sanitized_git_env()
+        assert 'GIT_NOT_A_REAL_VARIABLE_47B3F9' not in env, (
+            'sanitized_git_env() let an unrecognised GIT_* variable through '
+            '-- it is pinning specific names again, not the namespace'
+        )
+
+    def test_a_second_unknown_GIT_variable_is_also_stripped(self, monkeypatch):
+        # A differently-shaped name from the one above, so passing the first
+        # assertion cannot be a coincidence of matching one hardcoded string
+        # somewhere in the implementation.
+        monkeypatch.setenv('GIT_SOME_FUTURE_FLAG_THAT_DOES_NOT_EXIST_YET', '1')
+        env = sanitized_git_env()
+        assert 'GIT_SOME_FUTURE_FLAG_THAT_DOES_NOT_EXIST_YET' not in env, (
+            'sanitized_git_env() let an unrecognised GIT_* variable through '
+            '-- it is pinning specific names again, not the namespace'
+        )
+
+
+class TestTheAllowlistSurvives:
+    """The exception the namespace rule deliberately carves out: the
+    variables that change what a commit RECORDS (author/committer identity
+    and date), never where an operation LANDS or what git EXECUTES."""
+
+    def test_commit_identity_variables_survive(self, monkeypatch):
+        identity_vars = {
+            'GIT_AUTHOR_NAME': 'Test Author',
+            'GIT_AUTHOR_EMAIL': 'author@example.com',
+            'GIT_AUTHOR_DATE': '2026-01-01T00:00:00',
+            'GIT_COMMITTER_NAME': 'Test Committer',
+            'GIT_COMMITTER_EMAIL': 'committer@example.com',
+            'GIT_COMMITTER_DATE': '2026-01-01T00:00:00',
+        }
+        for key, value in identity_vars.items():
+            monkeypatch.setenv(key, value)
+
+        env = sanitized_git_env()
+
+        for key, value in identity_vars.items():
+            assert env.get(key) == value, (
+                '%s was stripped -- the allowlist must let commit-identity '
+                'variables through, or every caller that relies on '
+                'GIT_AUTHOR_*/GIT_COMMITTER_* for a scripted commit breaks'
+                % key
+            )
+
+    def test_the_allowlist_is_exactly_the_two_documented_prefixes(self):
+        # Pins the CONSTANT the function is documented to use, not just its
+        # current behaviour, so a future edit that widens the prefix list
+        # (or narrows it) without updating the surrounding comment is caught
+        # here rather than discovered later by an unrelated variable quietly
+        # surviving, or failing to survive, the strip.
+        assert GIT_IDENTITY_ENV_PREFIXES == ('GIT_AUTHOR_', 'GIT_COMMITTER_')
+
+
+class TestNonGitVariablesAreUntouched:
+    """A namespace strip must stay ON the namespace: writing one too broad
+    (matching anything that merely contains "GIT") is as easy a mistake as
+    writing one too narrow, and both are invisible in a green run unless
+    something specifically checks the boundary."""
+
+    def test_an_unrelated_variable_survives(self, monkeypatch):
+        monkeypatch.setenv('COUCHPOTATO_TEST_UNRELATED_VAR', 'kept')
+        env = sanitized_git_env()
+        assert env.get('COUCHPOTATO_TEST_UNRELATED_VAR') == 'kept'
+
+    def test_a_variable_that_merely_contains_GIT_as_a_substring_survives(
+        self, monkeypatch,
+    ):
+        # "LEGIT_UNRELATED_TOKEN" contains the substring "GIT_" starting at
+        # index 2 -- it must not trip a strip that checks containment instead
+        # of a leading-namespace prefix.
+        monkeypatch.setenv('LEGIT_UNRELATED_TOKEN', 'kept')
+        env = sanitized_git_env()
+        assert env.get('LEGIT_UNRELATED_TOKEN') == 'kept'
+
+    def test_PATH_survives(self):
+        # Without PATH, git itself cannot be exec'd by any caller of this
+        # function -- the strongest available check that the strip has not
+        # eaten something load-bearing well outside the GIT_* namespace.
+        env = sanitized_git_env()
+        assert 'PATH' in env and env['PATH']
+
+
+class TestTheTemplateDirEscapeIsClosed:
+    """The concrete attack from the T57 measurement, driven directly rather
+    than asserted from documentation or log text: a poisoned
+    `GIT_TEMPLATE_DIR` containing an executable `hooks/pre-commit` is copied
+    into every repo `git init` creates from that template, and RUN during
+    the repo's own first commit. Proven hostile with a hook that writes a
+    file to disk -- the sentinel's absence is the entire assertion, not a
+    substring of a log line.
+    """
+
+    @staticmethod
+    def _plant_hook(template_dir, sentinel_path):
+        hooks_dir = template_dir / 'hooks'
+        hooks_dir.mkdir(parents=True)
+        hook = hooks_dir / 'pre-commit'
+        hook.write_text('#!/bin/sh\ntouch "%s"\nexit 0\n' % sentinel_path)
+        mode = hook.stat().st_mode
+        hook.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        return hook
+
+    @staticmethod
+    def _seed_commit(repo_dir, env=None):
+        # `sanitized_git_env() if env is None else env` -- the same IfExp
+        # shape `assert_git_dir_is` uses in conftest.py, and the one form
+        # `test_no_test_file_invokes_git_without_sanitizing_the_environment`
+        # recognises as sanitised without tracking dataflow through a bound
+        # name. Deliberately NOT `env = env or sanitized_git_env()` bound
+        # outside the closure and reused: that shape is exactly what the
+        # call-site guard refuses to trust, on purpose, so the callers below
+        # can hand this helper either the real sanitiser or a deliberately
+        # raw environment and still pass that guard's scan.
+        def git(*args):
+            return subprocess.run(
+                ['git', *args], cwd=str(repo_dir),
+                env=sanitized_git_env() if env is None else env,
+                capture_output=True, text=True,
+            )
+
+        init = git('init', '-q', '-b', 'main')
+        assert init.returncode == 0, 'git init itself failed: %s' % init.stderr
+        git('config', 'user.email', 't@example.com')
+        git('config', 'user.name', 'T')
+        (repo_dir / 'f.txt').write_text('seed\n')
+        git('add', '-A')
+        commit = git('commit', '-q', '-m', 'seed')
+        assert commit.returncode == 0, (
+            'the seed commit itself failed, which proves nothing about the '
+            'hook either way: %s' % commit.stderr
+        )
+        head = git('rev-parse', 'HEAD')
+        assert head.returncode == 0 and head.stdout.strip(), (
+            'no commit was actually created -- the test setup is broken, '
+            'not just the assertion under test'
+        )
+
+    def test_the_attack_is_real_without_the_scrub(self, tmp_path, monkeypatch):
+        """Positive control, run FIRST so the negative result below means
+        something: proves the sentinel-presence/absence assertion is
+        actually pinned on the scrub, not on this platform or git version
+        silently declining to copy or run hooks from a template dir."""
+        template = tmp_path / 'hostile_template'
+        sentinel = tmp_path / 'PWNED_CONTROL'
+        self._plant_hook(template, sentinel)
+
+        repo_dir = tmp_path / 'repo'
+        repo_dir.mkdir()
+
+        monkeypatch.setenv('GIT_TEMPLATE_DIR', str(template))
+        # Deliberately the RAW ambient environment, not sanitized_git_env()
+        # -- this is what a fixture would hand git if the scrub did not
+        # exist at all.
+        raw_env = os.environ.copy()
+
+        self._seed_commit(repo_dir, raw_env)
+
+        assert sentinel.exists(), (
+            'the hook did not run even against the raw, unsanitised ambient '
+            'environment -- this platform/git version does not exercise the '
+            'attack this guard exists to close, so the test below would '
+            'pass for the wrong reason'
+        )
+
+    def test_a_hook_in_a_poisoned_template_dir_never_runs(
+        self, tmp_path, monkeypatch,
+    ):
+        template = tmp_path / 'hostile_template'
+        sentinel = tmp_path / 'PWNED'
+        self._plant_hook(template, sentinel)
+
+        repo_dir = tmp_path / 'repo'
+        repo_dir.mkdir()
+
+        # The poison sits in the AMBIENT environment, exactly where a real
+        # attacker or a misconfigured runner would place it -- this is what
+        # a fixture receives before sanitized_git_env() ever runs, not a
+        # value handed to the function as an argument.
+        monkeypatch.setenv('GIT_TEMPLATE_DIR', str(template))
+
+        env = sanitized_git_env()
+        assert 'GIT_TEMPLATE_DIR' not in env, (
+            'sanity check before the real assertion: the scrub must remove '
+            'GIT_TEMPLATE_DIR from the returned env, or the git calls below '
+            'are not actually exercising the fix'
+        )
+
+        self._seed_commit(repo_dir, env)
+
+        assert not sentinel.exists(), (
+            'the pre-commit hook from the poisoned GIT_TEMPLATE_DIR '
+            'EXECUTED during the fixture\'s own seed commit -- '
+            'sanitized_git_env() did not strip GIT_TEMPLATE_DIR from the '
+            'environment handed to git'
+        )

--- a/tests/unit/test_git_env_namespace_scrub.py
+++ b/tests/unit/test_git_env_namespace_scrub.py
@@ -55,7 +55,7 @@ extensions:
     grep -rn "GIT_" . | grep -vE '\.venv/|/\.git/|node_modules/|\.pytest_cache/|__pycache__/|/\.next/|/dist/|/build/'
 
 Every hit outside this file, `tests/conftest.py`, `tests/unit/conftest.py`,
-`test_fixtures_do_not_leak_gitdir.py`, `test_hybrid_gate.py` and
+`test_fixtures_do_not_leak_gitdir.py`, `test_mutation_changed.py` and
 `test_mutation_changed.py` (all already accounted for above) is
 documentation in `specs/REMEDIATION-2026-08.md`. Nothing reads a `GIT_*`
 variable, so nothing depends on inheriting one outside the identity
@@ -160,6 +160,27 @@ class TestNonGitVariablesAreUntouched:
         env = sanitized_git_env()
         assert env.get('LEGIT_UNRELATED_TOKEN') == 'kept'
 
+    def test_a_variable_beginning_GIT_without_the_separator_survives(
+        self, monkeypatch,
+    ):
+        # The likelier typo than a containment bug: a prefix one character
+        # short. `startswith('GIT')` still strips every GIT_* the tests above
+        # check, so all of them stay green while GITHUB_* is silently deleted
+        # from every environment this function hands to a subprocess. On a CI
+        # runner that is GITHUB_TOKEN, GITHUB_REF and the rest of the family.
+        # Nothing in this suite reads them today, which is exactly why no
+        # other assertion here can see the mistake.
+        monkeypatch.setenv('GITHUB_TOKEN', 'kept')
+        monkeypatch.setenv('GOPATH', 'kept')
+        env = sanitized_git_env()
+        assert env.get('GITHUB_TOKEN') == 'kept', (
+            'a variable starting with "GIT" but outside the GIT_ namespace '
+            'was stripped -- the prefix is missing its trailing underscore'
+        )
+        assert env.get('GOPATH') == 'kept', (
+            'GOPATH was stripped -- the prefix has collapsed to "G"'
+        )
+
     def test_PATH_survives(self):
         # Without PATH, git itself cannot be exec'd by any caller of this
         # function -- the strongest available check that the strip has not
@@ -236,10 +257,30 @@ class TestTheTemplateDirEscapeIsClosed:
         repo_dir.mkdir()
 
         monkeypatch.setenv('GIT_TEMPLATE_DIR', str(template))
-        # Deliberately the RAW ambient environment, not sanitized_git_env()
-        # -- this is what a fixture would hand git if the scrub did not
-        # exist at all.
-        raw_env = os.environ.copy()
+        # GIT_TEMPLATE_DIR ONLY, carried on an otherwise-sanitised
+        # environment. It is tempting to hand git the raw ambient
+        # `os.environ.copy()` here, on the reasoning that the control should
+        # reproduce what a fixture would face with no scrub at all -- and
+        # that is what this test did until review measured the cost. An
+        # ambient GIT_DIR (exactly what git exports into a `pre-push` hook
+        # from a worktree, which is the leak this whole file exists to close)
+        # would redirect every command below into the developer's REAL
+        # repository, and `assert sentinel.exists()` says nothing about where
+        # the commit landed, so it reports PASS while doing it. Measured on a
+        # victim repo with the root scrub removed: a stray commit, `user.name`
+        # overwritten, a tracked file dropped from the index, test green.
+        #
+        # The control's safety must not be borrowed from the root scrub in
+        # `tests/conftest.py`, because this test is one of the things that
+        # has to keep working when that layer regresses -- and it is defined
+        # BEFORE the tests covering that layer, so on exactly the run where
+        # it regressed, the damage would land before the red appeared.
+        #
+        # Poisoning the single variable under test is what the control
+        # actually needs: the hook still gets copied and still runs, which is
+        # the whole claim being proved.
+        raw_env = sanitized_git_env()
+        raw_env['GIT_TEMPLATE_DIR'] = str(template)
 
         self._seed_commit(repo_dir, raw_env)
 
@@ -364,4 +405,22 @@ class TestTheRootProcessWideScrubAppliesTheSameRule:
         assert report['COUCHPOTATO_TEST_UNRELATED_VAR'] == 'PRESENT', (
             'a variable outside the GIT_* namespace was removed by the root '
             'scrub -- it is too broad, not just too narrow'
+        )
+
+    def test_a_variable_beginning_GIT_without_the_separator_survives_process_start(self):
+        # The same one-character-short prefix mutation survives at THIS layer
+        # too, and this is the higher-leverage of the two: the root scrub
+        # mutates os.environ for the whole test process, so a prefix of 'GIT'
+        # deletes GITHUB_* from every test and every subprocess any of them
+        # spawns. Measured under that mutation: the full unit suite passed.
+        report = self._import_conftest_and_report(
+            {'GITHUB_TOKEN': 'kept', 'GOPATH': 'kept'},
+        )
+        assert report['GITHUB_TOKEN'] == 'PRESENT', (
+            'GITHUB_TOKEN did not survive the root scrub -- the prefix is '
+            'missing its trailing underscore and is eating GITHUB_*'
+        )
+        assert report['GOPATH'] == 'PRESENT', (
+            'GOPATH did not survive the root scrub -- the prefix has '
+            'collapsed to "G"'
         )


### PR DESCRIPTION
Closes T57. Also records T62 and ticks T57 in the plan.

## The defect

`tests/unit/conftest.py` stripped six named git variables before any fixture
shelled out to git. That list was derived from "what redirects the repository",
which is the wrong axis, and it missed two real escapes:

- **`GIT_CONFIG_PARAMETERS`** is exported by `git -c foo=bar <cmd>` into every
  subprocess it spawns, so `git -c ... push` from a worktree hands the suite
  arbitrary config. Same trigger and same class as the `GIT_DIR` leak already
  recorded, one name the list never had.
- **`GIT_TEMPLATE_DIR`** is arbitrary code execution, and it is not a location
  variable at all, so no denylist built on that axis would ever have contained
  it. Hooks in the template directory are copied into every repo `git init`
  creates and then run. Every throwaway repo this suite creates would have run
  one.

A denylist cannot be finished: it is wrong again the day git adds a variable,
and nothing announces that. A namespace rule excludes the new one the day it
ships.

## The change

Strip the whole `GIT_*` namespace, allow back only the commit-identity
prefixes (`GIT_AUTHOR_`, `GIT_COMMITTER_`), which change what a commit RECORDS
rather than where it lands or what runs. Applied at both layers: the
process-wide `os.environ` pop in `tests/conftest.py` that runs before
collection, and the per-call copy in `sanitized_git_env()`. The prefix tuple is
defined once and imported, because a rule stated twice goes stale the moment
one copy is updated.

Review measured a third escape neither the task nor the fix had claimed:
`GIT_EXEC_PATH` is exported into every hook environment and git runs
subcommands from it, so it is arbitrary code execution on the same footing as
the template directory. The namespace rule closes it for free, which is the
cleanest available proof that the original axis was wrong.

## Verification

Guards proven load-bearing by mutation, each hash-verified as landed and
byte-identical after restore:

| Mutation | Caught by |
|---|---|
| revert `sanitized_git_env()` to the six-name denylist | 3 tests red |
| revert the process-wide scrub to the denylist | the process-start test |
| drop the identity allowlist, either layer | the identity test for that layer |
| delete the process-wide scrub entirely | the process-start test |
| `startswith('GIT_')` -> `startswith('GIT')`, either layer | that layer's boundary probe |
| containment (`'GIT_' in var`), either layer | that layer's containment probe |
| plant the template hook non-executable | the positive control |

The positive control proves hook EXECUTION, not file presence: the hook
`touch`es a sentinel and the sentinel is the assertion, so a platform that
declines to run hooks turns the control RED rather than green.

## What review changed, recorded because it is the useful part

Four rounds. Three defects were introduced by fix commits and caught by the
next round, which is why each fix commit was reviewed as new work per CLAUDE.md
rule 11 rather than waved through:

1. The positive control ran git with the raw ambient environment. With the
   process-wide scrub regressed and `GIT_DIR` set the way git sets it in a
   worktree hook, it committed into the developer's REAL repository, overwrote
   `user.name` and dropped a tracked file from the index, while reporting PASS.
   Measured on a victim repo, both before and after the fix.
2. Fixing that with `sanitized_git_env()` only MOVED the dependency: the
   control was then safe because of a function this same file exists to prove
   can regress. A double fault still damaged the victim while passing. The
   control now builds a literal environment that depends on neither layer.
3. Aiming `HOME` at `tmp_path` looked like more isolation and was a hole: git
   reads global config from `HOME`, and a global `core.hooksPath` copies a
   template hook while SUPPRESSING execution, which is exactly the condition
   the control exists to announce. `HOME` is now carried from the ambient
   environment, and the control goes red under a hostile global config as it
   should. The isolation that change claimed to buy never existed, since an
   explicit `GIT_TEMPLATE_DIR` overrides a global `init.templateDir` anyway.

## Also in this PR

- Ticks T57 rather than leaving it for a follow-up, since an unticked merged
  task is the staleness T48 recorded against itself and T44 is reproducing now.
- Records **T62**: the pre-push hook never reads the refs git supplies on
  stdin, so it gates the working tree at hook start while git sends whatever
  the ref resolves to when the gate finishes. Observed twice on 2026-08-20.
- Reconciles T18's needs list in both directions, as
  `tests/unit/test_plan_needs_list.py` requires.

`make verify` green locally on this exact tip.