### PR TITLE
fix(BUG-017): the orphan cleanup is a one-time migration that never stopped running

### DIFF
--- a/couchpotato/runner.py
+++ b/couchpotato/runner.py
@@ -318,34 +318,75 @@ def _run_orphan_cleanup(db, log):
     swallows any read failure other than a corrupt document into a debug
     log and returns None either way (couchpotato/core/settings.py:818). We
     deliberately treat both cases the same as "not yet applied" and attempt
-    the run. That is safe specifically because this is a one-time
-    migration sharing the same database as the cleanup itself: if the
-    store really were unreadable, clean_orphaned_movies(db) reads from
-    that same db and would itself raise, which is caught below and leaves
-    the marker unset for a retry on the next boot (AC-DATA-3) rather than
-    deleting anything. The alternative, treating "unreadable" as "already
-    applied" and skipping, would risk permanently skipping a genuine
-    first-ever run on a store that is merely having a transient problem.
+    the run. That choice is NOT justified by either of the two claims an
+    earlier version of this docstring made, both measured and disproved in
+    fix round one:
+
+    - It is NOT true that an unreadable property store implies
+      clean_orphaned_movies(db) would also raise. Driven directly: a marker
+      document present with its `value` field missing reads back as None
+      (property store "unreadable" by this function's own test) while the
+      media table reads just fine -- a property read and a media read are
+      different reads over the same db -- and the cleanup then ran and
+      deleted for real. The gate fails open on that path by design, not by
+      accident.
+    - It is NOT true that clean_orphaned_movies(db) can be relied on to
+      raise when its scan fails. Its own scan loop catches `Exception`,
+      logs a warning on ITS OWN logger, and returns 0
+      (couchpotato/core/migration/clean_orphans.py:66-70) -- a scan that
+      failed completely is recorded here as a successful migration that
+      "removed 0", and the marker gets set.
+
+    Fail-open is still the right default for a one-time migration, but the
+    real reason is narrower than either claim above: it is the MARKER WRITE
+    itself raising, not clean_orphaned_movies raising, that delivers the
+    retry (AC-DATA-3). A property store too broken to durably record the
+    marker is also too broken to have recorded a false "already applied",
+    so the next boot tries again. The alternative, treating "unreadable" as
+    "already applied" and skipping, would risk permanently skipping a
+    genuine first-ever run on a store that is merely having a transient
+    problem.
     """
     from couchpotato.environment import Env
 
-    if Env.prop(ORPHAN_CLEANUP_MARKER):
-        log.info('Orphan cleanup skipped: already applied.')
-        return
-
     try:
+        try:
+            already_applied = Env.prop(ORPHAN_CLEANUP_MARKER)
+        except Exception:
+            # A failed READ of the marker itself is treated the same as
+            # "not yet applied" (see docstring above), not as the run's
+            # overall failure -- so the migration still gets attempted
+            # rather than merely failing without crashing. Nested rather
+            # than left to the outer except so this specific failure can't
+            # be confused with clean_orphaned_movies() or the marker WRITE
+            # failing below, which the outer except's retry semantics are
+            # about.
+            already_applied = None
+
+        if already_applied:
+            log.info('Orphan cleanup skipped: already applied.')
+            return
+
         from couchpotato.core.migration.clean_orphans import clean_orphaned_movies
         n_orphans = clean_orphaned_movies(db)
+        # Logged BEFORE the marker write below, not after: a marker write
+        # that itself fails (locked or read-only database, disk full,
+        # another writer) must still leave an accurate count of what was
+        # just deleted in the log, rather than the only line on this
+        # logger reading "skipped" on a boot that destroyed real records.
+        log.info('Orphan cleanup ran: removed %d orphaned movie entries with no metadata.', n_orphans)
         # Mark applied only once the scan has actually completed -- a scan
         # that finds nothing to remove has still run and must not be
         # retried on every future boot (AC-DATA-2).
         Env.prop(ORPHAN_CLEANUP_MARKER, value='true')
-        log.info('Orphan cleanup ran: removed %d orphaned movie entries with no metadata.', n_orphans)
     except Exception as e:
         # Marker deliberately NOT set here -- a failed run must be free to
         # retry on the next start rather than being silently skipped
-        # forever (AC-DATA-3).
-        log.warning('Orphan cleanup skipped: %s', e)
+        # forever (AC-DATA-3). Worded so this can never be confused with
+        # the "already applied" INFO line above: that line means finished
+        # and good, this one means armed and will retry, and they used to
+        # share the "Orphan cleanup skipped" prefix.
+        log.warning('Orphan cleanup did not complete, will retry on next start: %s', e)
 
 
 def runCouchPotato(options, base_path, args, data_dir=None, log_dir=None, Env=None, desktop=None):

--- a/couchpotato/runner.py
+++ b/couchpotato/runner.py
@@ -350,11 +350,16 @@ def _run_orphan_cleanup(db, log):
     on any failure at all -- measured with `db.update` raising
     `ConflictError`, `Env.prop(MARKER, value='true')` raised NOTHING,
     produced a second `property` row for the same identifier, and the
-    marker still read back None afterwards. The same hazard, a failed
-    property write that does not raise and instead leaves duplicate rows,
-    is already documented in this file at the session-secret creation
-    below (see the comment at line 596 onward); it is not restated in full
-    here.
+    marker still read back None afterwards. This is a DIFFERENT mechanism
+    from the duplicate-row hazard documented at the session secret's
+    creation in `runCouchPotato` below: that one is a race between
+    concurrent first-time creates on a property store with no uniqueness
+    constraint on `identifier`. Here there is only one writer, and the
+    duplicate row comes from `setProperty`'s own silent fallback to
+    `db.insert` on any `db.update` failure, not from concurrency. Both end
+    up as duplicate rows in the same table for the same underlying reason,
+    no uniqueness constraint on `identifier`, but by different mechanisms,
+    so fixing one does not fix the other.
 
     Also NOT reliable: clean_orphaned_movies(db) raising when its scan
     fails. Its own scan loop catches `Exception`, logs a warning on ITS OWN

--- a/couchpotato/runner.py
+++ b/couchpotato/runner.py
@@ -313,55 +313,60 @@ def _run_orphan_cleanup(db, log):
     means a behaviour change in the cleanup can never be confused with the
     gate that decides whether it runs.
 
-    Env.prop(ORPHAN_CLEANUP_MARKER) cannot tell "marker never set" apart
-    from "the property store could not be read": Settings.getProperty()
-    swallows any read failure other than a corrupt document into a debug
-    log and returns None either way (couchpotato/core/settings.py:818). We
-    deliberately treat both cases the same as "not yet applied" and attempt
-    the run. That choice is NOT justified by either of the two claims an
-    earlier version of this docstring made, both measured and disproved in
-    fix round one:
+    This function has two different behaviours for "the marker could not
+    be read", and they must not be confused with each other:
 
-    - It is NOT true that an unreadable property store implies
-      clean_orphaned_movies(db) would also raise. Driven directly: a marker
-      document present with its `value` field missing reads back as None
-      (property store "unreadable" by this function's own test) while the
-      media table reads just fine -- a property read and a media read are
-      different reads over the same db -- and the cleanup then ran and
-      deleted for real. The gate fails open on that path by design, not by
-      accident.
-    - It is NOT true that clean_orphaned_movies(db) can be relied on to
-      raise when its scan fails. Its own scan loop catches `Exception`,
-      logs a warning on ITS OWN logger, and returns 0
-      (couchpotato/core/migration/clean_orphans.py:66-70) -- a scan that
-      failed completely is recorded here as a successful migration that
-      "removed 0", and the marker gets set.
+    - An exception that ESCAPES Settings.getProperty (for example
+      `self.log.debug(...)` itself raising on the miss path, because
+      `self.log` is None until `Settings.setFile()` has run) now fails
+      SAFE. It propagates up through Env.prop into the try block below,
+      the single except clause at the bottom of this function catches it,
+      logs the "did not complete, will retry" warning, and the cleanup is
+      NOT run. The marker stays unset and the next boot retries (AC-DATA-3,
+      fix round two FIX A). Round one instead wrapped this read in its own
+      nested try/except that treated the failure as "not yet applied" and
+      ran the cleanup anyway; measured against a marker that was genuinely
+      already set, that ran a completed destructive migration a second
+      time with no warning logged at any level. The nested try/except is
+      gone.
+    - A read failure that Settings.getProperty SWALLOWS INTERNALLY (any
+      `db.get` exception other than a corrupt document,
+      couchpotato/core/settings.py:818) still returns None from
+      Env.prop, indistinguishable here from "never set". This function
+      cannot tell that apart, so it still fails OPEN on that path and
+      attempts the run: a marker document present with its `value` field
+      missing reads back as None while the media table reads just fine --
+      a property read and a media read are different reads over the same
+      db -- and the cleanup then runs and deletes for real. This residual
+      fail-open path is real, is not touched by this fix, and is recorded
+      as debt below rather than argued away.
 
-    Fail-open is still the right default for a one-time migration, but the
-    real reason is narrower than either claim above: it is the MARKER WRITE
-    itself raising, not clean_orphaned_movies raising, that delivers the
-    retry (AC-DATA-3). A property store too broken to durably record the
-    marker is also too broken to have recorded a false "already applied",
-    so the next boot tries again. The alternative, treating "unreadable" as
-    "already applied" and skipping, would risk permanently skipping a
-    genuine first-ever run on a store that is merely having a transient
-    problem.
+    A completed run's marker WRITE (Env.prop(ORPHAN_CLEANUP_MARKER,
+    value='true') below) failing is what actually delivers most retries in
+    practice (AC-DATA-3): if it raises, this function's except clause
+    catches it and leaves the marker unset. But a raise is not guaranteed.
+    `Settings.setProperty` (couchpotato/core/settings.py:834-850) wraps its
+    `db.update` in a bare `except Exception:` and falls back to `db.insert`
+    on any failure at all -- measured with `db.update` raising
+    `ConflictError`, `Env.prop(MARKER, value='true')` raised NOTHING,
+    produced a second `property` row for the same identifier, and the
+    marker still read back None afterwards. The same hazard, a failed
+    property write that does not raise and instead leaves duplicate rows,
+    is already documented in this file at the session-secret creation
+    below (see the comment at line 596 onward); it is not restated in full
+    here.
+
+    Also NOT reliable: clean_orphaned_movies(db) raising when its scan
+    fails. Its own scan loop catches `Exception`, logs a warning on ITS OWN
+    logger, and returns 0 (couchpotato/core/migration/clean_orphans.py:
+    66-70) -- a scan that failed completely is recorded here as a
+    successful migration that "removed 0", and the marker gets set
+    (recorded as debt below).
     """
     from couchpotato.environment import Env
 
     try:
-        try:
-            already_applied = Env.prop(ORPHAN_CLEANUP_MARKER)
-        except Exception:
-            # A failed READ of the marker itself is treated the same as
-            # "not yet applied" (see docstring above), not as the run's
-            # overall failure -- so the migration still gets attempted
-            # rather than merely failing without crashing. Nested rather
-            # than left to the outer except so this specific failure can't
-            # be confused with clean_orphaned_movies() or the marker WRITE
-            # failing below, which the outer except's retry semantics are
-            # about.
-            already_applied = None
+        already_applied = Env.prop(ORPHAN_CLEANUP_MARKER)
 
         if already_applied:
             log.info('Orphan cleanup skipped: already applied.')

--- a/couchpotato/runner.py
+++ b/couchpotato/runner.py
@@ -295,6 +295,59 @@ def _open_or_create_database(db, data_dir, base_path):
     return False
 
 
+#: Property-store marker (Env.prop, couchpotato/environment.py:79 -- the
+#: existing `property` document table, no schema change) recording that the
+#: one-time orphan cleanup migration below has completed.
+ORPHAN_CLEANUP_MARKER = 'migration.clean_orphans.applied'
+
+
+def _run_orphan_cleanup(db, log):
+    """Run the orphaned-movie cleanup ONCE, gated on the property marker
+    ORPHAN_CLEANUP_MARKER, instead of on every boot (BUG-017: an
+    unconditional call deleted a real library entry, "Passengers"
+    (tt1355644), on a routine production restart).
+
+    Deliberately does not touch couchpotato/core/migration/clean_orphans.py
+    itself (AC-SIMP-6): the classification logic there is separate, known-
+    imperfect, recorded debt, and keeping this change to the gate alone
+    means a behaviour change in the cleanup can never be confused with the
+    gate that decides whether it runs.
+
+    Env.prop(ORPHAN_CLEANUP_MARKER) cannot tell "marker never set" apart
+    from "the property store could not be read": Settings.getProperty()
+    swallows any read failure other than a corrupt document into a debug
+    log and returns None either way (couchpotato/core/settings.py:818). We
+    deliberately treat both cases the same as "not yet applied" and attempt
+    the run. That is safe specifically because this is a one-time
+    migration sharing the same database as the cleanup itself: if the
+    store really were unreadable, clean_orphaned_movies(db) reads from
+    that same db and would itself raise, which is caught below and leaves
+    the marker unset for a retry on the next boot (AC-DATA-3) rather than
+    deleting anything. The alternative, treating "unreadable" as "already
+    applied" and skipping, would risk permanently skipping a genuine
+    first-ever run on a store that is merely having a transient problem.
+    """
+    from couchpotato.environment import Env
+
+    if Env.prop(ORPHAN_CLEANUP_MARKER):
+        log.info('Orphan cleanup skipped: already applied.')
+        return
+
+    try:
+        from couchpotato.core.migration.clean_orphans import clean_orphaned_movies
+        n_orphans = clean_orphaned_movies(db)
+        # Mark applied only once the scan has actually completed -- a scan
+        # that finds nothing to remove has still run and must not be
+        # retried on every future boot (AC-DATA-2).
+        Env.prop(ORPHAN_CLEANUP_MARKER, value='true')
+        log.info('Orphan cleanup ran: removed %d orphaned movie entries with no metadata.', n_orphans)
+    except Exception as e:
+        # Marker deliberately NOT set here -- a failed run must be free to
+        # retry on the next start rather than being silently skipped
+        # forever (AC-DATA-3).
+        log.warning('Orphan cleanup skipped: %s', e)
+
+
 def runCouchPotato(options, base_path, args, data_dir=None, log_dir=None, Env=None, desktop=None):
 
     try:
@@ -472,14 +525,10 @@ def runCouchPotato(options, base_path, args, data_dir=None, log_dir=None, Env=No
         log.info('Starting server on port %(port)s', config)
     except Exception:
         pass
-    # Clean orphaned movie entries (Py2 migration: dead IMDB IDs with no metadata)
-    try:
-        from couchpotato.core.migration.clean_orphans import clean_orphaned_movies
-        n_orphans = clean_orphaned_movies(db)
-        if n_orphans:
-            log.info('Removed %d orphaned movie entries with no metadata.', n_orphans)
-    except Exception as e:
-        log.warning('Orphan cleanup skipped: %s', e)
+    # Clean orphaned movie entries -- one-time migration, gated so it runs
+    # once per install rather than on every boot (BUG-017: an unconditional
+    # call deleted a real library entry on a routine production restart).
+    _run_orphan_cleanup(db, log)
 
     # Fix release quality values (detect from name instead of searched quality)
     try:

--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -522,35 +522,63 @@ does not work for both, measured directly against real
   `-readonly` matters here: without it, sqlite3 takes a write lock on a
   database the live server may also be writing to.
 
-- **Container STOPPED** (the usual state around a promotion, and the state
-  the command above was never checked against): `-readonly` fails outright
-  with `Error: in prepare, unable to open database file (14)`. A WAL-mode
-  database cannot be opened read-only unless sqlite3 can also access its
-  shared-memory file, and a cleanly stopped container has usually
-  checkpointed and removed the `-shm`/`-wal` sidecars, so there is nothing
-  for `-readonly` to attach to. Dropping `-readonly` instead "works" in the
-  sense that it returns the right row, but it creates `-wal` and `-shm`
-  sidecar files next to the live database as a side effect of opening it
-  for writing, which is exactly the workaround the running-container case
-  above warns against. Use the `immutable` URI query parameter instead,
-  which reads a WAL-mode database without ever trying to write to it or
-  create sidecar files:
+- **Container STOPPED** (the usual state around a promotion): **list the
+  directory first**, and check the size of `couchpotato.db-wal` beside
+  `couchpotato.db`, before trusting either command below. That size is the
+  one precondition that actually decides which command gives the right
+  answer, and unlike "is anything else holding the file open" (the
+  precondition this section used to state), it is observable just by
+  listing the directory, and it is correct -- measured below.
 
-  ```bash
-  sqlite3 "file:/var/lib/plexmediaserver/CouchPotato/config/data/database_v2/couchpotato.db?immutable=1" \
-    "SELECT count(*), group_concat(json_extract(data,'\$.value'))
-       FROM documents
-      WHERE _t='property'
-        AND json_extract(data,'\$.identifier')='migration.clean_orphans.applied';"
-  ```
+  - **No `couchpotato.db-wal` file, or one present at 0 bytes.** The
+    write-ahead log has been fully folded back ("checkpointed") into the
+    main database file, so the base file already holds the whole truth. A
+    clean container stop does this automatically. `-readonly` fails
+    outright here with `Error: in prepare, unable to open database file
+    (14)`: a WAL-mode database cannot be opened read-only unless sqlite3
+    can also access its shared-memory file, and there is none live to
+    attach to. Dropping `-readonly` instead "works" in the sense that it
+    returns the right row, but it creates `-wal` and `-shm` sidecar files
+    next to the live database as a side effect of opening it for writing,
+    which is exactly the workaround the running-container case above warns
+    against. Use the `immutable` URI query parameter instead, which reads a
+    WAL-mode database without ever trying to write to it or create sidecar
+    files:
 
-  `immutable=1` only gives a correct answer when nothing else has the file
-  open: it skips WAL-awareness entirely and reads the base file as-is, so
-  pointed at a database a live process is still writing to it can return a
-  stale or plain wrong answer (measured: it reported the `documents` table
-  did not exist at all, because the schema and every row were still sitting
-  in the WAL, not yet checkpointed into the base file). Use it only once the
-  container is confirmed stopped.
+    ```bash
+    sqlite3 "file:/var/lib/plexmediaserver/CouchPotato/config/data/database_v2/couchpotato.db?immutable=1" \
+      "SELECT count(*), group_concat(json_extract(data,'\$.value'))
+         FROM documents
+        WHERE _t='property'
+          AND json_extract(data,'\$.identifier')='migration.clean_orphans.applied';"
+    ```
+
+  - **`couchpotato.db-wal` present at a nonzero size.** The write-ahead log
+    still holds committed data the base file does not have yet -- either
+    the container is actually running, or it stopped without finishing a
+    checkpoint (killed, crashed, host power loss). `immutable=1` is
+    UNTRUSTWORTHY in this state: it skips WAL-awareness entirely and reads
+    only the base file, so committed rows still sitting in the WAL are
+    invisible to it.
+
+    This section used to say `immutable=1` "only gives a correct answer
+    when nothing else has the file open" -- measured false. A real
+    `SQLiteAdapter`-created database, with the marker written through the
+    real `Env.prop` code path and the process then killed with `SIGKILL`
+    (so nothing was left holding the file open), still left a nonzero
+    `couchpotato.db-wal` behind, and `immutable=1` against it read the
+    marker as `0|` -- "still armed" in the table below -- when the true,
+    WAL-aware state was `1|true`, already applied. Acting on that wrong
+    `0|` by following the "Setting the marker" procedure below would insert
+    a SECOND marker row onto a database that already had one. Against an
+    emptier database the same gap read even worse: `immutable=1` reported
+    the `documents` table did not exist at all, because the schema itself
+    was still only in the WAL.
+
+    Do not reach for another one-shot flag here. The safe move is to start
+    the container and use the `-readonly` form from the "container
+    RUNNING" case above, which is WAL-aware and correct regardless of
+    whether the log has been checkpointed.
 
 Both forms return the same result shape:
 
@@ -595,6 +623,15 @@ container. This was verified end to end against a real adapter-created
 database: the row above, inserted this exact way into an otherwise-fresh
 database, read back through the real `Env.prop('migration.clean_orphans.applied')`
 call (not just the raw SQL check) as the string `'true'`.
+
+This INSERT itself leaves a zero-byte `couchpotato.db-wal` and a 32 KB
+`couchpotato.db-shm` sitting beside the database (measured) -- the same
+sidecar residue the running-container case above warns the write-mode
+workaround away from. That residue is harmless here: the `-wal` is empty,
+so the "no `couchpotato.db-wal`, or one present at 0 bytes" case above
+still applies, and `docker-entrypoint.sh:14` chowns `/config` and `/data`
+on every container start, so ownership left behind by an interactive root
+`sqlite3` session cannot lock the container out.
 
 **Standing operational rule:** the marker lives inside `couchpotato.db`, so
 any restore of that database -- including the DB restore in the Rollback

--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -486,6 +486,51 @@ otherwise the next `docker compose pull` silently re-deploys the broken image.
 > ⚠️ `config.bak/` under `/var/lib/plexmediaserver/CouchPotato/` must **never**
 > be deleted, by a backup script or by hand. It is not a scratch directory.
 
+### One-time boot migration markers
+
+`couchpotato/runner.py` gates a small number of one-time migrations behind
+a property-store marker so they run once, not on every boot (BUG-017:
+`clean_orphaned_movies` ran unconditionally and deleted a real library
+entry, "Passengers", on a routine restart). The marker is an ordinary
+`property` document, the same mechanism `Env.prop` already uses for
+everything else -- no separate schema or file.
+
+For the orphan cleanup specifically, the marker is
+`migration.clean_orphans.applied`, and it must be written to production
+BEFORE this release is deployed there (see the spec's "Pre-deploy" section,
+`specs/BUG-017-orphan-cleanup-runs-every-boot.md`), because production has
+never carried it.
+
+**Checking the marker from the host** (read-only, does not touch the running
+server):
+
+```bash
+sqlite3 -readonly \
+  /var/lib/plexmediaserver/CouchPotato/config/data/database_v2/couchpotato.db \
+  "SELECT count(*), group_concat(json_extract(data,'\$.value'))
+     FROM documents
+    WHERE _t='property'
+      AND json_extract(data,'\$.identifier')='migration.clean_orphans.applied';"
+```
+
+- `1|true` -- the marker is set; the cleanup has run and will not run again.
+- `0|` -- still armed; the cleanup will run on the next boot.
+- anything else -- more than one property row for the same identifier, which
+  should not happen; investigate rather than assume either state.
+
+`-readonly` matters: without it, sqlite3 takes a write lock on a database a
+live server may also be writing to. The database is in WAL mode, so query
+the live file in place with its `-wal` sidecar present rather than copying
+just the `.db` file on its own.
+
+**Standing operational rule:** the marker lives inside `couchpotato.db`, so
+any restore of that database -- including the DB restore in the Rollback
+section above -- resets it. A restored database runs every gated one-time
+migration again on its next boot, exactly as a fresh install would. This is
+expected, not a bug, and is why the gate is safe to have at all: a restore
+should be indistinguishable from a fresh database as far as these
+migrations are concerned.
+
 ### Backups
 
 `scripts/backup.sh` snapshots the SQLite DB (via `sqlite3 .backup`, or Python's

--- a/docs/development-process.md
+++ b/docs/development-process.md
@@ -501,27 +501,100 @@ BEFORE this release is deployed there (see the spec's "Pre-deploy" section,
 `specs/BUG-017-orphan-cleanup-runs-every-boot.md`), because production has
 never carried it.
 
-**Checking the marker from the host** (read-only, does not touch the running
-server):
+**Checking the marker from the host.** The database is in WAL (write-ahead
+log) mode, which changes which command is safe depending on whether the
+container is up. The two states need two different commands; the same one
+does not work for both, measured directly against real
+`SQLiteAdapter`-created databases in each state:
 
-```bash
-sqlite3 -readonly \
-  /var/lib/plexmediaserver/CouchPotato/config/data/database_v2/couchpotato.db \
-  "SELECT count(*), group_concat(json_extract(data,'\$.value'))
-     FROM documents
-    WHERE _t='property'
-      AND json_extract(data,'\$.identifier')='migration.clean_orphans.applied';"
-```
+- **Container RUNNING** (the live process holds the database open, and its
+  `-wal`/`-shm` sidecar files are present next to `couchpotato.db`):
+
+  ```bash
+  sqlite3 -readonly \
+    /var/lib/plexmediaserver/CouchPotato/config/data/database_v2/couchpotato.db \
+    "SELECT count(*), group_concat(json_extract(data,'\$.value'))
+       FROM documents
+      WHERE _t='property'
+        AND json_extract(data,'\$.identifier')='migration.clean_orphans.applied';"
+  ```
+
+  `-readonly` matters here: without it, sqlite3 takes a write lock on a
+  database the live server may also be writing to.
+
+- **Container STOPPED** (the usual state around a promotion, and the state
+  the command above was never checked against): `-readonly` fails outright
+  with `Error: in prepare, unable to open database file (14)`. A WAL-mode
+  database cannot be opened read-only unless sqlite3 can also access its
+  shared-memory file, and a cleanly stopped container has usually
+  checkpointed and removed the `-shm`/`-wal` sidecars, so there is nothing
+  for `-readonly` to attach to. Dropping `-readonly` instead "works" in the
+  sense that it returns the right row, but it creates `-wal` and `-shm`
+  sidecar files next to the live database as a side effect of opening it
+  for writing, which is exactly the workaround the running-container case
+  above warns against. Use the `immutable` URI query parameter instead,
+  which reads a WAL-mode database without ever trying to write to it or
+  create sidecar files:
+
+  ```bash
+  sqlite3 "file:/var/lib/plexmediaserver/CouchPotato/config/data/database_v2/couchpotato.db?immutable=1" \
+    "SELECT count(*), group_concat(json_extract(data,'\$.value'))
+       FROM documents
+      WHERE _t='property'
+        AND json_extract(data,'\$.identifier')='migration.clean_orphans.applied';"
+  ```
+
+  `immutable=1` only gives a correct answer when nothing else has the file
+  open: it skips WAL-awareness entirely and reads the base file as-is, so
+  pointed at a database a live process is still writing to it can return a
+  stale or plain wrong answer (measured: it reported the `documents` table
+  did not exist at all, because the schema and every row were still sitting
+  in the WAL, not yet checkpointed into the base file). Use it only once the
+  container is confirmed stopped.
+
+Both forms return the same result shape:
 
 - `1|true` -- the marker is set; the cleanup has run and will not run again.
 - `0|` -- still armed; the cleanup will run on the next boot.
 - anything else -- more than one property row for the same identifier, which
   should not happen; investigate rather than assume either state.
 
-`-readonly` matters: without it, sqlite3 takes a write lock on a database a
-live server may also be writing to. The database is in WAL mode, so query
-the live file in place with its `-wal` sidecar present rather than copying
-just the `.db` file on its own.
+**Setting the marker (container STOPPED).** The spec's "Pre-deploy" section
+requires the marker to be written to production before this release ships
+there, since production has never carried it. There is no running instance
+to ask to write it, so it has to be inserted by hand as an ordinary
+`property` document, shaped exactly the way `Settings.setProperty`
+(`couchpotato/core/settings.py:834-850`) would have written it -- checked
+by inserting via the real adapter into a throwaway database and reading the
+row back, not assumed:
+
+```bash
+sqlite3 /var/lib/plexmediaserver/CouchPotato/config/data/database_v2/couchpotato.db <<'SQL'
+INSERT INTO documents (_id, _rev, _t, data, created_at, updated_at)
+VALUES (
+  lower(hex(randomblob(16))),
+  lower(hex(randomblob(4))),
+  'property',
+  '{"_t": "property", "identifier": "migration.clean_orphans.applied", "value": "true"}',
+  (julianday('now') - 2440587.5) * 86400.0,
+  (julianday('now') - 2440587.5) * 86400.0
+);
+SQL
+```
+
+`_id` (32 lowercase hex characters) and `_rev` (8 lowercase hex characters)
+match the shape `SQLiteAdapter.insert()` generates via `uuid.uuid4().hex`
+and `uuid.uuid4().hex[:8]`; `randomblob`/`hex`/`lower` reproduce that shape
+without needing Python on the host. `created_at`/`updated_at` match the
+adapter's `time.time()` float epoch via the julian-day conversion, which
+works on any sqlite3 build rather than depending on a newer
+`unixepoch(...,'subsec')` that an older host `sqlite3` may not have. Verify
+immediately with the read-only check above (`immutable=1` form, container
+still stopped) and confirm it reads `1|true` before starting the
+container. This was verified end to end against a real adapter-created
+database: the row above, inserted this exact way into an otherwise-fresh
+database, read back through the real `Env.prop('migration.clean_orphans.applied')`
+call (not just the raw SQL check) as the string `'true'`.
 
 **Standing operational rule:** the marker lives inside `couchpotato.db`, so
 any restore of that database -- including the DB restore in the Rollback

--- a/specs/BUG-017-orphan-cleanup-runs-every-boot.md
+++ b/specs/BUG-017-orphan-cleanup-runs-every-boot.md
@@ -125,6 +125,21 @@ its next boot, gated exactly as if it were a fresh install.
 - **AC-SIMP-6:** The change is confined to `couchpotato/runner.py` and its
   tests. `clean_orphans.py` itself is not edited, so the gate cannot be confused
   with a behaviour change in the cleanup.
+- **AC-DATA-7:** (fix round two, FIX A) An exception that escapes the marker
+  READ (`Env.prop(ORPHAN_CLEANUP_MARKER)`) leaves the marker unset, logs the
+  same "did not complete, will retry on next start" warning as any other
+  failure in this function, and does NOT run `clean_orphaned_movies`. This
+  supersedes fix round one's nested try/except, which treated a read failure
+  as "not yet applied" and ran the cleanup anyway -- measured, against a
+  marker that was genuinely already set, to run a completed destructive
+  migration a second time with no warning logged at any level.
+- **AC-QA-8:** (removal criterion, phrased to fail if it is not really gone)
+  The nested try/except that used to sit around the marker read in
+  `couchpotato/runner.py` is gone, and a marker read that raises results in
+  zero records deleted and a warning logged, proven by driving
+  `_run_orphan_cleanup` directly with the read patched to raise.
+- **AC-QA-9:** (removal criterion) `test_docstring_mention_is_not_miscounted_as_a_call`
+  no longer exists in `tests/unit/test_orphan_cleanup_call_site_guard.py`.
 
 ## Recorded debt, not fixed here
 
@@ -152,3 +167,18 @@ its next boot, gated exactly as if it were a fresh install.
    on ITS OWN logger, and returns 0 -- which this gate then records as a
    completed migration that removed nothing. A failed scan is currently
    indistinguishable from a genuinely clean one.
+7. `Settings.getProperty` (`couchpotato/core/settings.py:818`) swallows most
+   read failures (any `db.get` exception other than a corrupt document) into
+   a debug log and returns `None`, indistinguishable here from "never set".
+   `_run_orphan_cleanup` cannot tell the two apart and still fails open on
+   that path: it attempts the run. Fix round two (FIX A) closed the narrower
+   case where the read raises and escapes `getProperty` entirely; this wider,
+   swallowed case is untouched.
+8. A failed marker WRITE does not always raise. `Settings.setProperty`
+   (`couchpotato/core/settings.py:834-850`) wraps its `db.update` in a bare
+   `except Exception:` and falls back to `db.insert` on any failure at all.
+   Measured: with `db.update` raising `ConflictError`,
+   `Env.prop(MARKER, value='true')` raised NOTHING, produced a second
+   `property` row for the same identifier, and the marker still read back
+   `None` afterwards. The same hazard is already documented for the session
+   secret at `couchpotato/runner.py` around line 596.

--- a/specs/BUG-017-orphan-cleanup-runs-every-boot.md
+++ b/specs/BUG-017-orphan-cleanup-runs-every-boot.md
@@ -1,0 +1,113 @@
+# BUG-017: the orphan cleanup is a one-time migration that never stopped running
+
+**Status:** agreed
+**Reported:** 2026-09-04, from a production deploy of v3.76.0
+**Severity:** data loss, recoverable tier. A library record is destroyed; the
+media file is not touched.
+
+## What happened
+
+Restarting production removed "Passengers" (2016, tt1355644) from a library of
+1,084 films. The 9.9 GB file is untouched on disk. What was destroyed is the
+record that the library owns it.
+
+Measured on the production host, against a backup taken minutes before the
+restart:
+
+    documents          4329 -> 4328
+    media_identifiers  1097 -> 1096
+    media status=done  1084 -> 1083
+
+The deleted record was not metadata-less in any ordinary sense. It carried
+`"title": "Passengers"`, `identifiers: {"imdb": "tt1355644"}`, a cached poster,
+and a `release` document with status `done` pointing at the real file. Only its
+`info` sub-document was empty, and `info` is the only thing the check reads.
+
+## Root cause
+
+`couchpotato/core/migration/clean_orphans.py` classifies a movie as an orphan
+from `info.titles`, `info.original_title`, `info.year` and `info.plot` alone. It
+never reads the document's own top-level `title`, its `identifiers`, or whether
+any release points at a file on disk.
+
+`couchpotato/runner.py:475` calls it on every startup, unconditionally, outside
+any migration gate. The commit that introduced it (b40e433f5, 2026-02-11, two
+days after the SQLite adapter landed) describes it as running "as part of the
+upgrade process", but no upgrade check was ever written.
+
+Two further facts establish that it is finished work:
+
+- Roughly half the module decodes Python 2 `bytes` values. That branch is now
+  unreachable: records are read through `json.loads`
+  (`couchpotato/core/db/sqlite_adapter.py:386`), which only ever yields `str`.
+- Its stated purpose, sweeping records broken by the CodernityDB to SQLite
+  conversion, completed in February 2026.
+
+It also cleans up incompletely. After deleting the media document it attempts to
+delete child records inside `except (RecordNotFound, Exception): pass`. On
+production the release document survived and still references the deleted
+media id; two documents reference an id that no longer exists.
+
+## Owner decision
+
+2026-09-04: keep the cleanup as a migration, stop it running on every startup.
+Quoted, because it sets the scope: "as long as this clean up runs as part of the
+migration script, we don't need to run it on every start up".
+
+## Scope
+
+Gate the cleanup so it runs once and records that it has run. Nothing else.
+
+## Not in scope
+
+- **Rewriting the orphan test itself.** Once it stops running on every boot, a
+  wrong answer is only reachable by a deliberate one-time migration on a
+  database that has never had one. Correcting the check is a separate, smaller
+  risk and is recorded as debt below rather than bundled here.
+- **The other two boot-time routines.** `fix_release_quality` (which reports
+  "Found 1268 releases to check" on every start) and `fix_profile_quality_order`
+  have the same shape. They are not destructive, so they are noise and waste
+  rather than risk. Recorded as debt.
+- **Restoring the Passengers record.** Operational, done by hand from the
+  verified backup after this ships, deliberately in that order so the final
+  ungated run cannot delete it again.
+- **A schema change.** The property store
+  (`Env.prop`, `couchpotato/environment.py:79`, backed by `property` documents,
+  1,139 already present in production) is the existing mechanism.
+
+## Acceptance criteria
+
+- **AC-DATA-1:** `clean_orphaned_movies` does not run when the property
+  `migration.clean_orphans.applied` is already set. Proven by driving the real
+  startup path twice against a database holding an orphan-shaped record, and
+  asserting the record survives the second run.
+- **AC-DATA-2:** The marker is set after a completed run, including a run that
+  removed nothing. A migration that finds nothing is still a migration that has
+  run.
+- **AC-DATA-3:** The marker is NOT set when the cleanup raises. A failed
+  migration must be allowed to retry rather than being silently skipped forever.
+- **AC-QA-4:** A test proves the guard is load-bearing: with the marker absent
+  the orphan-shaped record is removed, with it present the same record survives.
+  Both directions, same fixture, so the test cannot pass vacuously.
+- **AC-OPS-5:** The startup log distinguishes "skipped, already applied" from
+  "ran, removed N". An operator reading the log can tell which happened.
+- **AC-SIMP-6:** The change is confined to `couchpotato/runner.py` and its
+  tests. `clean_orphans.py` itself is not edited, so the gate cannot be confused
+  with a behaviour change in the cleanup.
+
+## Recorded debt, not fixed here
+
+1. The orphan test reads only `info` and ignores the top-level `title`,
+   `identifiers` and any landed release. Still wrong, now only reachable
+   deliberately.
+2. Child cleanup is swallowed by a bare `except`; production carries a release
+   document pointing at a deleted media id, and the same is true of any earlier
+   deletion.
+3. `fix_release_quality` and `fix_profile_quality_order` scan the whole library
+   on every boot with no gate.
+4. Log retention on the production host is roughly two days, so it cannot be
+   established whether this routine deleted anything before 2026-09-04.
+5. Eleven film folders in the managed movie roots are referenced by no library
+   record. Cause unknown and NOT attributed to this defect. Worth an audit on
+   its own merits; one of them, Moana (2026), is on disk while the library is
+   still actively searching for it.

--- a/specs/BUG-017-orphan-cleanup-runs-every-boot.md
+++ b/specs/BUG-017-orphan-cleanup-runs-every-boot.md
@@ -66,14 +66,38 @@ Gate the cleanup so it runs once and records that it has run. Nothing else.
   risk and is recorded as debt below rather than bundled here.
 - **The other two boot-time routines.** `fix_release_quality` (which reports
   "Found 1268 releases to check" on every start) and `fix_profile_quality_order`
-  have the same shape. They are not destructive, so they are noise and waste
-  rather than risk. Recorded as debt.
+  run on every boot with no gate, but they are not the same shape as each
+  other. Measured: `fix_profile_quality_order` is not destructive and is
+  noise and waste, as originally stated. `fix_release_quality` OVERWRITES
+  `quality` and `is_3d` on release documents on every boot whenever the
+  guessed quality disagrees with the stored one
+  (`fix_release_quality.py:81-85`), so a quality corrected by hand is
+  silently reverted on the next restart. It converges within a boot and the
+  value is derived metadata rather than a user record, so it sits in the
+  "expensive to redo" tier of this project's data-risk ranking rather than
+  "gone forever" -- but it is a low-severity overwrite to gate next, not
+  mere noise. Recorded as debt, restated below.
 - **Restoring the Passengers record.** Operational, done by hand from the
   verified backup after this ships, deliberately in that order so the final
   ungated run cannot delete it again.
 - **A schema change.** The property store
   (`Env.prop`, `couchpotato/environment.py:79`, backed by `property` documents,
   1,139 already present in production) is the existing mechanism.
+
+## Pre-deploy (required)
+
+Production has never carried `migration.clean_orphans.applied`. Before this
+release reaches production, the marker MUST be written to the production
+database first, so the deploy itself is not one more ungated run of the
+cleanup on a database that has never had one. See
+`docs/development-process.md` for the read-only query that checks the
+marker's current state, and how to set it.
+
+**Standing operational rule:** the marker lives inside `couchpotato.db` as an
+ordinary `property` document, not a separate file, so any restore of that
+database -- including the disaster-recovery restore already documented for
+this project -- resets it. A restored database runs the cleanup once more on
+its next boot, gated exactly as if it were a fresh install.
 
 ## Acceptance criteria
 
@@ -84,8 +108,15 @@ Gate the cleanup so it runs once and records that it has run. Nothing else.
 - **AC-DATA-2:** The marker is set after a completed run, including a run that
   removed nothing. A migration that finds nothing is still a migration that has
   run.
-- **AC-DATA-3:** The marker is NOT set when the cleanup raises. A failed
-  migration must be allowed to retry rather than being silently skipped forever.
+- **AC-DATA-3:** The marker is NOT set when an exception escapes the run --
+  either the marker write itself raising, or (rare) an exception escaping
+  `clean_orphaned_movies`. This only covers exceptions that actually escape:
+  `clean_orphaned_movies` almost never lets one, because its own scan loop
+  catches `Exception` internally, logs a warning on its own logger, and
+  returns 0 (recorded as debt item 6 below). A failed migration must be
+  allowed to retry rather than being silently skipped forever; in practice
+  the retry is delivered by the marker write failing, not by the cleanup
+  call failing.
 - **AC-QA-4:** A test proves the guard is load-bearing: with the marker absent
   the orphan-shaped record is removed, with it present the same record survives.
   Both directions, same fixture, so the test cannot pass vacuously.
@@ -104,10 +135,20 @@ Gate the cleanup so it runs once and records that it has run. Nothing else.
    document pointing at a deleted media id, and the same is true of any earlier
    deletion.
 3. `fix_release_quality` and `fix_profile_quality_order` scan the whole library
-   on every boot with no gate.
+   on every boot with no gate. `fix_profile_quality_order` is noise;
+   `fix_release_quality` also OVERWRITES `quality` and `is_3d` on release
+   documents whenever the guessed quality disagrees with the stored one
+   (`fix_release_quality.py:81-85`), silently reverting a hand-corrected
+   quality on the next restart -- a low-severity overwrite to gate next,
+   not mere noise.
 4. Log retention on the production host is roughly two days, so it cannot be
    established whether this routine deleted anything before 2026-09-04.
 5. Eleven film folders in the managed movie roots are referenced by no library
    record. Cause unknown and NOT attributed to this defect. Worth an audit on
    its own merits; one of them, Moana (2026), is on disk while the library is
    still actively searching for it.
+6. A scan that fails completely inside `clean_orphaned_movies` is caught by
+   its own `except Exception` (`clean_orphans.py:66-70`), logged as a warning
+   on ITS OWN logger, and returns 0 -- which this gate then records as a
+   completed migration that removed nothing. A failed scan is currently
+   indistinguishable from a genuinely clean one.

--- a/specs/PERF-001-lighthouse-in-ci.md
+++ b/specs/PERF-001-lighthouse-in-ci.md
@@ -1,0 +1,107 @@
+# PERF-001: make the page-speed budgets an automated check rather than a manual command
+
+> Planning output of the multi-lens harness (`~/.claude/AGENT-HARNESS.md`).
+> Acceptance criteria below are the contract the review cycle verifies against.
+> A review finding with no AC behind it is a **spec bug**: record it in
+> "Spec gaps found at review" so the planning lens improves.
+
+**Status:** draft
+**Lenses run:** not yet run
+**Owner decision that opened this:** 2026-09-04, choosing "wire it into CI" over
+recording a hold or dropping Lighthouse, when the recurring `extract-zip`
+advisory forced the question of whether the tool earns its place.
+
+## Problem
+
+The project's engineering standards make Core Web Vitals a must-do for any user
+interface and ask for lab budgets enforced as tests in CI. This repository has
+the tooling for that and runs none of it.
+
+`lighthouserc.js` is complete and carefully written. `package.json` exposes it as
+`npm run test:lighthouse`. Nothing invokes it: `git grep -nI "lhci\|lighthouse"
+-- .github/ Makefile scripts/` returns nothing, `scripts/verify.sh` has seven
+stages and none is Lighthouse, and the pre-push hook does not run it. It fires
+only when a person types the command.
+
+Three costs follow.
+
+1. **The standard is not met and nothing says so.** A performance regression
+   ships and is discovered by the person using the software.
+2. **The risk is carried without the benefit.** `@lhci/cli` drags in
+   `lighthouse`, `puppeteer-core` and `@puppeteer/browsers`, which is the whole
+   of the `extract-zip` advisory GHSA-jmr9-qjv8-65gv (no patched release exists;
+   `extract-zip@2.0.1` is newest). That finding has now been held twice with
+   identical reasoning, in #274 and #299, re-derived by hand each time.
+3. **The safety work around it is unexercised.** `lighthouserc.js`'s upload block
+   and `tests/unit/lighthouse_upload_stays_local.test.ts` exist because the tool
+   was previously POSTing rendered reports, embedding full-page screenshots of
+   the user's media library, to a public Google endpoint (fixed in #291, T47).
+   That guard protects a command almost nobody runs.
+
+The measurement that makes this concrete: the four URLs `lighthouserc.js`
+collects are `/`, `/available/`, `/add/` and `/settings/` on port 5050, and no
+automated check has ever loaded any of them with a stopwatch.
+
+## Not in scope
+
+- **Field data.** CrUX is the metric Google actually ranks on, and a lab score is
+  necessary-but-not-sufficient. This spec buys the lab budget only. Watching
+  Search Console or PageSpeed Insights stays manual.
+- **INP.** Lighthouse lab runs cannot measure Interaction to Next Paint; Total
+  Blocking Time is the accepted lab proxy and is what this spec budgets.
+- **Removing `@lhci/cli`, or closing the `extract-zip` advisory by upgrade.**
+  Neither is available: there is no patched release. This spec makes the
+  vulnerable code path unreachable in CI rather than absent from the tree.
+- **Re-auditing the upload safety work from #291.** It is correct. This spec must
+  not weaken it, and that is an acceptance criterion, but it is not reopened.
+- **A production performance monitor.** Nothing here reaches the running server.
+
+## Design intent, for the lenses to challenge
+
+Three choices that want scrutiny rather than assumption:
+
+**Reuse Playwright's Chromium instead of letting Lighthouse fetch its own.** The
+`accessibility` job already installs Chromium via `npx playwright install`.
+Pointing Lighthouse at that binary through `CHROME_PATH` means
+`@puppeteer/browsers`' download-and-unpack path, which is the only caller of
+`extract-zip`, is never invoked in CI. That turns the held advisory from
+"accepted risk we re-argue monthly" into "not reachable by anything automated",
+which is a better answer than either of the options it was weighed against.
+
+**A guard whose assertions are all warnings is a guard that cannot fail.** The
+existing `lighthouserc.js` sets every performance assertion to `warn`. Wiring
+that into CI unchanged would produce a green job that proves nothing, which is
+worse than no job because it launders an unknown into a tick. At least the core
+budgets must be `error`.
+
+**Budget numbers must be derived, not asserted.** The standards name LCP 2.5s,
+CLS 0.1, TTFB 800ms and FCP 1.8s. Whether this app currently meets them on a CI
+runner is unknown. The honest sequence is to measure first, then set the budget
+at or tighter than the standard where the app already passes, and record an
+explicit, dated gap where it does not, rather than setting a number the app
+fails on day one and immediately learning to ignore.
+
+## Open questions for the planning cycle
+
+1. Does the performance check block the merge, or report only at first? A gate
+   that flaps teaches people to re-run until green (§11, flaky guards), and
+   Lighthouse on a shared runner is a known source of variance. What evidence
+   would settle it?
+2. Where does it run: a new job, or inside `accessibility`, which already has
+   the server, the seed and the browser? A new required status check has to be
+   added to branch protection by hand.
+3. `numberOfRuns: 3` across four URLs is twelve page loads. What is the wall
+   clock, and does it belong in the merge path at all or on a schedule?
+4. `lighthouserc.js` asserts `categories:accessibility` at `error`, which the
+   axe suite already covers more precisely. Does that assertion earn its place,
+   or is it duplicated scope for `lens-simplicity` to cut?
+
+## Acceptance criteria
+
+*To be written by the planning cycle. Not drafted here on purpose: the numbers
+in particular must come from a measurement, and pre-filling them would anchor
+the lenses to a guess.*
+
+## Spec gaps found at review
+
+*(empty)*

--- a/tests/unit/test_orphan_cleanup_call_site_guard.py
+++ b/tests/unit/test_orphan_cleanup_call_site_guard.py
@@ -31,12 +31,12 @@ Fix round two, FIX C: `_real_calls_to` originally matched only the bare
 name `clean_orphaned_movies`. A reviewer measured that renaming the import
 at the bypass site (`from couchpotato.core.migration.clean_orphans import
 clean_orphaned_movies as _oc`, then `_oc(db)` planted beside the gate)
-made the bypass invisible to this guard -- it passed, and so did the
-entire unit suite, 3797 tests, the identical count that currently reads as
-clean. `_real_calls_to` now also resolves any local name the real function
-is imported under via `from couchpotato.core.migration.clean_orphans
-import clean_orphaned_movies as <alias>` and counts calls to that name
-too.
+made the bypass invisible to this guard -- it passed, and so did every
+other test in the unit suite, none of which asserts anything about this
+call site either. `_real_calls_to` now also resolves any local name the
+real function is imported under via `from
+couchpotato.core.migration.clean_orphans import clean_orphaned_movies as
+<alias>` and counts calls to that name too.
 
 Scope of what this guard catches, so nobody later mistakes it for more
 than it is: a second call under the ORIGINAL bare name, a call via
@@ -147,14 +147,75 @@ class TestExactlyOneRealCallSiteInsideTheGate:
         )
 
 
+class TestGuardedModuleNameMatchesRunnerPysRealImport:
+    """Fourth review, item 5. `GUARDED_MODULE_NAME` above is a hand-typed
+    constant with nothing tying it to what `runner.py` actually imports.
+
+    Measured two mutations against the real `runner.py`, module path
+    changed there alone, `GUARDED_MODULE_NAME` left untouched:
+
+    - A plain module move that still calls the function under its bare
+      name does NOT by itself defeat
+      `TestExactlyOneRealCallSiteInsideTheGate` above -- `_local_names_bound_to`
+      always seeds `local_names` with the bare `func_name` regardless of
+      which module matched, so the existing call is still found. But
+      `GUARDED_MODULE_NAME` is now asserting something false about the
+      codebase, and nothing was checking that until this test.
+    - Combine the same module move with the call site's own import
+      following it under an alias (`from <new module> import
+      clean_orphaned_movies as _oc`, then `_oc(db)`) -- the exact shape
+      FIX C added alias detection for -- and `_local_names_bound_to`'s
+      alias branch never matches, because it filters on
+      `node.module == GUARDED_MODULE_NAME`, the now-stale path. Only the
+      bare name stays in scope, the aliased call becomes invisible to
+      `_real_calls_to`, and `TestExactlyOneRealCallSiteInsideTheGate` fails
+      with "found 0 calls in runner.py" -- which reads as "the gate itself
+      is gone" when the real defect is a stale module name reopening
+      exactly the bypass FIX C was meant to close.
+
+    This test ties the constant to reality directly, so a module move
+    fails loudly and specifically here, in front of both scenarios above,
+    rather than the first one going unnoticed and the second one surfacing
+    as a confusing, differently-worded failure two tests away.
+    """
+
+    def test_guarded_module_name_matches_the_real_import_in_runner_py(self):
+        _source, tree = _parse_runner()
+
+        real_import_modules = {
+            node.module
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+            for alias in node.names
+            if alias.name == GUARDED_CALL_NAME
+        }
+
+        assert real_import_modules, (
+            'runner.py contains no "from <module> import %s" statement at '
+            'all -- either the import has changed shape entirely, or the '
+            'function is no longer imported by name' % GUARDED_CALL_NAME
+        )
+        assert real_import_modules == {GUARDED_MODULE_NAME}, (
+            'GUARDED_MODULE_NAME (%r) does not match the module(s) '
+            'runner.py actually imports %s from (%s) -- update the '
+            'constant, or this guard is silently checking the wrong '
+            'module and will stop seeing real calls if the import ever '
+            'moves again' % (
+                GUARDED_MODULE_NAME, GUARDED_CALL_NAME,
+                ', '.join(sorted(real_import_modules)),
+            )
+        )
+
+
 class TestRealCallsToDetectsAnAliasedImport:
     """FIX C, fix round two. `_real_calls_to` used to match only the bare
     name `clean_orphaned_movies`, so a bypass imported under a different
     local name (`from couchpotato.core.migration.clean_orphans import
     clean_orphaned_movies as _oc`, then `_oc(db)` planted beside the gate)
     was invisible to it. A reviewer measured that exact shape passing both
-    this guard and the entire unit suite, 3797 tests, the identical count
-    that currently reads as clean.
+    this guard and the rest of the unit suite untouched -- nothing else in
+    the suite asserts on this call site, so a bypass under an alias was
+    completely invisible, not merely unlikely to be noticed.
 
     This test does not mutate the real runner.py -- it parses a small
     synthetic module string that reproduces the aliased-bypass shape, so

--- a/tests/unit/test_orphan_cleanup_call_site_guard.py
+++ b/tests/unit/test_orphan_cleanup_call_site_guard.py
@@ -1,0 +1,121 @@
+"""BUG-017 fix round one, FIX 3: a bypass beside the gate survives every
+existing test.
+
+A reviewer of commit 312f2472f restored the old unconditional
+`clean_orphaned_movies(db)` call as a second block sitting right next to
+`_run_orphan_cleanup(db, log)` at the startup call site in
+`couchpotato/runner.py`. All five gate tests in
+`tests/unit/test_orphan_cleanup_gate.py`, and the entire rest of the unit
+suite, stayed green -- because none of them assert anything about
+`runner.py`'s CALL SITE, only about `_run_orphan_cleanup` driven directly.
+A unit test that calls the gate function itself structurally cannot see
+whether something else calls the real thing beside it.
+
+Modelled on the precedent for the same shape of bug in
+`tests/unit/test_auth_required_gate.py::TestTheStartupMigrationRunsBeforeDefaultsAreMaterialised`,
+which pins `resolve_auth_required_setting()`'s position by source order for
+the same reason.
+
+That precedent counts matching source LINES by string prefix. This guard
+parses `runner.py` with `ast` instead, and counts real `ast.Call` nodes,
+because a plain string/line count of "clean_orphaned_movies(db)" is a trap
+here specifically: `_run_orphan_cleanup`'s own docstring (runner.py, around
+line 323) mentions the literal text `clean_orphaned_movies(db)` in prose,
+explaining why an unreadable property store doesn't imply the cleanup would
+also raise. A naive occurrence count sees that docstring line as a second
+call on entirely clean code, and either fails a passing repo or needs a
+fudge factor that makes the guard unable to fail on a real bypass. Parsing
+the AST and filtering to `Call` nodes only counts code that actually
+executes.
+"""
+import ast
+from pathlib import Path
+
+RUNNER_PATH = Path(__file__).resolve().parents[2] / 'couchpotato' / 'runner.py'
+
+GATE_FUNCTION_NAME = '_run_orphan_cleanup'
+GUARDED_CALL_NAME = 'clean_orphaned_movies'
+
+
+def _parse_runner():
+    source = RUNNER_PATH.read_text(encoding='utf-8')
+    return source, ast.parse(source, filename=str(RUNNER_PATH))
+
+
+def _find_function(tree, name):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def _real_calls_to(tree, func_name):
+    """Every `ast.Call` node that invokes a function named `func_name`,
+    whether referenced bare (`clean_orphaned_movies(db)`) or via attribute
+    access (`module.clean_orphaned_movies(db)`). Deliberately does not look
+    at strings, comments or docstrings -- those are `ast.Constant` nodes,
+    not `ast.Call` nodes, so prose mentioning the name is invisible here.
+    """
+    calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == func_name:
+            calls.append(node)
+        elif isinstance(func, ast.Attribute) and func.attr == func_name:
+            calls.append(node)
+    return calls
+
+
+class TestExactlyOneRealCallSiteInsideTheGate:
+    """FIX 3. `clean_orphaned_movies` must be called exactly once anywhere
+    in `runner.py`, and that one call must live inside
+    `_run_orphan_cleanup` -- never beside it at the startup call site,
+    unguarded, and never a second time anywhere else in the file.
+    """
+
+    def test_docstring_mention_is_not_miscounted_as_a_call(self):
+        """Sanity check on the guard itself, not on runner.py: the known
+        docstring mention of the literal text "clean_orphaned_movies(db)"
+        must not appear as an `ast.Call` node, or this whole guard is
+        vacuous on a file that has never had a bypass.
+        """
+        source, tree = _parse_runner()
+        assert 'clean_orphaned_movies(db)' in source, (
+            'this test assumes the docstring mention still exists; if it '
+            'was removed, this sanity check no longer proves anything and '
+            'should be removed too'
+        )
+        calls = _real_calls_to(tree, GUARDED_CALL_NAME)
+        assert len(calls) == 1, (
+            'the docstring\'s prose mention of clean_orphaned_movies(db) '
+            'must not be counted as a real call -- if it is, this guard '
+            'cannot tell prose from code and is measuring the wrong thing'
+        )
+
+    def test_exactly_one_call_and_it_is_inside_the_gate_function(self):
+        _source, tree = _parse_runner()
+
+        calls = _real_calls_to(tree, GUARDED_CALL_NAME)
+
+        assert len(calls) == 1, (
+            'expected exactly one real call to %s() in runner.py, found %d '
+            'at line(s) %s. More than one means an unguarded bypass has '
+            'been restored beside the gate; zero means the gate itself is '
+            'gone.' % (GUARDED_CALL_NAME, len(calls), [c.lineno for c in calls])
+        )
+
+        gate_fn = _find_function(tree, GATE_FUNCTION_NAME)
+        assert gate_fn is not None, (
+            '%s is missing from runner.py entirely' % GATE_FUNCTION_NAME
+        )
+
+        call_line = calls[0].lineno
+        assert gate_fn.lineno <= call_line <= gate_fn.end_lineno, (
+            'the one call to %s() at line %d is OUTSIDE %s (lines %d-%d) '
+            '-- an ungated bypass exists at the startup call site' % (
+                GUARDED_CALL_NAME, call_line, GATE_FUNCTION_NAME,
+                gate_fn.lineno, gate_fn.end_lineno,
+            )
+        )

--- a/tests/unit/test_orphan_cleanup_call_site_guard.py
+++ b/tests/unit/test_orphan_cleanup_call_site_guard.py
@@ -20,13 +20,35 @@ That precedent counts matching source LINES by string prefix. This guard
 parses `runner.py` with `ast` instead, and counts real `ast.Call` nodes,
 because a plain string/line count of "clean_orphaned_movies(db)" is a trap
 here specifically: `_run_orphan_cleanup`'s own docstring (runner.py, around
-line 323) mentions the literal text `clean_orphaned_movies(db)` in prose,
-explaining why an unreadable property store doesn't imply the cleanup would
-also raise. A naive occurrence count sees that docstring line as a second
-call on entirely clean code, and either fails a passing repo or needs a
-fudge factor that makes the guard unable to fail on a real bypass. Parsing
-the AST and filtering to `Call` nodes only counts code that actually
-executes.
+line 359) mentions the literal text `clean_orphaned_movies(db)` in prose,
+explaining why its own scan loop cannot be relied on to raise when it
+fails. A naive occurrence count sees that docstring line as a second call
+on entirely clean code, and either fails a passing repo or needs a fudge
+factor that makes the guard unable to fail on a real bypass. Parsing the
+AST and filtering to `Call` nodes only counts code that actually executes.
+
+Fix round two, FIX C: `_real_calls_to` originally matched only the bare
+name `clean_orphaned_movies`. A reviewer measured that renaming the import
+at the bypass site (`from couchpotato.core.migration.clean_orphans import
+clean_orphaned_movies as _oc`, then `_oc(db)` planted beside the gate)
+made the bypass invisible to this guard -- it passed, and so did the
+entire unit suite, 3797 tests, the identical count that currently reads as
+clean. `_real_calls_to` now also resolves any local name the real function
+is imported under via `from couchpotato.core.migration.clean_orphans
+import clean_orphaned_movies as <alias>` and counts calls to that name
+too.
+
+Scope of what this guard catches, so nobody later mistakes it for more
+than it is: a second call under the ORIGINAL bare name, a call via
+attribute access on any module alias (`module.clean_orphaned_movies(db)`,
+regardless of what `module` itself is imported as), and now a call via a
+local alias created by an explicit `from ... import ... as ...` of the
+real function. It does NOT catch a bypass reached through `getattr`, or a
+call planted in some other module that itself imports and calls the real
+function and is then invoked here under a name this guard has never heard
+of -- both of those require a second layer of indirection deliberate
+enough that a reviewer judged them non-accidents, not something a rename
+slips past by itself, and this guard does not chase them.
 """
 import ast
 from pathlib import Path
@@ -35,6 +57,7 @@ RUNNER_PATH = Path(__file__).resolve().parents[2] / 'couchpotato' / 'runner.py'
 
 GATE_FUNCTION_NAME = '_run_orphan_cleanup'
 GUARDED_CALL_NAME = 'clean_orphaned_movies'
+GUARDED_MODULE_NAME = 'couchpotato.core.migration.clean_orphans'
 
 
 def _parse_runner():
@@ -49,19 +72,41 @@ def _find_function(tree, name):
     return None
 
 
-def _real_calls_to(tree, func_name):
-    """Every `ast.Call` node that invokes a function named `func_name`,
-    whether referenced bare (`clean_orphaned_movies(db)`) or via attribute
-    access (`module.clean_orphaned_movies(db)`). Deliberately does not look
-    at strings, comments or docstrings -- those are `ast.Constant` nodes,
-    not `ast.Call` nodes, so prose mentioning the name is invisible here.
+def _local_names_bound_to(tree, module_name, func_name):
+    """Every local name `func_name` is bound to by a
+    `from module_name import func_name [as alias]` statement anywhere in
+    the tree, including `func_name` itself. Renaming the import at a
+    bypass site (`... import clean_orphaned_movies as _oc`) must not hide
+    the call from `_real_calls_to` below -- see FIX C in the module
+    docstring.
     """
+    names = {func_name}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == module_name:
+            for alias in node.names:
+                if alias.name == func_name:
+                    names.add(alias.asname or alias.name)
+    return names
+
+
+def _real_calls_to(tree, func_name, module_name=GUARDED_MODULE_NAME):
+    """Every `ast.Call` node that invokes `func_name`, whether referenced
+    bare under its original name, under a local alias created by
+    `from module_name import func_name as <alias>`, or via attribute
+    access (`module.func_name(db)`, whatever `module` itself is bound to).
+    Deliberately does not look at strings, comments or docstrings -- those
+    are `ast.Constant` nodes, not `ast.Call` nodes, so prose mentioning the
+    name is invisible here. See the module docstring for what this
+    deliberately does NOT catch.
+    """
+    local_names = _local_names_bound_to(tree, module_name, func_name)
+
     calls = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         func = node.func
-        if isinstance(func, ast.Name) and func.id == func_name:
+        if isinstance(func, ast.Name) and func.id in local_names:
             calls.append(node)
         elif isinstance(func, ast.Attribute) and func.attr == func_name:
             calls.append(node)
@@ -74,25 +119,6 @@ class TestExactlyOneRealCallSiteInsideTheGate:
     `_run_orphan_cleanup` -- never beside it at the startup call site,
     unguarded, and never a second time anywhere else in the file.
     """
-
-    def test_docstring_mention_is_not_miscounted_as_a_call(self):
-        """Sanity check on the guard itself, not on runner.py: the known
-        docstring mention of the literal text "clean_orphaned_movies(db)"
-        must not appear as an `ast.Call` node, or this whole guard is
-        vacuous on a file that has never had a bypass.
-        """
-        source, tree = _parse_runner()
-        assert 'clean_orphaned_movies(db)' in source, (
-            'this test assumes the docstring mention still exists; if it '
-            'was removed, this sanity check no longer proves anything and '
-            'should be removed too'
-        )
-        calls = _real_calls_to(tree, GUARDED_CALL_NAME)
-        assert len(calls) == 1, (
-            'the docstring\'s prose mention of clean_orphaned_movies(db) '
-            'must not be counted as a real call -- if it is, this guard '
-            'cannot tell prose from code and is measuring the wrong thing'
-        )
 
     def test_exactly_one_call_and_it_is_inside_the_gate_function(self):
         _source, tree = _parse_runner()
@@ -119,3 +145,60 @@ class TestExactlyOneRealCallSiteInsideTheGate:
                 gate_fn.lineno, gate_fn.end_lineno,
             )
         )
+
+
+class TestRealCallsToDetectsAnAliasedImport:
+    """FIX C, fix round two. `_real_calls_to` used to match only the bare
+    name `clean_orphaned_movies`, so a bypass imported under a different
+    local name (`from couchpotato.core.migration.clean_orphans import
+    clean_orphaned_movies as _oc`, then `_oc(db)` planted beside the gate)
+    was invisible to it. A reviewer measured that exact shape passing both
+    this guard and the entire unit suite, 3797 tests, the identical count
+    that currently reads as clean.
+
+    This test does not mutate the real runner.py -- it parses a small
+    synthetic module string that reproduces the aliased-bypass shape, so
+    the helper's own alias resolution is pinned on every run without
+    depending on a file mutation. The real-file mutation is proved
+    separately, by hand, as part of this fix's review evidence.
+    """
+
+    def test_call_via_an_aliased_import_is_counted(self):
+        source = (
+            "from couchpotato.core.migration.clean_orphans import "
+            "clean_orphaned_movies as _oc\n"
+            "\n"
+            "def _run_orphan_cleanup(db, log):\n"
+            "    pass\n"
+            "\n"
+            "_oc(db)\n"
+        )
+        tree = ast.parse(source)
+
+        calls = _real_calls_to(tree, GUARDED_CALL_NAME)
+
+        assert len(calls) == 1, (
+            'a call to the guarded function imported under a different '
+            'local name via "import ... as" must still be counted -- '
+            'otherwise renaming the import at an unguarded call site '
+            'defeats this guard entirely (FIX C)'
+        )
+
+    def test_call_via_the_original_bare_name_is_still_counted(self):
+        """The plain bypass -- no alias at all -- must still be caught,
+        so the alias-resolution fix cannot have narrowed the guard.
+        """
+        source = (
+            "from couchpotato.core.migration.clean_orphans import "
+            "clean_orphaned_movies\n"
+            "\n"
+            "def _run_orphan_cleanup(db, log):\n"
+            "    pass\n"
+            "\n"
+            "clean_orphaned_movies(db)\n"
+        )
+        tree = ast.parse(source)
+
+        calls = _real_calls_to(tree, GUARDED_CALL_NAME)
+
+        assert len(calls) == 1

--- a/tests/unit/test_orphan_cleanup_gate.py
+++ b/tests/unit/test_orphan_cleanup_gate.py
@@ -1,0 +1,292 @@
+"""BUG-017: the orphan-movie cleanup must run once, not on every boot.
+
+`couchpotato.core.migration.clean_orphans.clean_orphaned_movies` deletes any
+media record it classifies as an orphan. On production it deleted a real
+library entry ("Passengers", tt1355644) on a routine restart, because
+`runner.py` called it unconditionally on every startup rather than gating it
+as a one-time migration.
+
+These tests pin the gate `runner.py` is expected to grow around that call,
+keyed by the existing `Env.prop` property store (no schema change -- see
+specs/BUG-017-orphan-cleanup-runs-every-boot.md). They do NOT touch
+`clean_orphans.py` (AC-SIMP-6): its classification logic, including the fact
+it only reads `info.*` and ignores the top-level `title`/`identifiers`, is
+recorded debt, not this task.
+
+`clean_orphaned_movies` itself is driven for real via a `SQLiteAdapter` in
+every test except AC-DATA-1's, which deliberately mocks it -- see that
+test's docstring for why the two need different techniques. AC-QA-4 is the
+one that must survive deleting the gate; the others pin narrower contract
+details (call count, marker value, log wording) that a real end-to-end test
+cannot cleanly isolate on its own.
+
+Expects `couchpotato.runner` to expose:
+
+    _run_orphan_cleanup(db, log) -> None
+
+called from the startup path in place of the current unconditional
+try/except block, using the property `migration.clean_orphans.applied` as
+the one-time marker. This function does not exist yet -- every test below
+fails on import until it does, which is the correct RED for this step.
+"""
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from couchpotato.core.db.sqlite_adapter import SQLiteAdapter
+from couchpotato.core.logger import CPLog
+from couchpotato.core.settings import Settings
+from couchpotato.environment import Env
+from couchpotato.runner import _run_orphan_cleanup
+
+ORPHAN_MARKER = 'migration.clean_orphans.applied'
+
+#: The logger name runner.py's own `log = CPLog(__name__)` resolves to
+#: inside `couchpotato/runner.py`, so caplog can scope to it precisely
+#: instead of picking up unrelated noise from the rest of the suite.
+RUNNER_LOGGER = 'couchpotato.runner'
+
+
+class _RealPropertySettings(Settings):
+    """The REAL `getProperty`/`setProperty` -- `Env.prop`'s actual target --
+    without `Settings.__init__`'s API-view/event registration or
+    `setFile`'s config.ini read, neither of which belongs in a unit test and
+    neither of which `Env.prop` touches. Mirrors the `FakeSettings` pattern
+    in tests/unit/test_session_secret_store.py, which documents the same
+    reasoning for the same class.
+
+    `self.log` is set (real `Settings.__init__` only sets it inside
+    `setFile`, which nothing here calls) because `getProperty` logs via
+    `self.log.debug` on its miss path -- reading an unset property with the
+    real default `Settings()` singleton crashes with AttributeError on a
+    None `.log` outside a full app boot, which is exactly the crash the
+    'marker absent' half of this fixture would hit if left unset.
+    """
+
+    def __init__(self):
+        self.log = CPLog('test-orphan-cleanup-gate')
+        self.file = None
+        self.p = None
+        self.directories_delimiter = '::'
+
+
+def _make_db(tmp_path, name='orphan-gate'):
+    adapter = SQLiteAdapter()
+    adapter.create(str(tmp_path / name))
+    return adapter
+
+
+def _orphan_doc(imdb):
+    """A movie record `clean_orphaned_movies` classifies as an orphan: no
+    titles, no year, no plot. Deliberately not the richer production
+    "Passengers" shape (title/identifiers/landed release) -- that gap is
+    `clean_orphans.py`'s own classification bug, recorded debt and out of
+    scope here (AC-SIMP-6); this file's job is only the gate around the
+    call, and needs a fixture the real function agrees is an orphan.
+    """
+    return {
+        '_t': 'media',
+        'type': 'movie',
+        'identifiers': {'imdb': imdb},
+        'info': {},
+    }
+
+
+def _good_doc(imdb, title):
+    """A movie record with real metadata -- `clean_orphaned_movies` must
+    never remove this regardless of the gate's state."""
+    return {
+        '_t': 'media',
+        'type': 'movie',
+        'identifiers': {'imdb': imdb},
+        'info': {
+            'titles': [title],
+            'original_title': title,
+            'year': 2020,
+            'plot': '',
+        },
+    }
+
+
+@pytest.fixture
+def env(tmp_path):
+    """`Env` wired to a real, throwaway `SQLiteAdapter` -- the same db/
+    property-store seam `_run_orphan_cleanup` and `Env.prop` will actually
+    read and write in production, just pointed at tmp_path instead of the
+    real data dir.
+    """
+    db = _make_db(tmp_path)
+    old_db = Env.get('db')
+    old_settings = Env.get('settings')
+
+    Env.set('db', db)
+    Env.set('settings', _RealPropertySettings())
+
+    yield type('EnvHandle', (), {'db': db})
+
+    Env.set('db', old_db)
+    Env.set('settings', old_settings)
+    db.close()
+
+
+class TestMarkerAlreadySetSkipsTheCall:
+    """AC-DATA-1."""
+
+    def test_marker_already_set_skips_the_cleanup_call_and_the_orphan_survives(self, env):
+        """Asserts the function is never INVOKED, not just that this one
+        fixture happens to survive -- the complement to AC-QA-4's real,
+        unmocked double-direction test below, which proves the observable
+        behaviour but can't by itself distinguish "skipped" from "ran and
+        coincidentally removed nothing".
+
+        Patches `clean_orphans.clean_orphaned_movies` at its OWN module
+        rather than `couchpotato.runner.clean_orphaned_movies`: the existing
+        two migrations right below this one in runner.py
+        (fix_release_quality, fix_profile_quality_order) both import their
+        function locally inside their try block rather than at module level,
+        and the orphan cleanup being replaced here currently does the same
+        -- so this is the call-site shape already established for every
+        migration in this function, not a new constraint invented for this
+        test.
+        """
+        orphan = env.db.insert(_orphan_doc('tt0000003'))
+        Env.prop(ORPHAN_MARKER, value='true')
+        log = CPLog(RUNNER_LOGGER)
+
+        with patch(
+            'couchpotato.core.migration.clean_orphans.clean_orphaned_movies'
+        ) as mock_clean:
+            _run_orphan_cleanup(env.db, log)
+
+        mock_clean.assert_not_called()
+        survivor = env.db.get('id', orphan['_id'])
+        assert survivor['identifiers']['imdb'] == 'tt0000003'
+
+
+class TestMarkerSetAfterACompletedRun:
+    """AC-DATA-2."""
+
+    def test_marker_is_set_after_a_run_that_removed_nothing(self, env):
+        """A migration that scanned and found nothing removable has still
+        run -- it must not be retried every boot for the rest of this
+        install's life just because nothing needed cleaning up this time.
+        """
+        env.db.insert(_good_doc('tt1234567', 'A Real Movie'))
+        assert Env.prop(ORPHAN_MARKER) is None
+        log = CPLog(RUNNER_LOGGER)
+
+        _run_orphan_cleanup(env.db, log)
+
+        assert Env.prop(ORPHAN_MARKER), (
+            'the marker must be set even though clean_orphaned_movies '
+            'removed zero records -- a completed no-op scan is still a '
+            'completed migration (AC-DATA-2)'
+        )
+
+
+class TestMarkerNotSetWhenCleanupRaises:
+    """AC-DATA-3."""
+
+    def test_marker_not_set_when_cleanup_raises_and_the_warning_is_still_logged(self, env, caplog):
+        """A failed migration must be retryable on the next boot, so the
+        marker write has to be conditional on success -- but the existing
+        behaviour of swallowing the exception into a log.warning (so a
+        cleanup bug cannot abort startup) must survive unchanged; only the
+        marker write becomes conditional.
+        """
+        env.db.insert(_orphan_doc('tt7777777'))
+        log = CPLog(RUNNER_LOGGER)
+
+        with patch(
+            'couchpotato.core.migration.clean_orphans.clean_orphaned_movies',
+            side_effect=RuntimeError('boom'),
+        ):
+            with caplog.at_level(logging.WARNING, logger=RUNNER_LOGGER):
+                _run_orphan_cleanup(env.db, log)  # must not raise out of here
+
+        assert Env.prop(ORPHAN_MARKER) is None, (
+            'a failed run must not be marked applied -- it has to retry on '
+            'the next start (AC-DATA-3)'
+        )
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any('orphan' in r.getMessage().lower() for r in warnings), (
+            'the existing "Orphan cleanup skipped: ..." warning must still '
+            'fire on failure -- only the marker write is newly conditional'
+        )
+
+
+class TestStartupLogDistinguishesSkipFromRun:
+    """AC-OPS-5."""
+
+    def test_startup_log_distinguishes_skip_from_run(self, env, caplog):
+        """Drives the real startup path twice on the same db, same as
+        AC-DATA-1's proof shape: first boot has no marker and runs (and
+        removes the seeded orphan, so a "ran" line is guaranteed rather than
+        depending on whether zero-removed runs also log); second boot has
+        the marker and skips. An operator reading the log must be able to
+        tell the two apart without cross-referencing the database.
+        """
+        env.db.insert(_orphan_doc('tt8888888'))
+        log = CPLog(RUNNER_LOGGER)
+
+        with caplog.at_level(logging.INFO, logger=RUNNER_LOGGER):
+            _run_orphan_cleanup(env.db, log)
+        run_messages = [r.getMessage().lower() for r in caplog.records]
+        caplog.clear()
+
+        with caplog.at_level(logging.INFO, logger=RUNNER_LOGGER):
+            _run_orphan_cleanup(env.db, log)
+        skip_messages = [r.getMessage().lower() for r in caplog.records]
+
+        assert any('ran' in m or 'removed' in m for m in run_messages), (
+            'the run that actually cleaned the database must say so (AC-OPS-5)'
+        )
+        assert any('skip' in m and 'applied' in m for m in skip_messages), (
+            'the run that was skipped because the marker is already applied '
+            'must say so, using words an operator can distinguish from the '
+            '"ran" line above (AC-OPS-5)'
+        )
+
+
+class TestGateIsLoadBearing:
+    """AC-QA-4 -- the point of this task. One db, one fixture, both
+    directions, proven with the REAL clean_orphaned_movies (no mocking):
+    with the marker absent an orphan is removed; with the marker present an
+    identically-shaped orphan inserted afterwards survives the same call.
+
+    This is the test that must fail if the gate is deleted: an unconditional
+    call would remove the second orphan too, since it is a genuine orphan by
+    clean_orphans.py's own rules. Every other test in this file pins a
+    narrower contract detail (call count, marker value, log wording) that
+    this one does not by itself distinguish.
+    """
+
+    def test_marker_absent_removes_the_orphan_marker_present_keeps_it(self, env):
+        log = CPLog(RUNNER_LOGGER)
+
+        # Direction one: no marker yet -> the orphan is removed.
+        first = env.db.insert(_orphan_doc('tt0000001'))
+        assert Env.prop(ORPHAN_MARKER) is None
+
+        _run_orphan_cleanup(env.db, log)
+
+        with pytest.raises(KeyError):
+            env.db.get('id', first['_id'])
+        assert Env.prop(ORPHAN_MARKER), (
+            'the first run must have set the marker -- direction two below '
+            'depends on it, and AC-DATA-2 pins this on its own'
+        )
+
+        # Direction two: marker now set -> a fresh, identically-shaped
+        # orphan inserted AFTER the first run survives the same call.
+        second = env.db.insert(_orphan_doc('tt0000002'))
+
+        _run_orphan_cleanup(env.db, log)
+
+        survivor = env.db.get('id', second['_id'])
+        assert survivor['identifiers']['imdb'] == 'tt0000002', (
+            'an orphan-shaped record inserted after the marker was set must '
+            'survive a later run -- if this fails, the gate is not '
+            "preventing the call, only AC-DATA-1's mock made it look like it was"
+        )

--- a/tests/unit/test_orphan_cleanup_gate.py
+++ b/tests/unit/test_orphan_cleanup_gate.py
@@ -264,25 +264,38 @@ class TestMarkerWriteFailureStillLogsTheCount:
         )
 
 
-class TestMarkerReadFailureDoesNotAbortBoot:
-    """Regression test for fix round one, FIX 5.
+class TestMarkerReadFailureDoesNotRunTheCleanup:
+    """Regression test for fix round two, FIX A -- supersedes round one's
+    FIX 5, which is now the bug.
 
-    `Env.prop(ORPHAN_CLEANUP_MARKER)` (the read) used to sit OUTSIDE the
-    try/except in `_run_orphan_cleanup`. `Settings.getProperty` calls
-    `self.log.debug(...)` on its miss path, and `self.log` is None until
-    `Settings.setFile()` has run -- not reachable via CouchPotato.py's real
-    boot order today, but a read that raised there would propagate straight
-    out of `_run_orphan_cleanup` and abort startup, unlike every other
-    property-store failure this function already tolerates.
+    Round one wrapped the marker READ in its own nested try/except so a
+    read failure was treated as "not yet applied" and the migration still
+    ran to completion. Round two's adversarial review measured the actual
+    cost of that: with the marker genuinely already set (a completed
+    migration) and the read raising anyway, the nested except swallowed
+    the read failure so completely that nothing downstream could tell it
+    had happened. The cleanup ran a SECOND time, for real, with no warning
+    logged at any level -- a completed destructive migration silently ran
+    again.
 
-    The fix moves the read inside the try (nested, so its own failure is
-    treated as "not yet applied" rather than as the run's overall failure),
-    preserving the documented fail-open intent: an unreadable marker must
-    still let the migration attempt to run, not merely fail without
-    crashing.
+    The nested try/except is deleted. The marker read now sits directly
+    inside the outer try, so a read failure is caught by the SAME handler
+    that already handles a failed `clean_orphaned_movies()` call or a
+    failed marker write: it logs the "did not complete, will retry"
+    warning, does NOT run the cleanup, and leaves the marker unset so the
+    next boot retries. This is a genuine behaviour change from round one:
+    a marker read failure now fails SAFE (nothing runs) rather than fail
+    OPEN (the migration runs regardless of the marker's real state).
     """
 
-    def test_marker_read_raising_does_not_abort_the_boot_and_the_run_still_happens(self, env, caplog):
+    def test_marker_read_raising_prevents_a_second_destructive_run(self, env, caplog):
+        """Matches the scenario the round-two review measured directly:
+        the marker is genuinely already applied, and the read raises
+        anyway. Proves the cleanup is not invoked a second time and a
+        warning is logged, where round one's code deleted the record and
+        logged nothing.
+        """
+        Env.prop(ORPHAN_MARKER, value='true')
         orphan = env.db.insert(_orphan_doc('tt9999999'))
         log = CPLog(RUNNER_LOGGER)
 
@@ -293,20 +306,59 @@ class TestMarkerReadFailureDoesNotAbortBoot:
                 raise AttributeError("'NoneType' object has no attribute 'debug'")
             return original_prop(identifier, value=value, default=default)
 
-        with patch('couchpotato.environment.Env.prop', side_effect=prop_that_fails_only_on_read):
-            with caplog.at_level(logging.INFO, logger=RUNNER_LOGGER):
-                _run_orphan_cleanup(env.db, log)  # must not raise out of here
+        with patch(
+            'couchpotato.core.migration.clean_orphans.clean_orphaned_movies'
+        ) as mock_clean:
+            with patch('couchpotato.environment.Env.prop', side_effect=prop_that_fails_only_on_read):
+                with caplog.at_level(logging.WARNING, logger=RUNNER_LOGGER):
+                    _run_orphan_cleanup(env.db, log)  # must not raise out of here
 
-        # The real assertion: the migration still ATTEMPTED and COMPLETED
-        # the run despite the unreadable marker, rather than merely failing
-        # without crashing -- so the seeded orphan was actually removed and
-        # the marker ends up set via the (unpatched) write.
-        with pytest.raises(KeyError):
-            env.db.get('id', orphan['_id'])
-        assert Env.prop(ORPHAN_MARKER), (
-            'a marker READ failure must be treated as "not yet applied" and '
-            'the migration must still run to completion and set the marker '
-            '-- not merely swallow the exception and skip the run (FIX 5)'
+        mock_clean.assert_not_called()
+        survivor = env.db.get('id', orphan['_id'])
+        assert survivor['identifiers']['imdb'] == 'tt9999999', (
+            'a marker read failure must not let a completed migration run '
+            'a second time'
+        )
+        warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            'did not complete' in m.lower() or 'will retry' in m.lower()
+            for m in warnings
+        ), (
+            'a marker read failure must be logged as a warning -- silently '
+            'running the migration again with no warning at any level is '
+            'exactly the defect this fix removes'
+        )
+
+    def test_marker_read_raising_leaves_the_marker_unset_when_never_applied(self, env, caplog):
+        """The other direction: an install that has never run the
+        migration, whose read also fails. The marker must stay unset (so
+        the next boot retries) and the cleanup must not run blind.
+        """
+        orphan = env.db.insert(_orphan_doc('tt9999998'))
+        assert Env.prop(ORPHAN_MARKER) is None
+        log = CPLog(RUNNER_LOGGER)
+
+        original_prop = Env.prop
+
+        def prop_that_fails_only_on_read(identifier, value=None, default=None):
+            if value is None:
+                raise AttributeError("'NoneType' object has no attribute 'debug'")
+            return original_prop(identifier, value=value, default=default)
+
+        with patch(
+            'couchpotato.core.migration.clean_orphans.clean_orphaned_movies'
+        ) as mock_clean:
+            with patch('couchpotato.environment.Env.prop', side_effect=prop_that_fails_only_on_read):
+                with caplog.at_level(logging.WARNING, logger=RUNNER_LOGGER):
+                    _run_orphan_cleanup(env.db, log)  # must not raise out of here
+
+        mock_clean.assert_not_called()
+        survivor = env.db.get('id', orphan['_id'])
+        assert survivor['identifiers']['imdb'] == 'tt9999998'
+        assert Env.prop(ORPHAN_MARKER) is None, (
+            'a marker read failure on a never-applied install must leave '
+            'the marker unset so the next boot retries, not run the '
+            'migration blind and not silently skip it forever either'
         )
 
 

--- a/tests/unit/test_orphan_cleanup_gate.py
+++ b/tests/unit/test_orphan_cleanup_gate.py
@@ -211,13 +211,122 @@ class TestMarkerNotSetWhenCleanupRaises:
         )
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert any('orphan' in r.getMessage().lower() for r in warnings), (
-            'the existing "Orphan cleanup skipped: ..." warning must still '
-            'fire on failure -- only the marker write is newly conditional'
+            'the existing "Orphan cleanup did not complete, will retry on '
+            'next start: ..." warning must still fire on failure -- only '
+            'the marker write is newly conditional'
+        )
+
+
+class TestMarkerWriteFailureStillLogsTheCount:
+    """Regression test for fix round one, FIX 1.
+
+    A reviewer of commit 312f2472f measured this against the code as it
+    shipped: `_run_orphan_cleanup` wrote the marker BEFORE logging the
+    removed count, so a marker write that raised (locked or read-only
+    database, disk full, another writer) meant the count line was never
+    reached -- the ONLY line on the runner logger read "Orphan cleanup
+    skipped", indistinguishable from a no-op skip, on a boot that had just
+    deleted real records. Measured on that reviewer's fixture: three
+    records destroyed, log said skipped.
+
+    The fix moves the count log above the marker write, so a failed marker
+    write now produces BOTH the count line and the failure line.
+    """
+
+    def test_a_failed_marker_write_still_logs_the_removed_count(self, env, caplog):
+        env.db.insert(_orphan_doc('tt5555555'))
+        log = CPLog(RUNNER_LOGGER)
+
+        original_prop = Env.prop
+
+        def prop_that_fails_only_on_write(identifier, value=None, default=None):
+            if value is None:
+                return original_prop(identifier, default=default)
+            raise OSError('database is locked')
+
+        with patch('couchpotato.environment.Env.prop', side_effect=prop_that_fails_only_on_write):
+            with caplog.at_level(logging.INFO, logger=RUNNER_LOGGER):
+                _run_orphan_cleanup(env.db, log)  # must not raise out of here
+
+        messages = [r.getMessage().lower() for r in caplog.records]
+        assert any('orphan cleanup ran: removed 1' in m for m in messages), (
+            'the count of what was actually removed must be logged even '
+            'when the marker write that follows it fails -- otherwise a '
+            'boot that destroyed real records logs only "skipped" (FIX 1)'
+        )
+        assert any('did not complete' in m or 'will retry' in m for m in messages), (
+            'the marker-write failure itself must ALSO be logged, so an '
+            'operator sees both what happened and that it will retry (FIX 1)'
+        )
+        assert Env.prop(ORPHAN_MARKER) is None, (
+            'a failed marker write must leave the marker unset so the next '
+            'boot retries the migration'
+        )
+
+
+class TestMarkerReadFailureDoesNotAbortBoot:
+    """Regression test for fix round one, FIX 5.
+
+    `Env.prop(ORPHAN_CLEANUP_MARKER)` (the read) used to sit OUTSIDE the
+    try/except in `_run_orphan_cleanup`. `Settings.getProperty` calls
+    `self.log.debug(...)` on its miss path, and `self.log` is None until
+    `Settings.setFile()` has run -- not reachable via CouchPotato.py's real
+    boot order today, but a read that raised there would propagate straight
+    out of `_run_orphan_cleanup` and abort startup, unlike every other
+    property-store failure this function already tolerates.
+
+    The fix moves the read inside the try (nested, so its own failure is
+    treated as "not yet applied" rather than as the run's overall failure),
+    preserving the documented fail-open intent: an unreadable marker must
+    still let the migration attempt to run, not merely fail without
+    crashing.
+    """
+
+    def test_marker_read_raising_does_not_abort_the_boot_and_the_run_still_happens(self, env, caplog):
+        orphan = env.db.insert(_orphan_doc('tt9999999'))
+        log = CPLog(RUNNER_LOGGER)
+
+        original_prop = Env.prop
+
+        def prop_that_fails_only_on_read(identifier, value=None, default=None):
+            if value is None:
+                raise AttributeError("'NoneType' object has no attribute 'debug'")
+            return original_prop(identifier, value=value, default=default)
+
+        with patch('couchpotato.environment.Env.prop', side_effect=prop_that_fails_only_on_read):
+            with caplog.at_level(logging.INFO, logger=RUNNER_LOGGER):
+                _run_orphan_cleanup(env.db, log)  # must not raise out of here
+
+        # The real assertion: the migration still ATTEMPTED and COMPLETED
+        # the run despite the unreadable marker, rather than merely failing
+        # without crashing -- so the seeded orphan was actually removed and
+        # the marker ends up set via the (unpatched) write.
+        with pytest.raises(KeyError):
+            env.db.get('id', orphan['_id'])
+        assert Env.prop(ORPHAN_MARKER), (
+            'a marker READ failure must be treated as "not yet applied" and '
+            'the migration must still run to completion and set the marker '
+            '-- not merely swallow the exception and skip the run (FIX 5)'
         )
 
 
 class TestStartupLogDistinguishesSkipFromRun:
-    """AC-OPS-5."""
+    """AC-OPS-5.
+
+    Updated for fix round one, FIX 2: a reviewer found that
+    `grep "Orphan cleanup skipped"` matched two log lines with opposite
+    meanings -- the finished-and-good "already applied" INFO line, and the
+    armed-and-will-retry failure WARNING line, which used to share the same
+    "skipped" prefix. The failure line is now worded "Orphan cleanup did
+    not complete, will retry on next start: %s" so the two states are
+    distinguishable by text alone, not only by log level.
+
+    The "ran" assertion below is also tightened: a reviewer flagged the
+    original `'ran' in m or 'removed' in m` as a substring-on-prose smell
+    that could match a log line that merely mentions those words rather
+    than the real success message. It now checks the actual message
+    prefix.
+    """
 
     def test_startup_log_distinguishes_skip_from_run(self, env, caplog):
         """Drives the real startup path twice on the same db, same as
@@ -239,13 +348,16 @@ class TestStartupLogDistinguishesSkipFromRun:
             _run_orphan_cleanup(env.db, log)
         skip_messages = [r.getMessage().lower() for r in caplog.records]
 
-        assert any('ran' in m or 'removed' in m for m in run_messages), (
-            'the run that actually cleaned the database must say so (AC-OPS-5)'
+        assert any('orphan cleanup ran: removed' in m for m in run_messages), (
+            'the run that actually cleaned the database must log the exact '
+            '"ran: removed N" line, not merely something that happens to '
+            'contain "ran" or "removed" (AC-OPS-5)'
         )
-        assert any('skip' in m and 'applied' in m for m in skip_messages), (
+        assert any('orphan cleanup skipped: already applied' in m for m in skip_messages), (
             'the run that was skipped because the marker is already applied '
-            'must say so, using words an operator can distinguish from the '
-            '"ran" line above (AC-OPS-5)'
+            'must say so with the exact "skipped: already applied" wording, '
+            'which is now the ONLY meaning that prefix carries in this '
+            'logger -- the failure path no longer shares it (AC-OPS-5, FIX 2)'
         )
 
 

--- a/tests/unit/test_orphan_cleanup_gate.py
+++ b/tests/unit/test_orphan_cleanup_gate.py
@@ -294,9 +294,17 @@ class TestMarkerReadFailureDoesNotRunTheCleanup:
         anyway. Proves the cleanup is not invoked a second time and a
         warning is logged, where round one's code deleted the record and
         logged nothing.
+
+        `clean_orphaned_movies` is mocked out here (unlike AC-QA-4's
+        real, unmocked double-direction test), so `mock_clean.assert_not_called()`
+        is the ONLY assertion that can actually fail this test -- a record
+        survival check would be illustrative at best: the mock cannot
+        delete anything regardless of whether the gate did its job, so it
+        would pass even with the gate removed entirely (fourth review,
+        item 6b). Dropped rather than kept as decoration, per this
+        project's repeated experience with assertions that cannot fail.
         """
         Env.prop(ORPHAN_MARKER, value='true')
-        orphan = env.db.insert(_orphan_doc('tt9999999'))
         log = CPLog(RUNNER_LOGGER)
 
         original_prop = Env.prop
@@ -314,11 +322,6 @@ class TestMarkerReadFailureDoesNotRunTheCleanup:
                     _run_orphan_cleanup(env.db, log)  # must not raise out of here
 
         mock_clean.assert_not_called()
-        survivor = env.db.get('id', orphan['_id'])
-        assert survivor['identifiers']['imdb'] == 'tt9999999', (
-            'a marker read failure must not let a completed migration run '
-            'a second time'
-        )
         warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
         assert any(
             'did not complete' in m.lower() or 'will retry' in m.lower()
@@ -410,6 +413,47 @@ class TestStartupLogDistinguishesSkipFromRun:
             'must say so with the exact "skipped: already applied" wording, '
             'which is now the ONLY meaning that prefix carries in this '
             'logger -- the failure path no longer shares it (AC-OPS-5, FIX 2)'
+        )
+
+
+class TestFailureWarningNeverSharesTheSkippedPrefix:
+    """Fourth review, item 2. FIX 2 above separated the two log messages
+    that used to share the prefix "Orphan cleanup skipped" -- the benign
+    INFO ("already applied.") and the WARNING that means the migration is
+    still armed and will retry. Nothing before this test actually GUARDED
+    that separation: the existing failure-path assertions
+    (`'did not complete' in m or 'will retry' in m`) are satisfied by
+    either wording, so a reviewer who reworded the failure warning back to
+    'Orphan cleanup skipped: did not complete, will retry on next start:
+    %s' -- restoring the exact defect FIX 2 fixed -- left the entire unit
+    suite green, because nothing anywhere was asserting on the ABSENCE of
+    "skipped" from that specific message.
+
+    This test closes that gap directly: it drives a real failure and
+    asserts the resulting warning does not contain the string "Orphan
+    cleanup skipped", so a regression is caught here rather than needing a
+    human to notice the reworded string in a diff.
+    """
+
+    def test_the_failure_warning_does_not_contain_the_word_skipped(self, env, caplog):
+        env.db.insert(_orphan_doc('tt6666666'))
+        log = CPLog(RUNNER_LOGGER)
+
+        with patch(
+            'couchpotato.core.migration.clean_orphans.clean_orphaned_movies',
+            side_effect=RuntimeError('boom'),
+        ):
+            with caplog.at_level(logging.WARNING, logger=RUNNER_LOGGER):
+                _run_orphan_cleanup(env.db, log)  # must not raise out of here
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, 'expected a warning to be logged when the cleanup raises'
+        assert not any('Orphan cleanup skipped' in m for m in warnings), (
+            'the FAILURE warning must never contain "Orphan cleanup skipped" '
+            '-- that prefix means finished-and-good in the INFO line above, '
+            'and a failure warning that shares it is indistinguishable from '
+            'a benign skip by anyone grepping the log for it (the exact '
+            'defect FIX 2 removed)'
         )
 
 


### PR DESCRIPTION
A routine production restart on 2026-09-04 deleted "Passengers" (2016) from a
library of 1,084 films. The 9.9 GB file was untouched; the record that the
library owns it was destroyed.

## The defect

`couchpotato/core/migration/clean_orphans.py` classifies a movie as an orphan
from `info.titles`, `info.original_title`, `info.year` and `info.plot` alone.
The deleted record carried `"title": "Passengers"`, `identifiers: {"imdb":
"tt1355644"}`, a cached poster, and a `release` document with status `done`
pointing at the real file. Only its `info` sub-document was empty, and `info` is
the only thing the check reads.

`couchpotato/runner.py` called it on every startup, unconditionally, outside any
migration gate. The commit that introduced it (b40e433f5, 2026-02-11, two days
after the SQLite adapter landed) describes it as running "as part of the upgrade
process". No upgrade check was ever written, so it has run on every boot since
February.

Measured on the production host against a backup taken minutes before:

```
documents          4329 -> 4328
media_identifiers  1097 -> 1096
media status=done  1084 -> 1083
```

## What this changes

The cleanup is gated behind a property-store marker
(`migration.clean_orphans.applied`) so it runs once per install rather than on
every boot. `clean_orphans.py` itself is deliberately untouched: the
classification logic is separate, still wrong, and recorded as debt. Keeping
this change to the gate alone means a behaviour change in the cleanup can never
be confused with the gate that decides whether it runs.

No schema change. The marker is an ordinary `property` document, the mechanism
`Env.prop` already uses; production carries 1,139 of them.

## Review history, stated because it is unusual

Five commits, three fix rounds, four independent review passes. Two rounds hit
the rework circuit-breaker and were escalated to the owner rather than iterated
through. The escalations were right both times:

- **Round one introduced a defect.** A nested `try/except` added around the
  marker read turned a loud boot failure that deleted nothing into a silent
  success that deleted a film. Measured: marker set, read raises, before it
  logged `removed 1` and destroyed a record; after deleting the nesting it logs
  a warning, destroys nothing, and retries next boot. **The fix was to remove
  code, not add it.**
- **Round two shipped a runbook command that reads backwards.** The documented
  stopped-container check reported "marker not set" on a database where it was
  set, whenever the container had not stopped cleanly. Reproduced twice with two
  different symptoms (a wrong answer, and a hard error). Corrected to key on the
  write-ahead log's size, which is observable by listing the directory.

## Guards, and proof they are load-bearing

Every guard here was broken deliberately, watched to fail, and restored by file
copy with a hash check.

| Guard | Proven by |
|---|---|
| The gate itself | Replacing the marker check with `if False:` fails 3 tests with `KeyError: Document not found`, the real deletion symptom |
| The call site | Reinstating the old unconditional block beside the gated call passed all 3799 tests before this guard existed; it now fails naming both lines |
| An aliased bypass | `import ... as _oc` then `_oc(db)` also passed everything; the guard now resolves the import binding and catches it |
| The marker-read path | Restoring round one's nested `try/except` fails both new tests on `assert_not_called` |
| The log wording | Reintroducing the shared `Orphan cleanup skipped` prefix fails the new assertion while the other 8 stay green |
| The guard's own module pin | Moving the import path fails loudly instead of silently disarming alias detection |

One vacuous test was found and deleted: its premise assertion was satisfied by
the real call site regardless of the docstring it claimed to be checking.

## Deploying this

**The marker must be written to the production database BEFORE this release is
deployed there.** Production has never carried it, so the deploy would otherwise
be one more ungated run of the cleanup. The procedure and the check are in
`docs/development-process.md` under "One-time boot migration markers".

Standing rule recorded there too: the marker lives inside `couchpotato.db`, so
any database restore resets it and the cleanup runs once more on the next boot,
gated exactly as a fresh install would be.

## Recorded debt, not fixed here

1. The orphan test ignores the top-level `title`, `identifiers` and any landed
   release. Still wrong, now only reachable deliberately.
2. Child cleanup is swallowed by a bare `except`; production carries a release
   document pointing at a deleted media id.
3. `fix_release_quality` and `fix_profile_quality_order` are still ungated.
   `fix_release_quality` overwrites `quality` and `is_3d` on every boot, so a
   hand-corrected quality is silently reverted.
4. Production log retention is roughly two days, so it cannot be established
   whether this routine deleted anything before 2026-09-04. A disk audit found
   no evidence of earlier deletions, but it can only see films still on disk.
5. `getProperty` swallows most read failures into `None`, so a residual
   fail-open path remains inside it.
6. `setProperty` can fail without raising, falling back to `db.insert` and
   leaving duplicate rows.
7. One weak assertion left in place in an adjacent test, flagged by the
   implementer rather than silently widened.

Local gate green. Two independent `code-reviewer` passes plus two adversarial
`reviewer-verification` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
