### PR TITLE
fix(a11y): the setup wizard's form labels were not associated with any field

### DIFF
--- a/couchpotato/ui/templates/wizard.html
+++ b/couchpotato/ui/templates/wizard.html
@@ -95,13 +95,13 @@
         
         <div class="space-y-4">
           <div>
-            <label class="block text-xs text-cp-muted mb-1.5">Username</label>
-            <input type="text" x-model="formData.username" placeholder="Leave empty to skip"
+            <label for="wizard-username" class="block text-xs text-cp-muted mb-1.5">Username</label>
+            <input id="wizard-username" type="text" x-model="formData.username" placeholder="Leave empty to skip"
                    class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-4 py-2.5 text-sm focus:outline-none focus:border-cp-accent/30">
           </div>
           <div>
-            <label class="block text-xs text-cp-muted mb-1.5">Password</label>
-            <input type="password" x-model="formData.password" placeholder="Leave empty to skip"
+            <label for="wizard-password" class="block text-xs text-cp-muted mb-1.5">Password</label>
+            <input id="wizard-password" type="password" x-model="formData.password" placeholder="Leave empty to skip"
                    class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-4 py-2.5 text-sm focus:outline-none focus:border-cp-accent/30">
           </div>
         </div>
@@ -162,10 +162,10 @@
             <div x-show="formData.newznab.enabled" x-transition class="space-y-3">
               <template x-for="(entry, idx) in formData.newznab.entries" :key="idx">
                 <div class="flex gap-2 items-center">
-                  <input type="text" :placeholder="'Indexer URL (e.g. https://api.nzbgeek.info)'" 
+                  <input type="text" aria-label="Newznab indexer URL" :placeholder="'Indexer URL (e.g. https://api.nzbgeek.info)'" 
                          x-model="entry.host"
                          class="flex-[2] bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
-                  <input type="password" placeholder="API Key" x-model="entry.api_key" autocomplete="new-password"
+                  <input type="password" aria-label="Newznab API key" placeholder="API Key" x-model="entry.api_key" autocomplete="new-password"
                          class="flex-1 bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   <button @click="formData.newznab.entries.splice(idx, 1)" x-show="formData.newznab.entries.length > 1"
                           class="text-cp-muted hover:text-cp-danger transition-colors">
@@ -259,13 +259,13 @@
               </div>
               <div x-show="formData.torrentpotato.enabled" x-transition class="space-y-3">
                 <div>
-                  <label class="block text-xs text-cp-muted mb-1">Jackett URL</label>
-                  <input type="text" x-model="formData.torrentpotato.jackett_url" placeholder="http://localhost:9117"
+                  <label for="wizard-jackett-url" class="block text-xs text-cp-muted mb-1">Jackett URL</label>
+                  <input id="wizard-jackett-url" type="text" x-model="formData.torrentpotato.jackett_url" placeholder="http://localhost:9117"
                          class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                 </div>
                 <div>
-                  <label class="block text-xs text-cp-muted mb-1">Jackett API Key</label>
-                  <input type="password" x-model="formData.torrentpotato.jackett_api_key" placeholder="Your Jackett API key"
+                  <label for="wizard-jackett-api-key" class="block text-xs text-cp-muted mb-1">Jackett API Key</label>
+                  <input id="wizard-jackett-api-key" type="password" x-model="formData.torrentpotato.jackett_api_key" placeholder="Your Jackett API key"
                          class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                 </div>
                 <button @click="syncJackett()" :disabled="jackettSyncing"
@@ -310,7 +310,7 @@
                   <div x-show="tracker.enabled" x-transition class="grid grid-cols-2 gap-2 mt-3">
                     <template x-for="field in tracker.fields" :key="field.name">
                       <div :class="field.full ? 'col-span-2' : ''">
-                        <label class="block text-[10px] text-cp-muted mb-1" x-text="field.label"></label>
+                        <label :for="'wizard-tracker-' + tracker.id + '-' + field.name" class="block text-[10px] text-cp-muted mb-1" x-text="field.label"></label>
                         {#- autocomplete="new-password" for the same reason as the
                             direct credential inputs: these render as
                             type="password" for every tracker's `password` and
@@ -330,7 +330,7 @@
                             for tracker usernames" has found the cause, and the
                             fix is to move the attribute into the field data,
                             not to drop it. -#}
-                        <input :type="field.type || 'text'" x-model="formData.privateTrackers[tracker.id][field.name]"
+                        <input :id="'wizard-tracker-' + tracker.id + '-' + field.name" :type="field.type || 'text'" x-model="formData.privateTrackers[tracker.id][field.name]"
                                autocomplete="new-password"
                                :placeholder="field.placeholder || ''"
                                class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-1.5 text-xs focus:outline-none focus:border-cp-accent/30">
@@ -421,17 +421,17 @@
             </div>
             <div x-show="formData.blackholeEnabled" x-transition class="space-y-3">
               <div>
-                <label class="block text-xs text-cp-muted mb-1">NZB Watch Folder</label>
+                <label for="wizard-blackhole-nzb-dir" class="block text-xs text-cp-muted mb-1">NZB Watch Folder</label>
                 <div class="flex gap-2">
-                  <input type="text" x-model="formData.downloaderConfig.blackhole.nzb_directory" placeholder="/path/to/nzb/watch"
+                  <input id="wizard-blackhole-nzb-dir" type="text" x-model="formData.downloaderConfig.blackhole.nzb_directory" placeholder="/path/to/nzb/watch"
                          class="flex-1 bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   <button @click="browseDirectory('blackhole_nzb')" class="px-3 py-2 rounded-md text-xs bg-white/[0.04] text-cp-muted hover:text-cp-text hover:bg-white/[0.06] transition-colors">Browse</button>
                 </div>
               </div>
               <div>
-                <label class="block text-xs text-cp-muted mb-1">Torrent Watch Folder</label>
+                <label for="wizard-blackhole-torrent-dir" class="block text-xs text-cp-muted mb-1">Torrent Watch Folder</label>
                 <div class="flex gap-2">
-                  <input type="text" x-model="formData.downloaderConfig.blackhole.torrent_directory" placeholder="/path/to/torrent/watch"
+                  <input id="wizard-blackhole-torrent-dir" type="text" x-model="formData.downloaderConfig.blackhole.torrent_directory" placeholder="/path/to/torrent/watch"
                          class="flex-1 bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   <button @click="browseDirectory('blackhole_torrent')" class="px-3 py-2 rounded-md text-xs bg-white/[0.04] text-cp-muted hover:text-cp-text hover:bg-white/[0.06] transition-colors">Browse</button>
                 </div>
@@ -458,18 +458,18 @@
               <template x-if="formData.downloader === 'sabnzbd'">
                 <div class="space-y-3">
                   <div>
-                    <label class="block text-xs text-cp-muted mb-1">Host</label>
-                    <input type="text" x-model="formData.downloaderConfig.sabnzbd.host" placeholder="http://localhost:8080"
+                    <label for="wizard-legacy-sabnzbd-host" class="block text-xs text-cp-muted mb-1">Host</label>
+                    <input id="wizard-legacy-sabnzbd-host" type="text" x-model="formData.downloaderConfig.sabnzbd.host" placeholder="http://localhost:8080"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                   <div>
-                    <label class="block text-xs text-cp-muted mb-1">API Key</label>
-                    <input type="password" x-model="formData.downloaderConfig.sabnzbd.api_key" autocomplete="new-password" placeholder="Your SABnzbd API key"
+                    <label for="wizard-legacy-sabnzbd-api-key" class="block text-xs text-cp-muted mb-1">API Key</label>
+                    <input id="wizard-legacy-sabnzbd-api-key" type="password" x-model="formData.downloaderConfig.sabnzbd.api_key" autocomplete="new-password" placeholder="Your SABnzbd API key"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                   <div>
-                    <label class="block text-xs text-cp-muted mb-1">Category (optional)</label>
-                    <input type="text" x-model="formData.downloaderConfig.sabnzbd.category" placeholder="movies"
+                    <label for="wizard-legacy-sabnzbd-category" class="block text-xs text-cp-muted mb-1">Category (optional)</label>
+                    <input id="wizard-legacy-sabnzbd-category" type="text" x-model="formData.downloaderConfig.sabnzbd.category" placeholder="movies"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                 </div>
@@ -479,19 +479,19 @@
               <template x-if="formData.downloader === 'nzbget'">
                 <div class="space-y-3">
                   <div>
-                    <label class="block text-xs text-cp-muted mb-1">Host</label>
-                    <input type="text" x-model="formData.downloaderConfig.nzbget.host" placeholder="http://localhost:6789"
+                    <label for="wizard-legacy-nzbget-host" class="block text-xs text-cp-muted mb-1">Host</label>
+                    <input id="wizard-legacy-nzbget-host" type="text" x-model="formData.downloaderConfig.nzbget.host" placeholder="http://localhost:6789"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                   <div class="grid grid-cols-2 gap-3">
                     <div>
-                      <label class="block text-xs text-cp-muted mb-1">Username</label>
-                      <input type="text" x-model="formData.downloaderConfig.nzbget.username" placeholder="nzbget"
+                      <label for="wizard-legacy-nzbget-username" class="block text-xs text-cp-muted mb-1">Username</label>
+                      <input id="wizard-legacy-nzbget-username" type="text" x-model="formData.downloaderConfig.nzbget.username" placeholder="nzbget"
                              class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                     </div>
                     <div>
-                      <label class="block text-xs text-cp-muted mb-1">Password</label>
-                      <input type="password" x-model="formData.downloaderConfig.nzbget.password"
+                      <label for="wizard-legacy-nzbget-password" class="block text-xs text-cp-muted mb-1">Password</label>
+                      <input id="wizard-legacy-nzbget-password" type="password" x-model="formData.downloaderConfig.nzbget.password"
                              class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                     </div>
                   </div>
@@ -502,19 +502,19 @@
               <template x-if="formData.downloader === 'qbittorrent'">
                 <div class="space-y-3">
                   <div>
-                    <label class="block text-xs text-cp-muted mb-1">Host</label>
-                    <input type="text" x-model="formData.downloaderConfig.qbittorrent.host" placeholder="http://localhost:8080"
+                    <label for="wizard-legacy-qbittorrent-host" class="block text-xs text-cp-muted mb-1">Host</label>
+                    <input id="wizard-legacy-qbittorrent-host" type="text" x-model="formData.downloaderConfig.qbittorrent.host" placeholder="http://localhost:8080"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                   <div class="grid grid-cols-2 gap-3">
                     <div>
-                      <label class="block text-xs text-cp-muted mb-1">Username</label>
-                      <input type="text" x-model="formData.downloaderConfig.qbittorrent.username" placeholder="admin"
+                      <label for="wizard-legacy-qbittorrent-username" class="block text-xs text-cp-muted mb-1">Username</label>
+                      <input id="wizard-legacy-qbittorrent-username" type="text" x-model="formData.downloaderConfig.qbittorrent.username" placeholder="admin"
                              class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                     </div>
                     <div>
-                      <label class="block text-xs text-cp-muted mb-1">Password</label>
-                      <input type="password" x-model="formData.downloaderConfig.qbittorrent.password"
+                      <label for="wizard-legacy-qbittorrent-password" class="block text-xs text-cp-muted mb-1">Password</label>
+                      <input id="wizard-legacy-qbittorrent-password" type="password" x-model="formData.downloaderConfig.qbittorrent.password"
                              class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                     </div>
                   </div>
@@ -525,19 +525,19 @@
               <template x-if="formData.downloader === 'transmission'">
                 <div class="space-y-3">
                   <div>
-                    <label class="block text-xs text-cp-muted mb-1">Host</label>
-                    <input type="text" x-model="formData.downloaderConfig.transmission.host" placeholder="http://localhost:9091"
+                    <label for="wizard-legacy-transmission-host" class="block text-xs text-cp-muted mb-1">Host</label>
+                    <input id="wizard-legacy-transmission-host" type="text" x-model="formData.downloaderConfig.transmission.host" placeholder="http://localhost:9091"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                   <div class="grid grid-cols-2 gap-3">
                     <div>
-                      <label class="block text-xs text-cp-muted mb-1">Username (optional)</label>
-                      <input type="text" x-model="formData.downloaderConfig.transmission.username"
+                      <label for="wizard-legacy-transmission-username" class="block text-xs text-cp-muted mb-1">Username (optional)</label>
+                      <input id="wizard-legacy-transmission-username" type="text" x-model="formData.downloaderConfig.transmission.username"
                              class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                     </div>
                     <div>
-                      <label class="block text-xs text-cp-muted mb-1">Password (optional)</label>
-                      <input type="password" x-model="formData.downloaderConfig.transmission.password"
+                      <label for="wizard-legacy-transmission-password" class="block text-xs text-cp-muted mb-1">Password (optional)</label>
+                      <input id="wizard-legacy-transmission-password" type="password" x-model="formData.downloaderConfig.transmission.password"
                              class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                     </div>
                   </div>
@@ -548,13 +548,13 @@
               <template x-if="formData.downloader === 'deluge'">
                 <div class="space-y-3">
                   <div>
-                    <label class="block text-xs text-cp-muted mb-1">Host</label>
-                    <input type="text" x-model="formData.downloaderConfig.deluge.host" placeholder="http://localhost:8112"
+                    <label for="wizard-legacy-deluge-host" class="block text-xs text-cp-muted mb-1">Host</label>
+                    <input id="wizard-legacy-deluge-host" type="text" x-model="formData.downloaderConfig.deluge.host" placeholder="http://localhost:8112"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                   <div>
-                    <label class="block text-xs text-cp-muted mb-1">Password</label>
-                    <input type="password" x-model="formData.downloaderConfig.deluge.password"
+                    <label for="wizard-legacy-deluge-password" class="block text-xs text-cp-muted mb-1">Password</label>
+                    <input id="wizard-legacy-deluge-password" type="password" x-model="formData.downloaderConfig.deluge.password"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                 </div>
@@ -564,19 +564,19 @@
               <template x-if="formData.downloader === 'rtorrent'">
                 <div class="space-y-3">
                   <div>
-                    <label class="block text-xs text-cp-muted mb-1">Host (SCGI/RPC URL)</label>
-                    <input type="text" x-model="formData.downloaderConfig.rtorrent.host" placeholder="scgi://localhost:5000 or http://localhost/RPC2"
+                    <label for="wizard-legacy-rtorrent-host" class="block text-xs text-cp-muted mb-1">Host (SCGI/RPC URL)</label>
+                    <input id="wizard-legacy-rtorrent-host" type="text" x-model="formData.downloaderConfig.rtorrent.host" placeholder="scgi://localhost:5000 or http://localhost/RPC2"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                   <div class="grid grid-cols-2 gap-3">
                     <div>
-                      <label class="block text-xs text-cp-muted mb-1">Username (optional)</label>
-                      <input type="text" x-model="formData.downloaderConfig.rtorrent.username"
+                      <label for="wizard-legacy-rtorrent-username" class="block text-xs text-cp-muted mb-1">Username (optional)</label>
+                      <input id="wizard-legacy-rtorrent-username" type="text" x-model="formData.downloaderConfig.rtorrent.username"
                              class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                     </div>
                     <div>
-                      <label class="block text-xs text-cp-muted mb-1">Password (optional)</label>
-                      <input type="password" x-model="formData.downloaderConfig.rtorrent.password"
+                      <label for="wizard-legacy-rtorrent-password" class="block text-xs text-cp-muted mb-1">Password (optional)</label>
+                      <input id="wizard-legacy-rtorrent-password" type="password" x-model="formData.downloaderConfig.rtorrent.password"
                              class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                     </div>
                   </div>
@@ -587,19 +587,19 @@
               <template x-if="formData.downloader === 'utorrent'">
                 <div class="space-y-3">
                   <div>
-                    <label class="block text-xs text-cp-muted mb-1">Host</label>
-                    <input type="text" x-model="formData.downloaderConfig.utorrent.host" placeholder="http://localhost:8080/gui"
+                    <label for="wizard-legacy-utorrent-host" class="block text-xs text-cp-muted mb-1">Host</label>
+                    <input id="wizard-legacy-utorrent-host" type="text" x-model="formData.downloaderConfig.utorrent.host" placeholder="http://localhost:8080/gui"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                   <div class="grid grid-cols-2 gap-3">
                     <div>
-                      <label class="block text-xs text-cp-muted mb-1">Username</label>
-                      <input type="text" x-model="formData.downloaderConfig.utorrent.username"
+                      <label for="wizard-legacy-utorrent-username" class="block text-xs text-cp-muted mb-1">Username</label>
+                      <input id="wizard-legacy-utorrent-username" type="text" x-model="formData.downloaderConfig.utorrent.username"
                              class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                     </div>
                     <div>
-                      <label class="block text-xs text-cp-muted mb-1">Password</label>
-                      <input type="password" x-model="formData.downloaderConfig.utorrent.password"
+                      <label for="wizard-legacy-utorrent-password" class="block text-xs text-cp-muted mb-1">Password</label>
+                      <input id="wizard-legacy-utorrent-password" type="password" x-model="formData.downloaderConfig.utorrent.password"
                              class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                     </div>
                   </div>
@@ -610,13 +610,13 @@
               <template x-if="formData.downloader === 'blackhole'">
                 <div class="space-y-3">
                   <div>
-                    <label class="block text-xs text-cp-muted mb-1">NZB Directory</label>
-                    <input type="text" x-model="formData.downloaderConfig.blackhole.nzb_directory" placeholder="/path/to/nzb/watch/folder"
+                    <label for="wizard-legacy-blackhole-nzb-dir" class="block text-xs text-cp-muted mb-1">NZB Directory</label>
+                    <input id="wizard-legacy-blackhole-nzb-dir" type="text" x-model="formData.downloaderConfig.blackhole.nzb_directory" placeholder="/path/to/nzb/watch/folder"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                   <div>
-                    <label class="block text-xs text-cp-muted mb-1">Torrent Directory</label>
-                    <input type="text" x-model="formData.downloaderConfig.blackhole.torrent_directory" placeholder="/path/to/torrent/watch/folder"
+                    <label for="wizard-legacy-blackhole-torrent-dir" class="block text-xs text-cp-muted mb-1">Torrent Directory</label>
+                    <input id="wizard-legacy-blackhole-torrent-dir" type="text" x-model="formData.downloaderConfig.blackhole.torrent_directory" placeholder="/path/to/torrent/watch/folder"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                 </div>
@@ -626,19 +626,19 @@
               <template x-if="formData.downloader === 'synology'">
                 <div class="space-y-3">
                   <div>
-                    <label class="block text-xs text-cp-muted mb-1">Host</label>
-                    <input type="text" x-model="formData.downloaderConfig.synology.host" placeholder="http://diskstation:5000"
+                    <label for="wizard-legacy-synology-host" class="block text-xs text-cp-muted mb-1">Host</label>
+                    <input id="wizard-legacy-synology-host" type="text" x-model="formData.downloaderConfig.synology.host" placeholder="http://diskstation:5000"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                   <div class="grid grid-cols-2 gap-3">
                     <div>
-                      <label class="block text-xs text-cp-muted mb-1">Username</label>
-                      <input type="text" x-model="formData.downloaderConfig.synology.username"
+                      <label for="wizard-legacy-synology-username" class="block text-xs text-cp-muted mb-1">Username</label>
+                      <input id="wizard-legacy-synology-username" type="text" x-model="formData.downloaderConfig.synology.username"
                              class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                     </div>
                     <div>
-                      <label class="block text-xs text-cp-muted mb-1">Password</label>
-                      <input type="password" x-model="formData.downloaderConfig.synology.password"
+                      <label for="wizard-legacy-synology-password" class="block text-xs text-cp-muted mb-1">Password</label>
+                      <input id="wizard-legacy-synology-password" type="password" x-model="formData.downloaderConfig.synology.password"
                              class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                     </div>
                   </div>
@@ -649,8 +649,8 @@
               <template x-if="formData.downloader === 'putio'">
                 <div class="space-y-3">
                   <div>
-                    <label class="block text-xs text-cp-muted mb-1">OAuth Token</label>
-                    <input type="password" x-model="formData.downloaderConfig.putio.oauth_token" autocomplete="new-password" placeholder="Your Put.io OAuth token"
+                    <label for="wizard-legacy-putio-oauth-token" class="block text-xs text-cp-muted mb-1">OAuth Token</label>
+                    <input id="wizard-legacy-putio-oauth-token" type="password" x-model="formData.downloaderConfig.putio.oauth_token" autocomplete="new-password" placeholder="Your Put.io OAuth token"
                            class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   </div>
                 </div>
@@ -697,9 +697,9 @@
 
         <div x-show="formData.renamer.enabled" x-transition class="space-y-4">
           <div>
-            <label class="block text-xs text-cp-muted mb-1.5">Download Folder</label>
+            <label for="wizard-renamer-from" class="block text-xs text-cp-muted mb-1.5">Download Folder</label>
             <div class="flex gap-2">
-              <input type="text" x-model="formData.renamer.from" placeholder="/path/to/downloads/complete"
+              <input id="wizard-renamer-from" type="text" x-model="formData.renamer.from" placeholder="/path/to/downloads/complete"
                      class="flex-1 bg-white/[0.03] border border-white/[0.06] rounded-md px-4 py-2.5 text-sm focus:outline-none focus:border-cp-accent/30">
               <button @click="browseDirectory('renamer_from')" type="button"
                       class="px-4 py-2 rounded-md text-sm bg-white/[0.04] text-cp-muted hover:text-cp-text hover:bg-white/[0.06] transition-colors shrink-0">
@@ -710,9 +710,9 @@
           </div>
           
           <div>
-            <label class="block text-xs text-cp-muted mb-1.5">Movie Library</label>
+            <label for="wizard-renamer-to" class="block text-xs text-cp-muted mb-1.5">Movie Library</label>
             <div class="flex gap-2">
-              <input type="text" x-model="formData.renamer.to" placeholder="/path/to/movies"
+              <input id="wizard-renamer-to" type="text" x-model="formData.renamer.to" placeholder="/path/to/movies"
                      class="flex-1 bg-white/[0.03] border border-white/[0.06] rounded-md px-4 py-2.5 text-sm focus:outline-none focus:border-cp-accent/30">
               <button @click="browseDirectory('renamer_to')" type="button"
                       class="px-4 py-2 rounded-md text-sm bg-white/[0.04] text-cp-muted hover:text-cp-text hover:bg-white/[0.06] transition-colors shrink-0">
@@ -723,15 +723,15 @@
           </div>
 
           <div>
-            <label class="block text-xs text-cp-muted mb-1.5">Folder Naming</label>
-            <input type="text" x-model="formData.renamer.folder_name" placeholder="<namethe> (<year>)"
+            <label for="wizard-renamer-folder-name" class="block text-xs text-cp-muted mb-1.5">Folder Naming</label>
+            <input id="wizard-renamer-folder-name" type="text" x-model="formData.renamer.folder_name" placeholder="<namethe> (<year>)"
                    class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-4 py-2.5 text-sm focus:outline-none focus:border-cp-accent/30">
             <p class="text-[10px] text-cp-muted mt-1">Example: <span class="text-cp-text">The Dark Knight (2008)</span></p>
           </div>
 
           <div>
-            <label class="block text-xs text-cp-muted mb-1.5">File Naming</label>
-            <input type="text" x-model="formData.renamer.file_name" placeholder="<thename><cd>.<ext>"
+            <label for="wizard-renamer-file-name" class="block text-xs text-cp-muted mb-1.5">File Naming</label>
+            <input id="wizard-renamer-file-name" type="text" x-model="formData.renamer.file_name" placeholder="<thename><cd>.<ext>"
                    class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-4 py-2.5 text-sm focus:outline-none focus:border-cp-accent/30">
             <p class="text-[10px] text-cp-muted mt-1">Example: <span class="text-cp-text">The Dark Knight.mkv</span></p>
           </div>
@@ -1415,74 +1415,74 @@ function setupWizard() {
     getDownloaderFields(id) {
       const configs = {
         sabnzbd: `
-          <div><label class="block text-xs text-cp-muted mb-1">Host</label>
-          <input type="text" x-model="formData.downloaderConfig.sabnzbd.host" placeholder="http://localhost:8080" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
-          <div><label class="block text-xs text-cp-muted mb-1">API Key</label>
-          <input type="password" x-model="formData.downloaderConfig.sabnzbd.api_key" autocomplete="new-password" placeholder="Your SABnzbd API key" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
-          <div><label class="block text-xs text-cp-muted mb-1">Category (optional)</label>
-          <input type="text" x-model="formData.downloaderConfig.sabnzbd.category" placeholder="movies" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`,
+          <div><label for="wizard-dl-sabnzbd-host" class="block text-xs text-cp-muted mb-1">Host</label>
+          <input id="wizard-dl-sabnzbd-host" type="text" x-model="formData.downloaderConfig.sabnzbd.host" placeholder="http://localhost:8080" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+          <div><label for="wizard-dl-sabnzbd-api-key" class="block text-xs text-cp-muted mb-1">API Key</label>
+          <input id="wizard-dl-sabnzbd-api-key" type="password" x-model="formData.downloaderConfig.sabnzbd.api_key" autocomplete="new-password" placeholder="Your SABnzbd API key" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+          <div><label for="wizard-dl-sabnzbd-category" class="block text-xs text-cp-muted mb-1">Category (optional)</label>
+          <input id="wizard-dl-sabnzbd-category" type="text" x-model="formData.downloaderConfig.sabnzbd.category" placeholder="movies" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`,
         nzbget: `
-          <div><label class="block text-xs text-cp-muted mb-1">Host</label>
-          <input type="text" x-model="formData.downloaderConfig.nzbget.host" placeholder="http://localhost:6789" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+          <div><label for="wizard-dl-nzbget-host" class="block text-xs text-cp-muted mb-1">Host</label>
+          <input id="wizard-dl-nzbget-host" type="text" x-model="formData.downloaderConfig.nzbget.host" placeholder="http://localhost:6789" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           <div class="grid grid-cols-2 gap-3">
-            <div><label class="block text-xs text-cp-muted mb-1">Username</label>
-            <input type="text" x-model="formData.downloaderConfig.nzbget.username" placeholder="nzbget" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
-            <div><label class="block text-xs text-cp-muted mb-1">Password</label>
-            <input type="password" x-model="formData.downloaderConfig.nzbget.password" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+            <div><label for="wizard-dl-nzbget-username" class="block text-xs text-cp-muted mb-1">Username</label>
+            <input id="wizard-dl-nzbget-username" type="text" x-model="formData.downloaderConfig.nzbget.username" placeholder="nzbget" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+            <div><label for="wizard-dl-nzbget-password" class="block text-xs text-cp-muted mb-1">Password</label>
+            <input id="wizard-dl-nzbget-password" type="password" x-model="formData.downloaderConfig.nzbget.password" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           </div>`,
         qbittorrent: `
-          <div><label class="block text-xs text-cp-muted mb-1">Host</label>
-          <input type="text" x-model="formData.downloaderConfig.qbittorrent.host" placeholder="http://localhost:8080" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+          <div><label for="wizard-dl-qbittorrent-host" class="block text-xs text-cp-muted mb-1">Host</label>
+          <input id="wizard-dl-qbittorrent-host" type="text" x-model="formData.downloaderConfig.qbittorrent.host" placeholder="http://localhost:8080" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           <div class="grid grid-cols-2 gap-3">
-            <div><label class="block text-xs text-cp-muted mb-1">Username</label>
-            <input type="text" x-model="formData.downloaderConfig.qbittorrent.username" placeholder="admin" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
-            <div><label class="block text-xs text-cp-muted mb-1">Password</label>
-            <input type="password" x-model="formData.downloaderConfig.qbittorrent.password" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+            <div><label for="wizard-dl-qbittorrent-username" class="block text-xs text-cp-muted mb-1">Username</label>
+            <input id="wizard-dl-qbittorrent-username" type="text" x-model="formData.downloaderConfig.qbittorrent.username" placeholder="admin" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+            <div><label for="wizard-dl-qbittorrent-password" class="block text-xs text-cp-muted mb-1">Password</label>
+            <input id="wizard-dl-qbittorrent-password" type="password" x-model="formData.downloaderConfig.qbittorrent.password" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           </div>`,
         transmission: `
-          <div><label class="block text-xs text-cp-muted mb-1">Host</label>
-          <input type="text" x-model="formData.downloaderConfig.transmission.host" placeholder="http://localhost:9091" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+          <div><label for="wizard-dl-transmission-host" class="block text-xs text-cp-muted mb-1">Host</label>
+          <input id="wizard-dl-transmission-host" type="text" x-model="formData.downloaderConfig.transmission.host" placeholder="http://localhost:9091" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           <div class="grid grid-cols-2 gap-3">
-            <div><label class="block text-xs text-cp-muted mb-1">Username (optional)</label>
-            <input type="text" x-model="formData.downloaderConfig.transmission.username" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
-            <div><label class="block text-xs text-cp-muted mb-1">Password (optional)</label>
-            <input type="password" x-model="formData.downloaderConfig.transmission.password" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+            <div><label for="wizard-dl-transmission-username" class="block text-xs text-cp-muted mb-1">Username (optional)</label>
+            <input id="wizard-dl-transmission-username" type="text" x-model="formData.downloaderConfig.transmission.username" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+            <div><label for="wizard-dl-transmission-password" class="block text-xs text-cp-muted mb-1">Password (optional)</label>
+            <input id="wizard-dl-transmission-password" type="password" x-model="formData.downloaderConfig.transmission.password" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           </div>`,
         deluge: `
-          <div><label class="block text-xs text-cp-muted mb-1">Host</label>
-          <input type="text" x-model="formData.downloaderConfig.deluge.host" placeholder="http://localhost:8112" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
-          <div><label class="block text-xs text-cp-muted mb-1">Password</label>
-          <input type="password" x-model="formData.downloaderConfig.deluge.password" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`,
+          <div><label for="wizard-dl-deluge-host" class="block text-xs text-cp-muted mb-1">Host</label>
+          <input id="wizard-dl-deluge-host" type="text" x-model="formData.downloaderConfig.deluge.host" placeholder="http://localhost:8112" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+          <div><label for="wizard-dl-deluge-password" class="block text-xs text-cp-muted mb-1">Password</label>
+          <input id="wizard-dl-deluge-password" type="password" x-model="formData.downloaderConfig.deluge.password" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`,
         rtorrent: `
-          <div><label class="block text-xs text-cp-muted mb-1">Host (SCGI/RPC URL)</label>
-          <input type="text" x-model="formData.downloaderConfig.rtorrent.host" placeholder="scgi://localhost:5000 or http://localhost/RPC2" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+          <div><label for="wizard-dl-rtorrent-host" class="block text-xs text-cp-muted mb-1">Host (SCGI/RPC URL)</label>
+          <input id="wizard-dl-rtorrent-host" type="text" x-model="formData.downloaderConfig.rtorrent.host" placeholder="scgi://localhost:5000 or http://localhost/RPC2" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           <div class="grid grid-cols-2 gap-3">
-            <div><label class="block text-xs text-cp-muted mb-1">Username (optional)</label>
-            <input type="text" x-model="formData.downloaderConfig.rtorrent.username" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
-            <div><label class="block text-xs text-cp-muted mb-1">Password (optional)</label>
-            <input type="password" x-model="formData.downloaderConfig.rtorrent.password" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+            <div><label for="wizard-dl-rtorrent-username" class="block text-xs text-cp-muted mb-1">Username (optional)</label>
+            <input id="wizard-dl-rtorrent-username" type="text" x-model="formData.downloaderConfig.rtorrent.username" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+            <div><label for="wizard-dl-rtorrent-password" class="block text-xs text-cp-muted mb-1">Password (optional)</label>
+            <input id="wizard-dl-rtorrent-password" type="password" x-model="formData.downloaderConfig.rtorrent.password" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           </div>`,
         utorrent: `
-          <div><label class="block text-xs text-cp-muted mb-1">Host</label>
-          <input type="text" x-model="formData.downloaderConfig.utorrent.host" placeholder="http://localhost:8080/gui" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+          <div><label for="wizard-dl-utorrent-host" class="block text-xs text-cp-muted mb-1">Host</label>
+          <input id="wizard-dl-utorrent-host" type="text" x-model="formData.downloaderConfig.utorrent.host" placeholder="http://localhost:8080/gui" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           <div class="grid grid-cols-2 gap-3">
-            <div><label class="block text-xs text-cp-muted mb-1">Username</label>
-            <input type="text" x-model="formData.downloaderConfig.utorrent.username" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
-            <div><label class="block text-xs text-cp-muted mb-1">Password</label>
-            <input type="password" x-model="formData.downloaderConfig.utorrent.password" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+            <div><label for="wizard-dl-utorrent-username" class="block text-xs text-cp-muted mb-1">Username</label>
+            <input id="wizard-dl-utorrent-username" type="text" x-model="formData.downloaderConfig.utorrent.username" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+            <div><label for="wizard-dl-utorrent-password" class="block text-xs text-cp-muted mb-1">Password</label>
+            <input id="wizard-dl-utorrent-password" type="password" x-model="formData.downloaderConfig.utorrent.password" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           </div>`,
         synology: `
-          <div><label class="block text-xs text-cp-muted mb-1">Host</label>
-          <input type="text" x-model="formData.downloaderConfig.synology.host" placeholder="http://diskstation:5000" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+          <div><label for="wizard-dl-synology-host" class="block text-xs text-cp-muted mb-1">Host</label>
+          <input id="wizard-dl-synology-host" type="text" x-model="formData.downloaderConfig.synology.host" placeholder="http://diskstation:5000" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           <div class="grid grid-cols-2 gap-3">
-            <div><label class="block text-xs text-cp-muted mb-1">Username</label>
-            <input type="text" x-model="formData.downloaderConfig.synology.username" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
-            <div><label class="block text-xs text-cp-muted mb-1">Password</label>
-            <input type="password" x-model="formData.downloaderConfig.synology.password" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+            <div><label for="wizard-dl-synology-username" class="block text-xs text-cp-muted mb-1">Username</label>
+            <input id="wizard-dl-synology-username" type="text" x-model="formData.downloaderConfig.synology.username" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
+            <div><label for="wizard-dl-synology-password" class="block text-xs text-cp-muted mb-1">Password</label>
+            <input id="wizard-dl-synology-password" type="password" x-model="formData.downloaderConfig.synology.password" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>
           </div>`,
         putio: `
-          <div><label class="block text-xs text-cp-muted mb-1">OAuth Token</label>
-          <input type="password" x-model="formData.downloaderConfig.putio.oauth_token" autocomplete="new-password" placeholder="Your Put.io OAuth token" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`
+          <div><label for="wizard-dl-putio-oauth-token" class="block text-xs text-cp-muted mb-1">OAuth Token</label>
+          <input id="wizard-dl-putio-oauth-token" type="password" x-model="formData.downloaderConfig.putio.oauth_token" autocomplete="new-password" placeholder="Your Put.io OAuth token" class="w-full bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30"></div>`
       };
       return configs[id] || '';
     },

--- a/couchpotato/ui/templates/wizard.html
+++ b/couchpotato/ui/templates/wizard.html
@@ -162,12 +162,13 @@
             <div x-show="formData.newznab.enabled" x-transition class="space-y-3">
               <template x-for="(entry, idx) in formData.newznab.entries" :key="idx">
                 <div class="flex gap-2 items-center">
-                  <input type="text" aria-label="Newznab indexer URL" :placeholder="'Indexer URL (e.g. https://api.nzbgeek.info)'" 
+                  <input type="text" :aria-label="'Newznab indexer URL ' + (idx + 1)" :placeholder="'Indexer URL (e.g. https://api.nzbgeek.info)'"
                          x-model="entry.host"
                          class="flex-[2] bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
-                  <input type="password" aria-label="Newznab API key" placeholder="API Key" x-model="entry.api_key" autocomplete="new-password"
+                  <input type="password" :aria-label="'Newznab API key ' + (idx + 1)" placeholder="API Key" x-model="entry.api_key" autocomplete="new-password"
                          class="flex-1 bg-white/[0.03] border border-white/[0.06] rounded-md px-3 py-2 text-xs focus:outline-none focus:border-cp-accent/30">
                   <button @click="formData.newznab.entries.splice(idx, 1)" x-show="formData.newznab.entries.length > 1"
+                          :aria-label="'Remove indexer ' + (idx + 1)"
                           class="text-cp-muted hover:text-cp-danger transition-colors">
                     <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
                   </button>
@@ -307,7 +308,7 @@
                     {% set toggle_label_expr = "'Enable ' + tracker.name" %}
                     {% include "partials/settings/toggle.html" %}
                   </div>
-                  <div x-show="tracker.enabled" x-transition class="grid grid-cols-2 gap-2 mt-3">
+                  <div x-show="tracker.enabled" x-transition class="grid grid-cols-2 gap-2 mt-3" role="group" :aria-label="tracker.name">
                     <template x-for="field in tracker.fields" :key="field.name">
                       <div :class="field.full ? 'col-span-2' : ''">
                         <label :for="'wizard-tracker-' + tracker.id + '-' + field.name" class="block text-[10px] text-cp-muted mb-1" x-text="field.label"></label>
@@ -352,8 +353,8 @@
         </div>
         
         <!-- Usenet Client Section -->
-        <div x-show="formData.searchType === 'usenet' || formData.searchType === 'both'" class="mb-6">
-          <h3 class="text-sm font-medium text-cp-accent mb-3 flex items-center gap-2">
+        <div x-show="formData.searchType === 'usenet' || formData.searchType === 'both'" class="mb-6" role="group" aria-labelledby="wizard-usenet-client-heading">
+          <h3 id="wizard-usenet-client-heading" class="text-sm font-medium text-cp-accent mb-3 flex items-center gap-2">
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"/></svg>
             Usenet Client
           </h3>
@@ -377,8 +378,8 @@
         </div>
 
         <!-- Torrent Client Section -->
-        <div x-show="formData.searchType === 'torrents' || formData.searchType === 'both'" class="mb-6">
-          <h3 class="text-sm font-medium text-cp-accent mb-3 flex items-center gap-2">
+        <div x-show="formData.searchType === 'torrents' || formData.searchType === 'both'" class="mb-6" role="group" aria-labelledby="wizard-torrent-client-heading">
+          <h3 id="wizard-torrent-client-heading" class="text-sm font-medium text-cp-accent mb-3 flex items-center gap-2">
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 7.5h-.75A2.25 2.25 0 004.5 9.75v7.5a2.25 2.25 0 002.25 2.25h7.5a2.25 2.25 0 002.25-2.25v-7.5a2.25 2.25 0 00-2.25-2.25h-.75m-6 3.75l3 3m0 0l3-3m-3 3V1.5m6 9h.75a2.25 2.25 0 012.25 2.25v7.5a2.25 2.25 0 01-2.25 2.25h-7.5a2.25 2.25 0 01-2.25-2.25v-.75"/></svg>
             Torrent Client
           </h3>
@@ -887,7 +888,7 @@
       <div class="bg-cp-card rounded-xl border border-white/[0.05] w-full max-w-lg mx-4 max-h-[80vh] flex flex-col">
         <div class="px-4 py-3 border-b border-white/[0.04] flex items-center justify-between">
           <h3 class="text-sm font-medium">Browse Folders</h3>
-          <button @click="browserOpen = false" class="text-cp-muted hover:text-cp-text">
+          <button @click="browserOpen = false" aria-label="Close directory browser" class="text-cp-muted hover:text-cp-text">
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
           </button>
         </div>

--- a/specs/A11Y-001-form-labels-not-associated.md
+++ b/specs/A11Y-001-form-labels-not-associated.md
@@ -78,3 +78,14 @@ is part of this change.
 
 1. `Web:S6819`, 39 findings, ARIA roles used where a semantic element exists.
 2. The remaining SonarQube backlog, sequenced and not batched.
+3. Colour contrast on the Providers step's search-type hint text (light
+   theme): "NZB indexers", "Torrent trackers" and "Maximum coverage" at
+   2.34:1 against a 4.5:1 requirement (axe `color-contrast`, serious).
+   Surfaced by AC-QA-5's extended E2E scan reaching the Providers step for
+   the first time; a different defect (WCAG 1.4.3) to the one this change
+   fixes, so it is recorded rather than fixed here. The wizard's later-step
+   scan in `tests/e2e/accessibility.a11y.spec.ts` is scoped to
+   `checkFieldNameA11y` (label/accessible-name rules only) rather than the
+   full `checkA11y`, for the same reason `checkToggleA11y` already is: an
+   unrelated pre-existing finding on a step must not mask the specific
+   regression that step's check exists to catch.

--- a/specs/A11Y-001-form-labels-not-associated.md
+++ b/specs/A11Y-001-form-labels-not-associated.md
@@ -35,14 +35,18 @@ is part of this change.
 
 ## Scope
 
-- `wizard.html`, all 61 labels and 63 inputs.
+- `wizard.html`, all 61 labels and 63 inputs. **Correction (round 2 review,
+  see below): only 37 of those 63 fields are reachable in the running app.**
+  The rest sit inside markup that can never render.
 - The stragglers elsewhere, measured: `partials/movie_cards.html` (2 labels, 0
   with `for`), `partials/settings/field_types.html` (1 of 1),
   `partials/settings/combined_basics_card.html` (1 of 1),
   `partials/settings/header.html` (1 of 1),
   `partials/settings/provider_card.html` (1 of 1),
   `partials/settings/profiles.html` (2 of 7), `partials/settings/logs_tab.html`
-  (1 of 2), `logs.html` (1 of 2).
+  (1 of 2), `logs.html` (1 of 2). **Correction: all eight were found already
+  compliant when the guard below was written against them (see below) — this
+  bullet lists where the guard runs, not where a diff was needed.**
 - A guard that fails when a label or field is added without an association.
 - An E2E scan that walks the wizard's steps rather than only its first.
 
@@ -70,9 +74,48 @@ is part of this change.
   by removing one association and watching it fail.
 - **AC-QA-5:** The E2E accessibility scan reaches wizard steps beyond the first.
   Proven by removing a label association on a LATER step and watching the E2E
-  scan fail, which it currently would not.
+  scan fail. **Correction (round 2 review): this held for only about one field
+  in twenty.** axe's `label` rule accepts a `placeholder` as an accessible
+  name, and 41 of the wizard's 63 fields carry one — so the scan only had
+  teeth on the roughly one-in-twenty field with no placeholder. Fixed by
+  replacing the axe-only scan with a DOM-level check
+  (`assertFieldNamesAreReal` in `tests/e2e/accessibility.a11y.spec.ts`) that
+  reads each visible field's actual accessible name and rejects it when that
+  name is merely the placeholder axe would have accepted. Re-proven: removing
+  `for="wizard-renamer-from"` (Library step, which HAS a placeholder) now
+  fails; it did not before. The scan's axe rule list was also carrying two
+  rule ids (`duplicate-id`, `duplicate-id-active`) that are `enabled: false`
+  in the installed axe-core (4.13.0) and so could never report anything, plus
+  two (`select-name`, `aria-input-field-name`) that apply to element types
+  and roles this page has zero of (`<select>`; ARIA text-input-alike roles).
+  All four dropped; `duplicate-id-aria`, which IS enabled, stays. A step's
+  arrival is now asserted before it is scanned (heading + a known field both
+  visible), and each scan asserts a measured minimum field count, so a scan
+  that silently re-examines the wrong step or examines nothing fails loudly
+  instead of reporting a clean run.
 - **AC-SIMP-6:** No visual change. The wizard must look identical; this adds
   attributes, it does not restyle.
+- **AC-A11Y-7** (round 2 review, B2): where two visible fields would
+  otherwise share one accessible name (e.g. two enabled download clients'
+  "Host" fields, two enabled private trackers' "Username" fields), each sits
+  inside a distinct named group (`role="group"` plus `aria-label` or
+  `aria-labelledby` naming the group, not the field), so assistive tech
+  announces which group a field belongs to even though the visible label
+  text is identical. Proven by asserting each field resolves inside its own
+  differently-named group (`getByRole('group', { name: ... })`) and watching
+  that assertion fail when the grouping markup is removed.
+- **AC-A11Y-8** (round 2 review, B3): every icon-only button (no visible text
+  content) has a non-empty accessible name. Proven with axe's `button-name`
+  rule run against a scan that actually renders the button — the remove-row
+  button (only visible with 2+ entries) and the directory browser's close
+  button (only visible once opened) are both exercised for this, not left to
+  a scan that never visits the state they render in.
+- **AC-A11Y-9** (round 2 review, A4): a label names the field it is actually
+  paired with, not merely *a* field. `toBeFocused()` alone cannot tell a
+  correct `for`/`id` pairing from a swapped one — both move focus somewhere.
+  Proven with `toHaveAccessibleName` asserting the exact expected text, and by
+  swapping the Security step's `for` values and watching it fail while the
+  focus-only assertion stayed green.
 
 ## Recorded debt
 
@@ -89,3 +132,36 @@ is part of this change.
    full `checkA11y`, for the same reason `checkToggleA11y` already is: an
    unrelated pre-existing finding on a step must not mask the specific
    regression that step's check exists to catch.
+4. `wizard.html:452`'s `<template x-if="false && formData.downloader">`
+   block (26 of the file's 63 measured fields, see the round 2 correction
+   below) is dead: the `false &&` short-circuits every render, and it is
+   verified at runtime that zero `wizard-legacy-*` ids ever reach the DOM.
+   Left in place for this change (not deleted) because it is out of scope for
+   an accessibility fix; removing it is separate cleanup work.
+
+## Round 2 correction (review, this fix cycle)
+
+Two independent reviews of the first commit (ed2bea7c4) confirmed the shipped
+wizard markup was correct — including the JavaScript-injected fields, all 63
+of them, zero duplicate ids, zero dangling `for` — but found the guards this
+spec's ACs describe were weaker than claimed, plus real gaps in three
+templates and in this spec. The guard fixes are recorded against the ACs
+above (AC-QA-5, AC-A11Y-7/8/9); the counting corrections are:
+
+- **The "63 fields" count is real but the reachable count is 37.** Measured
+  via the same `find_accessible_name_violations` parse this spec's guard
+  uses: 39 fields live in `wizard.html`'s own markup (26 of them inside the
+  dead block above) and 24 more are injected by `getDownloaderFields()`'s
+  JS template-literal strings — 39 + 24 = 63, minus the 26 dead ones = 37
+  reachable. The user-facing win this change delivers is 37 fields properly
+  named, not 63.
+- **The eight non-wizard Scope templates needed no diff.** Every field in
+  `movie_cards.html`, `field_types.html`, `combined_basics_card.html`,
+  `header.html`, `provider_card.html`, `profiles.html`, `logs_tab.html` and
+  `logs.html` was already named by a wrapping `<label>` or an `aria-label`
+  before this change — confirmed by running the guard against each and
+  finding zero violations with no edits made. Two of them
+  (`header.html`, `provider_card.html`) contain no interactive field at all,
+  so their parametrised guard run asserts on an empty list; that is a
+  correct, expected CLEAN result, not a gap. The original Scope bullet read
+  as though a diff was needed in all eight; it was not.

--- a/specs/A11Y-001-form-labels-not-associated.md
+++ b/specs/A11Y-001-form-labels-not-associated.md
@@ -1,0 +1,80 @@
+# A11Y-001: form labels are not associated with their fields
+
+**Status:** agreed
+**Source:** SonarQube, 118 findings at MEDIUM or higher across
+`Web:S6853`, `Web:InputWithoutLabelCheck` and `Web:S6819`.
+**Owner decision:** 2026-09-05, take the accessibility slice first.
+
+## Problem
+
+61 `<label>` elements in `couchpotato/ui/templates/wizard.html`, and not one is
+associated with a field. Measured:
+
+    wizard.html      labels=61  with for=0   inputs=63  with aria-label=0
+
+Every label sits visually above its input and is invisible to assistive
+technology, which announces those fields as unlabelled. That includes the
+security step where a new user sets their username and password, and every
+download client's API key and token field. It also means clicking a label does
+not focus its field, which costs every user, not only screen reader users.
+
+This is WCAG 2.2 AA, 1.3.1 Info and Relationships, 3.3.2 Labels or
+Instructions, and 4.1.2 Name, Role, Value.
+
+## Why the existing tests do not catch it
+
+They are not wrong; they are looking at a different thing. `axe` scans the
+rendered DOM and correctly ignores hidden elements. The wizard is a multi-step
+form whose later steps are `x-show`-gated, so at the moment
+`tests/e2e/accessibility.a11y.spec.ts:247` scans it, most of those fields are
+not visible and are never evaluated. SonarQube reads the template source and
+sees all of them.
+
+That gap is the more valuable finding than the labels themselves, and closing it
+is part of this change.
+
+## Scope
+
+- `wizard.html`, all 61 labels and 63 inputs.
+- The stragglers elsewhere, measured: `partials/movie_cards.html` (2 labels, 0
+  with `for`), `partials/settings/field_types.html` (1 of 1),
+  `partials/settings/combined_basics_card.html` (1 of 1),
+  `partials/settings/header.html` (1 of 1),
+  `partials/settings/provider_card.html` (1 of 1),
+  `partials/settings/profiles.html` (2 of 7), `partials/settings/logs_tab.html`
+  (1 of 2), `logs.html` (1 of 2).
+- A guard that fails when a label or field is added without an association.
+- An E2E scan that walks the wizard's steps rather than only its first.
+
+## Not in scope
+
+- `Web:S6819` (prefer a semantic tag over an ARIA role), 39 findings. A
+  different defect with a different fix; it earns its own change.
+- The other 829 findings at MEDIUM or higher. Sequenced separately, and the
+  complexity ones are explicitly not being taken as a batch.
+- Redesigning the wizard.
+
+## Acceptance criteria
+
+- **AC-A11Y-1:** Every interactive field in the templates listed under Scope has
+  an accessible name, satisfied by ONE of: an explicit `for`/`id` pair, being
+  wrapped by its `<label>`, or an `aria-label`/`aria-labelledby`. All three are
+  valid; a guard that demands only the first is wrong.
+- **AC-A11Y-2:** No duplicate `id` on any page. The three inputs inside `x-for`
+  loops need bound ids (`:id="..."`), not static ones. A static id repeated per
+  iteration is a worse defect than the one being fixed.
+- **AC-A11Y-3:** Clicking a label moves focus to its field. This is the
+  behaviour the fix buys and it is observable, unlike the markup itself.
+- **AC-QA-4:** A guard parses the templates and fails when a field has no
+  accessible name by any of the three routes in AC-A11Y-1. Proven load-bearing
+  by removing one association and watching it fail.
+- **AC-QA-5:** The E2E accessibility scan reaches wizard steps beyond the first.
+  Proven by removing a label association on a LATER step and watching the E2E
+  scan fail, which it currently would not.
+- **AC-SIMP-6:** No visual change. The wizard must look identical; this adds
+  attributes, it does not restyle.
+
+## Recorded debt
+
+1. `Web:S6819`, 39 findings, ARIA roles used where a semantic element exists.
+2. The remaining SonarQube backlog, sequenced and not batched.

--- a/specs/A11Y-001-form-labels-not-associated.md
+++ b/specs/A11Y-001-form-labels-not-associated.md
@@ -45,7 +45,7 @@ is part of this change.
   `partials/settings/provider_card.html` (1 of 1),
   `partials/settings/profiles.html` (2 of 7), `partials/settings/logs_tab.html`
   (1 of 2), `logs.html` (1 of 2). **Correction: all eight were found already
-  compliant when the guard below was written against them (see below) — this
+  compliant when the guard below was written against them (see below), this
   bullet lists where the guard runs, not where a diff was needed.**
 - A guard that fails when a label or field is added without an association.
 - An E2E scan that walks the wizard's steps rather than only its first.
@@ -76,7 +76,7 @@ is part of this change.
   Proven by removing a label association on a LATER step and watching the E2E
   scan fail. **Correction (round 2 review): this held for only about one field
   in twenty.** axe's `label` rule accepts a `placeholder` as an accessible
-  name, and 41 of the wizard's 63 fields carry one — so the scan only had
+  name, and 41 of the wizard's 63 fields carry one, so the scan only had
   teeth on the roughly one-in-twenty field with no placeholder. Fixed by
   replacing the axe-only scan with a DOM-level check
   (`assertFieldNamesAreReal` in `tests/e2e/accessibility.a11y.spec.ts`) that
@@ -106,13 +106,13 @@ is part of this change.
   that assertion fail when the grouping markup is removed.
 - **AC-A11Y-8** (round 2 review, B3): every icon-only button (no visible text
   content) has a non-empty accessible name. Proven with axe's `button-name`
-  rule run against a scan that actually renders the button — the remove-row
+  rule run against a scan that actually renders the button, the remove-row
   button (only visible with 2+ entries) and the directory browser's close
   button (only visible once opened) are both exercised for this, not left to
   a scan that never visits the state they render in.
 - **AC-A11Y-9** (round 2 review, A4): a label names the field it is actually
   paired with, not merely *a* field. `toBeFocused()` alone cannot tell a
-  correct `for`/`id` pairing from a swapped one — both move focus somewhere.
+  correct `for`/`id` pairing from a swapped one, both move focus somewhere.
   Proven with `toHaveAccessibleName` asserting the exact expected text, and by
   swapping the Security step's `for` values and watching it fail while the
   focus-only assertion stayed green.
@@ -139,11 +139,11 @@ is part of this change.
    Left in place for this change (not deleted) because it is out of scope for
    an accessibility fix; removing it is separate cleanup work.
 
-## Round 2 correction (review, this fix cycle)
+## Round 2 correction (from review, this fix cycle)
 
 Two independent reviews of the first commit (ed2bea7c4) confirmed the shipped
-wizard markup was correct — including the JavaScript-injected fields, all 63
-of them, zero duplicate ids, zero dangling `for` — but found the guards this
+wizard markup was correct, including the JavaScript-injected fields, all 63
+of them, zero duplicate ids, zero dangling `for`, but found the guards this
 spec's ACs describe were weaker than claimed, plus real gaps in three
 templates and in this spec. The guard fixes are recorded against the ACs
 above (AC-QA-5, AC-A11Y-7/8/9); the counting corrections are:
@@ -152,14 +152,14 @@ above (AC-QA-5, AC-A11Y-7/8/9); the counting corrections are:
   via the same `find_accessible_name_violations` parse this spec's guard
   uses: 39 fields live in `wizard.html`'s own markup (26 of them inside the
   dead block above) and 24 more are injected by `getDownloaderFields()`'s
-  JS template-literal strings — 39 + 24 = 63, minus the 26 dead ones = 37
+  JS template-literal strings, 39 + 24 = 63, minus the 26 dead ones = 37
   reachable. The user-facing win this change delivers is 37 fields properly
   named, not 63.
 - **The eight non-wizard Scope templates needed no diff.** Every field in
   `movie_cards.html`, `field_types.html`, `combined_basics_card.html`,
   `header.html`, `provider_card.html`, `profiles.html`, `logs_tab.html` and
   `logs.html` was already named by a wrapping `<label>` or an `aria-label`
-  before this change — confirmed by running the guard against each and
+  before this change, confirmed by running the guard against each and
   finding zero violations with no edits made. Two of them
   (`header.html`, `provider_card.html`) contain no interactive field at all,
   so their parametrised guard run asserts on an empty list; that is a

--- a/tests/e2e/accessibility.a11y.spec.ts
+++ b/tests/e2e/accessibility.a11y.spec.ts
@@ -91,9 +91,127 @@ async function checkToggleA11y(page: any, pageName: string) {
 // exercise whether label association actually holds once axe can see the
 // step at all. These rules are exactly the ones a missing or duplicated
 // accessible name trips.
-async function checkFieldNameA11y(page: any, pageName: string) {
+//
+// Round 2 (both A11Y-001 reviews found the same three holes in this
+// function, so it is rewritten rather than patched):
+//
+// A1 -- axe's `label` rule accepts a `placeholder` as an accessible name.
+// 41 of the wizard's 63 fields carry one. Demonstrated: removing the `for`
+// from wizard-renamer-from (Library step, which HAS a placeholder) left this
+// whole function green; removing it from wizard-dl-qbittorrent-password (the
+// one visited field with no placeholder) correctly went red. So axe alone
+// had teeth on roughly one field in twenty. `assertFieldNamesAreReal` below
+// is a DOM-level check that does not have that blind spot: it reads each
+// visible field's actual label/aria text and rejects it when that text is
+// merely the placeholder axe would have accepted.
+//
+// A2 -- `duplicate-id` and `duplicate-id-active` are BOTH `enabled: false`
+// in the installed axe-core (4.13.0; verified via
+// `axe._audit.rules.find(r => r.id === '...').enabled`), so neither can ever
+// report anything here -- dropped. The real case this was meant to catch
+// (two visible fields sharing an id) surfaces as `incomplete`, not
+// `violations`, which the old code never inspected either way;
+// `assertFieldNamesAreReal` checks id uniqueness directly instead.
+// `select-name` and `aria-input-field-name` are also dropped: this page has
+// zero `<select>` elements and zero roles either rule applies to (verified:
+// `grep -c '<select' wizard.html` is 0, and no `role="textbox|combobox|
+// searchbox|spinbutton|slider"` appears anywhere in it), so both rules
+// described a check that could never run. `duplicate-id-aria` stays; it IS
+// enabled and covers ARIA-referential duplicate ids axe's own way.
+async function assertFieldNamesAreReal(page: any, pageName: string, minFields: number) {
+  const scan = await page.evaluate(() => {
+    const isVisible = (el: Element) => {
+      const style = window.getComputedStyle(el);
+      if (style.display === 'none' || style.visibility === 'hidden' ||
+          parseFloat(style.opacity || '1') === 0) return false;
+      const rect = (el as HTMLElement).getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    };
+
+    const fields = Array.from(document.querySelectorAll('input, textarea, select'))
+      .filter((el) => (el as HTMLInputElement).type !== 'hidden')
+      .filter(isVisible) as (HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement)[];
+
+    const idCounts = new Map<string, number>();
+    for (const field of fields) {
+      const id = field.getAttribute('id');
+      if (id) idCounts.set(id, (idCounts.get(id) || 0) + 1);
+    }
+
+    const problems: string[] = [];
+
+    for (const field of fields) {
+      const id = field.getAttribute('id');
+      const describe = () =>
+        `<${field.tagName.toLowerCase()} id=${JSON.stringify(id)} ` +
+        `x-model=${JSON.stringify(field.getAttribute('x-model'))} ` +
+        `placeholder=${JSON.stringify((field as HTMLInputElement).placeholder || null)}>`;
+
+      if (id && (idCounts.get(id) || 0) > 1) {
+        problems.push(`${describe()}: id ${JSON.stringify(id)} is shared by ${idCounts.get(id)} visible elements (AC-A11Y-2)`);
+      }
+
+      const labelsFor = id ? Array.from(document.querySelectorAll(`label[for="${CSS.escape(id)}"]`)) : [];
+      if (labelsFor.length > 1) {
+        problems.push(`${describe()}: ${labelsFor.length} <label for> elements point at it, expected exactly 1`);
+      }
+
+      const ariaLabel = (field.getAttribute('aria-label') || '').trim();
+      const labelledbyIds = (field.getAttribute('aria-labelledby') || '').trim();
+      const labelledbyText = labelledbyIds
+        ? labelledbyIds.split(/\s+/).map((refId) => document.getElementById(refId)?.textContent?.trim() || '').join(' ').trim()
+        : '';
+
+      const accessibleName = labelsFor.length === 1
+        ? (labelsFor[0].textContent || '').trim()
+        : (ariaLabel || labelledbyText);
+
+      if (!accessibleName) {
+        problems.push(`${describe()}: no label[for], aria-label or aria-labelledby resolved to a non-empty name`);
+        continue;
+      }
+
+      // A1: the accessible name must not be merely the placeholder -- a
+      // sighted user already sees the placeholder disappear on input, so a
+      // screen reader user told only "Indexer URL (e.g. ...)" once typing
+      // starts has lost the one cue they had.
+      const placeholder = ((field as HTMLInputElement).placeholder || '').trim();
+      if (placeholder && accessibleName === placeholder) {
+        problems.push(`${describe()}: accessible name is identical to its own placeholder ("${placeholder}")`);
+      }
+    }
+
+    return { problems, checked: fields.length };
+  });
+
+  // A5: a coverage floor. Without this, a scan that silently degrades to
+  // examining zero fields (a broken selector, a step that failed to render,
+  // a navigation click that landed on the wrong step) still reports zero
+  // problems and reads as clean.
+  expect(
+    scan.checked,
+    `${pageName}: expected at least ${minFields} visible field(s) to examine, found ${scan.checked} -- ` +
+    `the scan may be looking at the wrong step, or nothing rendered`,
+  ).toBeGreaterThanOrEqual(minFields);
+
+  expect(
+    scan.problems,
+    `${pageName}: field accessible-name problem(s):\n${scan.problems.join('\n')}`,
+  ).toEqual([]);
+}
+
+async function checkFieldNameA11y(page: any, pageName: string, minFields: number) {
+  await assertFieldNamesAreReal(page, pageName, minFields);
+
+  // axe as a second opinion for anything the DOM check above does not
+  // cover -- e.g. aria-labelledby pointing at a missing id, which
+  // assertFieldNamesAreReal treats as an empty name (still a real failure)
+  // but axe's `label` rule names more precisely. `button-name` is included
+  // here too: B3 added two icon-only buttons that only render once a
+  // second Newznab entry / the directory browser is opened, both of which
+  // this test now does before scanning the relevant step.
   const results = await new AxeBuilder({ page })
-    .withRules(['label', 'aria-input-field-name', 'select-name', 'duplicate-id', 'duplicate-id-aria', 'duplicate-id-active'])
+    .withRules(['label', 'duplicate-id-aria', 'button-name'])
     .analyze();
 
   if (results.violations.length > 0) {
@@ -108,6 +226,20 @@ async function checkFieldNameA11y(page: any, pageName: string) {
     results.violations.length,
     `Found field-name a11y violations on ${pageName}: ${results.violations.map(v => v.id).join(', ')}`
   ).toBe(0);
+}
+
+// A3: a step-arrival assertion. Blocking the wizard from advancing to the
+// intended step must fail the corresponding scan loudly, rather than the
+// scan silently re-examining whichever step is actually showing (every step
+// but Welcome shares the same DOM structure enough that a stray field count
+// alone would not always catch this). Checks BOTH the step's own heading and
+// one field unique to that step, because `x-show` toggles the wrapping div's
+// visibility, but a heading alone would still pass if the wizard were stuck
+// one step behind (every step after Welcome renders inside a similarly
+// shaped card).
+async function assertWizardStepShowing(page: any, headingText: string | RegExp, knownFieldSelector: string) {
+  await expect(page.getByRole('heading', { name: headingText })).toBeVisible();
+  await expect(page.locator(knownFieldSelector).first()).toBeVisible();
 }
 
 test.describe('Accessibility', () => {
@@ -299,7 +431,13 @@ test.describe('Accessibility', () => {
     // Step 2: Security -- username/password.
     await page.getByRole('button', { name: 'Continue' }).click();
     await page.waitForTimeout(300);
-    await checkFieldNameA11y(page, 'Setup Wizard (Security)');
+    // A3: assert the wizard actually reached this step before scanning it --
+    // demonstrated to matter: blocking `nextStep()` from advancing left the
+    // Welcome step showing while this scan ran unaware, and reported clean.
+    await assertWizardStepShowing(page, 'Server Security', '#wizard-username');
+    // A5: floor measured directly against this markup -- 2 fields
+    // (username, password).
+    await checkFieldNameA11y(page, 'Setup Wizard (Security)', 2);
 
     // Security -> Providers (Skip, no credentials needed for this scan).
     await page.getByRole('button', { name: 'Skip' }).click();
@@ -317,7 +455,39 @@ test.describe('Accessibility', () => {
     await page.waitForTimeout(300);
     await page.getByRole('switch', { name: 'Enable PassThePopcorn' }).click();
     await page.waitForTimeout(300);
-    await checkFieldNameA11y(page, 'Setup Wizard (Providers)');
+    await assertWizardStepShowing(page, 'Where to Search', '#wizard-jackett-url');
+    // A5: floor measured directly -- 7 fields (2 Newznab entry, 2 Jackett,
+    // 3 PassThePopcorn), before B1's second indexer entry below adds 2 more.
+    await checkFieldNameA11y(page, 'Setup Wizard (Providers)', 7);
+
+    // B2 regression coverage: PassThePopcorn's "Username" is grouped by
+    // tracker name so a second enabled tracker's own "Username" is
+    // distinguishable the same way the Usenet/Torrent client groups are
+    // checked further below.
+    await expect(
+      page.getByRole('group', { name: 'PassThePopcorn' }).getByLabel('Username'),
+    ).toBeVisible();
+
+    // B1/B3 regression coverage: add a second Newznab indexer entry so the
+    // `x-for`-bound aria-labels (B1) and the per-row remove button (B3) both
+    // render a second time, then re-scan. Two DISTINCT accessible names are
+    // asserted directly (not just "no violation") because axe's `label` rule
+    // is satisfied by two fields both named "Newznab indexer URL" -- it
+    // checks presence, not uniqueness -- so only a direct read of the two
+    // names can catch the static-aria-label regression B1 fixed.
+    await page.getByRole('button', { name: '+ Add another indexer' }).click();
+    await page.waitForTimeout(300);
+    const indexerUrlInputs = page.getByLabel(/Newznab indexer URL \d+/);
+    await expect(indexerUrlInputs).toHaveCount(2);
+    const firstName = await indexerUrlInputs.nth(0).getAttribute('aria-label');
+    const secondName = await indexerUrlInputs.nth(1).getAttribute('aria-label');
+    expect(
+      firstName,
+      'two Newznab indexer rows must not share one accessible name',
+    ).not.toBe(secondName);
+    const removeButtons = page.getByRole('button', { name: /^Remove indexer \d+$/ });
+    await expect(removeButtons).toHaveCount(2);
+    await checkFieldNameA11y(page, 'Setup Wizard (Providers, two indexers)', 9);
 
     // Step 4: Downloader -- pick one client from each list so
     // getDownloaderFields()'s x-html-injected markup actually renders, and
@@ -328,12 +498,48 @@ test.describe('Accessibility', () => {
     await page.getByRole('button', { name: 'qBittorrent' }).click();
     await page.getByRole('switch', { name: 'Enable Black Hole' }).click();
     await page.waitForTimeout(300);
-    await checkFieldNameA11y(page, 'Setup Wizard (Downloader)');
+    await assertWizardStepShowing(page, 'Download Clients', '#wizard-dl-sabnzbd-host');
+    // A5: floor measured directly -- 8 fields (3 SABnzbd, 3 qBittorrent, 2
+    // Black Hole).
+    await checkFieldNameA11y(page, 'Setup Wizard (Downloader)', 8);
+
+    // B2 regression coverage: with one Usenet client (SABnzbd) and one
+    // Torrent client (qBittorrent) both configured, "Host" is the visible
+    // label on two different fields. Distinguishing them is the GROUP each
+    // sits in (aria-labelledby the section heading), not the field's own
+    // name -- getByRole('group', ...) is the direct way to prove that
+    // grouping is real rather than decorative.
+    await expect(
+      page.getByRole('group', { name: 'Usenet Client' }).getByLabel('Host'),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('group', { name: 'Torrent Client' }).getByLabel('Host'),
+    ).toBeVisible();
 
     // Step 5: Library -- renamer fields, on by default.
     await page.getByRole('button', { name: 'Continue' }).click();
     await page.waitForTimeout(500);
-    await checkFieldNameA11y(page, 'Setup Wizard (Library)');
+    await assertWizardStepShowing(page, 'Movie Library', '#wizard-renamer-from');
+    // A5: floor measured directly -- 4 fields (download folder, movie
+    // library, folder naming, file naming).
+    await checkFieldNameA11y(page, 'Setup Wizard (Library)', 4);
+
+    // B3 regression coverage: the directory browser's close button is the
+    // only visible way to dismiss it and is icon-only. It only exists in the
+    // DOM once opened, so open it here rather than relying on a full-page
+    // scan that would never have found it hidden behind `x-show`.
+    await page.getByRole('button', { name: 'Browse' }).first().click();
+    const closeBrowser = page.getByRole('button', { name: 'Close directory browser' });
+    await expect(closeBrowser).toBeVisible();
+    const browserResults = await new AxeBuilder({ page })
+      .include('.fixed.inset-0.z-50')
+      .withRules(['button-name'])
+      .analyze();
+    expect(
+      browserResults.violations.map(v => v.nodes.map(n => n.html).join('; ')),
+      'directory browser button(s) with no accessible name',
+    ).toEqual([]);
+    await closeBrowser.click();
   });
 
   test('Setup Wizard provider toggles are accessible and keyboard-operable', async ({ page }) => {

--- a/tests/e2e/accessibility.a11y.spec.ts
+++ b/tests/e2e/accessibility.a11y.spec.ts
@@ -453,19 +453,28 @@ test.describe('Accessibility', () => {
     await page.getByRole('switch', { name: 'Enable Jackett / TorrentPotato' }).click();
     await page.getByRole('button', { name: /Private Trackers/ }).click();
     await page.waitForTimeout(300);
+    // TWO trackers enabled, not one: a single enabled tracker cannot prove
+    // B2's fix, because a static id/for pair inside the field loop would
+    // never collide with itself -- it only collides once a second tracker's
+    // identically-named "Username"/"Passkey" fields are ALSO visible.
     await page.getByRole('switch', { name: 'Enable PassThePopcorn' }).click();
+    await page.getByRole('switch', { name: 'Enable HDBits' }).click();
     await page.waitForTimeout(300);
     await assertWizardStepShowing(page, 'Where to Search', '#wizard-jackett-url');
-    // A5: floor measured directly -- 7 fields (2 Newznab entry, 2 Jackett,
-    // 3 PassThePopcorn), before B1's second indexer entry below adds 2 more.
-    await checkFieldNameA11y(page, 'Setup Wizard (Providers)', 7);
+    // A5: floor measured directly -- 9 fields (2 Newznab entry, 2 Jackett,
+    // 3 PassThePopcorn, 2 HDBits), before B1's second indexer entry below
+    // adds 2 more.
+    await checkFieldNameA11y(page, 'Setup Wizard (Providers)', 9);
 
-    // B2 regression coverage: PassThePopcorn's "Username" is grouped by
-    // tracker name so a second enabled tracker's own "Username" is
-    // distinguishable the same way the Usenet/Torrent client groups are
-    // checked further below.
+    // B2 regression coverage: PassThePopcorn's and HDBits' "Username" fields
+    // are identically named but grouped by tracker name, so assistive tech
+    // can tell them apart the same way the Usenet/Torrent client groups
+    // (checked further below) disambiguate two "Host" fields.
     await expect(
       page.getByRole('group', { name: 'PassThePopcorn' }).getByLabel('Username'),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('group', { name: 'HDBits' }).getByLabel('Username'),
     ).toBeVisible();
 
     // B1/B3 regression coverage: add a second Newznab indexer entry so the
@@ -487,7 +496,7 @@ test.describe('Accessibility', () => {
     ).not.toBe(secondName);
     const removeButtons = page.getByRole('button', { name: /^Remove indexer \d+$/ });
     await expect(removeButtons).toHaveCount(2);
-    await checkFieldNameA11y(page, 'Setup Wizard (Providers, two indexers)', 9);
+    await checkFieldNameA11y(page, 'Setup Wizard (Providers, two indexers)', 11);
 
     // Step 4: Downloader -- pick one client from each list so
     // getDownloaderFields()'s x-html-injected markup actually renders, and

--- a/tests/e2e/accessibility.a11y.spec.ts
+++ b/tests/e2e/accessibility.a11y.spec.ts
@@ -83,6 +83,33 @@ async function checkToggleA11y(page: any, pageName: string) {
   ).toBe(0);
 }
 
+// A11Y-001, AC-QA-4/AC-QA-5: scoped the same way checkToggleA11y is above,
+// and for the same reason. The wizard's later steps have pre-existing,
+// unrelated findings this task does not own (e.g. color-contrast on the
+// search-type hint text, tracked separately, not in A11Y-001's scope) --
+// a full checkA11y sweep on those steps would fail on THOSE and never
+// exercise whether label association actually holds once axe can see the
+// step at all. These rules are exactly the ones a missing or duplicated
+// accessible name trips.
+async function checkFieldNameA11y(page: any, pageName: string) {
+  const results = await new AxeBuilder({ page })
+    .withRules(['label', 'aria-input-field-name', 'select-name', 'duplicate-id', 'duplicate-id-aria', 'duplicate-id-active'])
+    .analyze();
+
+  if (results.violations.length > 0) {
+    console.log(`Field-name a11y violations on ${pageName}:`);
+    results.violations.forEach(violation => {
+      console.log(`  - ${violation.id}: ${violation.description}`);
+      violation.nodes.forEach(node => console.log(`    ${node.html}`));
+    });
+  }
+
+  expect(
+    results.violations.length,
+    `Found field-name a11y violations on ${pageName}: ${results.violations.map(v => v.id).join(', ')}`
+  ).toBe(0);
+}
+
 test.describe('Accessibility', () => {
   test('Wanted page should be accessible', async ({ page }) => {
     await page.goto('/');
@@ -253,7 +280,60 @@ test.describe('Accessibility', () => {
     // toggle switches at a non-canonical size (w-10 h-5) and without
     // role="switch"/:aria-checked/aria-label, which axe's aria-required-attr /
     // aria-allowed-attr rules would catch on any toggle actually in view.
-    await checkA11y(page, 'Setup Wizard');
+    await checkA11y(page, 'Setup Wizard (Welcome)');
+
+    // AC-QA-5 (A11Y-001): every step below this point used to go unscanned.
+    // The wizard is `x-show`-gated per step, so axe -- which correctly
+    // ignores hidden elements -- only ever saw the Welcome step above.
+    // specs/A11Y-001-form-labels-not-associated.md measured the gap this
+    // left: 118 SonarQube findings against 0 from axe, because SonarQube
+    // reads template source and axe reads the rendered DOM at a moment most
+    // of that source was not visible. Walk the real flow, the same shape
+    // navigateWizardToProviders above uses, and scan each step once its
+    // fields are actually visible -- opening the nested toggles too, so the
+    // fields that only render once a section is enabled (Newznab entries,
+    // Jackett credentials, a private tracker's fields, the chosen
+    // downloader's fields) are in the DOM when the scan runs, not skipped
+    // the same way the Welcome-only scan skipped everything below it.
+
+    // Step 2: Security -- username/password.
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await page.waitForTimeout(300);
+    await checkFieldNameA11y(page, 'Setup Wizard (Security)');
+
+    // Security -> Providers (Skip, no credentials needed for this scan).
+    await page.getByRole('button', { name: 'Skip' }).click();
+    await page.waitForTimeout(300);
+
+    // Step 3: Providers -- "Both" renders usenet and torrent sections
+    // together; enabling Newznab and Jackett reveals their credential
+    // fields, and expanding + enabling one private tracker reveals the
+    // `x-for` field loop (AC-A11Y-2's bound-id case).
+    await page.getByRole('button', { name: /^Both/ }).click();
+    await page.waitForTimeout(300);
+    await page.getByRole('switch', { name: 'Enable Newznab Indexers' }).click();
+    await page.getByRole('switch', { name: 'Enable Jackett / TorrentPotato' }).click();
+    await page.getByRole('button', { name: /Private Trackers/ }).click();
+    await page.waitForTimeout(300);
+    await page.getByRole('switch', { name: 'Enable PassThePopcorn' }).click();
+    await page.waitForTimeout(300);
+    await checkFieldNameA11y(page, 'Setup Wizard (Providers)');
+
+    // Step 4: Downloader -- pick one client from each list so
+    // getDownloaderFields()'s x-html-injected markup actually renders, and
+    // enable Black Hole for its own folder fields.
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await page.waitForTimeout(500);
+    await page.getByRole('button', { name: 'SABnzbd' }).click();
+    await page.getByRole('button', { name: 'qBittorrent' }).click();
+    await page.getByRole('switch', { name: 'Enable Black Hole' }).click();
+    await page.waitForTimeout(300);
+    await checkFieldNameA11y(page, 'Setup Wizard (Downloader)');
+
+    // Step 5: Library -- renamer fields, on by default.
+    await page.getByRole('button', { name: 'Continue' }).click();
+    await page.waitForTimeout(500);
+    await checkFieldNameA11y(page, 'Setup Wizard (Library)');
   });
 
   test('Setup Wizard provider toggles are accessible and keyboard-operable', async ({ page }) => {

--- a/tests/e2e/wizard.spec.ts
+++ b/tests/e2e/wizard.spec.ts
@@ -48,11 +48,13 @@ test.describe('Wizard: a refused save must not read as success', () => {
       timeout: 10000,
     });
     await page.getByRole('button', { name: /Continue/i }).click();
-    // The security step's inputs carry no name or id -- they are Alpine
-    // `x-model` bindings -- so they are addressed by type + placeholder.
-    // An earlier draft used input[name="username"], matched nothing, and every
-    // test failed for a reason unrelated to what they assert. The control test
-    // below is what exposed that: it should PASS before any fix.
+    // The security step's inputs are Alpine `x-model` bindings and carry no
+    // `name`, so they are addressed by type + placeholder here rather than by
+    // name. (A11Y-001 later gave them ids for label association, but not
+    // names, so this locator still holds.) An earlier draft used
+    // input[name="username"], matched nothing, and every test failed for a
+    // reason unrelated to what they assert. The control test below is what
+    // exposed that: it should PASS before any fix.
     await expect(SECURITY_USERNAME(page)).toBeVisible({ timeout: 5000 });
   }
 
@@ -329,5 +331,52 @@ test.describe('Wizard: a refused save must not read as success', () => {
       page.locator('body'),
       'a successful save failed to advance the wizard',
     ).toContainText('Where to Search', { timeout: 5000, useInnerText: true });
+  });
+});
+
+/**
+ * A11Y-001, AC-A11Y-3: clicking a label must move focus to its field.
+ *
+ * This is the user-visible behaviour the for/id association actually buys --
+ * unlike the markup itself, it is directly observable, and it is the native
+ * browser behaviour for an explicit for/id pair, not something the app's own
+ * JS has to implement. Covers both the static case (Security step) and the
+ * bound-id case inside an `x-for` loop (a private tracker's fields), since
+ * the bound pair is the one AC-A11Y-2 warns is easy to get wrong -- a static
+ * id there would collide across iterations, but only a real click proves the
+ * pairing that ships actually resolves to a single field, not zero or many.
+ */
+test.describe('Wizard: clicking a label focuses its field (AC-A11Y-3)', () => {
+  test('the Security step labels focus their inputs', async ({ page }) => {
+    await page.goto('/wizard/');
+    await page.getByRole('button', { name: /Continue/i }).click();
+    await expect(page.locator('#wizard-username')).toBeVisible({ timeout: 5000 });
+
+    await page.locator('label[for="wizard-username"]').click();
+    await expect(page.locator('#wizard-username')).toBeFocused();
+
+    await page.locator('label[for="wizard-password"]').click();
+    await expect(page.locator('#wizard-password')).toBeFocused();
+  });
+
+  test('a private tracker field label, with its bound :for/:id, focuses its input', async ({
+    page,
+  }) => {
+    await page.goto('/wizard/');
+    await page.getByRole('button', { name: /Continue/i }).click(); // Welcome -> Security
+    await page.getByRole('button', { name: /^Skip$/i }).click(); // Security -> Providers
+    await page.getByRole('button', { name: /^Torrents/ }).click();
+    await page.getByRole('button', { name: /Private Trackers/ }).click();
+    await page.getByRole('switch', { name: 'Enable PassThePopcorn' }).click();
+
+    // Bound to `'wizard-tracker-' + tracker.id + '-' + field.name`; PassThePopcorn's
+    // id is 'passthepopcorn' and its first field is 'username' -- see
+    // setupWizard()'s privateTrackers data.
+    const label = page.locator('label[for="wizard-tracker-passthepopcorn-username"]');
+    const field = page.locator('#wizard-tracker-passthepopcorn-username');
+    await expect(field).toBeVisible({ timeout: 5000 });
+
+    await label.click();
+    await expect(field).toBeFocused();
   });
 });

--- a/tests/e2e/wizard.spec.ts
+++ b/tests/e2e/wizard.spec.ts
@@ -345,12 +345,22 @@ test.describe('Wizard: a refused save must not read as success', () => {
  * the bound pair is the one AC-A11Y-2 warns is easy to get wrong -- a static
  * id there would collide across iterations, but only a real click proves the
  * pairing that ships actually resolves to a single field, not zero or many.
+ *
+ * A11Y-001 round 2 (review A4): a focus-only assertion cannot catch a WRONG
+ * pairing, only a MISSING one. Swapping the `for` values on the Security
+ * step's two labels still focuses A field on click -- just the wrong one --
+ * so `toBeFocused()` alone stayed green while `wizard-username` announced
+ * "Password" and vice versa. `toHaveAccessibleName` below pins the label
+ * text against the field it actually names, which the swap breaks.
  */
 test.describe('Wizard: clicking a label focuses its field (AC-A11Y-3)', () => {
   test('the Security step labels focus their inputs', async ({ page }) => {
     await page.goto('/wizard/');
     await page.getByRole('button', { name: /Continue/i }).click();
     await expect(page.locator('#wizard-username')).toBeVisible({ timeout: 5000 });
+
+    await expect(page.locator('#wizard-username')).toHaveAccessibleName('Username');
+    await expect(page.locator('#wizard-password')).toHaveAccessibleName('Password');
 
     await page.locator('label[for="wizard-username"]').click();
     await expect(page.locator('#wizard-username')).toBeFocused();
@@ -375,6 +385,8 @@ test.describe('Wizard: clicking a label focuses its field (AC-A11Y-3)', () => {
     const label = page.locator('label[for="wizard-tracker-passthepopcorn-username"]');
     const field = page.locator('#wizard-tracker-passthepopcorn-username');
     await expect(field).toBeVisible({ timeout: 5000 });
+
+    await expect(field).toHaveAccessibleName('Username');
 
     await label.click();
     await expect(field).toBeFocused();

--- a/tests/unit/test_wizard_form_labels_a11y.py
+++ b/tests/unit/test_wizard_form_labels_a11y.py
@@ -167,13 +167,26 @@ def find_static_id_in_loop_violations(path):
     defect than the missing label it would "fix" -- every iteration renders
     the same id, so the DOM ends up with duplicates. Fields in a loop must use
     a bound `:id` (unique per iteration, e.g. from the loop item), not a
-    static one."""
+    static one.
+
+    Deduped by element identity (round 2 review, C4): `soup.find_all` on an
+    OUTER `<template x-for>` also walks any INNER one nested inside it (the
+    real shape at wizard.html:297/:311, a tracker loop containing a
+    per-tracker field loop), and the outer `for loop in ...` here visits the
+    inner loop a second time as its own top-level match -- so one real
+    static-id defect was reported twice, not once. `seen` tracks which
+    elements have already been checked, by object identity, across every
+    loop level."""
     text = _strip_jinja_comments(path.read_text())
     soup = BeautifulSoup(text, 'html.parser')
 
     violations = []
+    seen = set()
     for loop in soup.find_all('template', attrs={'x-for': True}):
         for el in loop.find_all(list(FIELD_TAGS) + ['label']):
+            if id(el) in seen:
+                continue
+            seen.add(id(el))
             if el.get('id'):
                 violations.append(
                     '%s: %s inside an x-for loop has a static id -- this '
@@ -277,6 +290,40 @@ def test_the_loop_checker_flags_a_static_id_inside_x_for():
     finally:
         bad_path.unlink()
         good_path.unlink()
+
+
+def test_the_loop_checker_does_not_double_count_a_nested_loop():
+    """Round 2 review (C4): `find_all('template', attrs={'x-for': True})`
+    matches BOTH the outer and the inner loop in wizard.html's real shape (a
+    tracker loop containing a per-tracker field loop, wizard.html:297/:311).
+    Walking the outer loop's subtree with `find_all` also walks the inner
+    loop's elements, and the inner loop is then walked a second time as its
+    own top-level match -- so one real static-id defect was reported twice,
+    which would have doubled every count a caller relied on. Two distinct
+    violations (one label, one input) must be reported as exactly two, not
+    four."""
+    nested_bad = (
+        '<template x-for="tracker in trackers" :key="tracker.id">'
+        '<div>'
+        '<template x-for="field in tracker.fields" :key="field.name">'
+        '<div><label for="field-id">X</label><input id="field-id"></div>'
+        '</template>'
+        '</div>'
+        '</template>'
+    )
+    import tempfile
+    with tempfile.NamedTemporaryFile('w', suffix='.html', delete=False) as f:
+        f.write(nested_bad)
+        nested_path = Path(f.name)
+
+    try:
+        violations = find_static_id_in_loop_violations(nested_path)
+        assert len(violations) == 2, (
+            'one static-id label and one static-id input inside a nested '
+            'x-for must be reported once each, not once per loop level they '
+            'sit inside -- got %r' % violations)
+    finally:
+        nested_path.unlink()
 
 
 # --- the guard, run against the real templates -------------------------------

--- a/tests/unit/test_wizard_form_labels_a11y.py
+++ b/tests/unit/test_wizard_form_labels_a11y.py
@@ -70,7 +70,17 @@ _JINJA_COMMENT = re.compile(r'{#.*?#}', re.S)
 #: A JS template-literal string, inside a <script> block, that contains form
 #: markup -- see the getDownloaderFields() note above.
 _JS_HTML_STRING = re.compile(r'`([^`]*<(?:input|label|select|textarea)[^`]*)`', re.S)
-_SCRIPT_BLOCK = re.compile(r'<script\b[^>]*>(.*?)</script>', re.S)
+#: Script bodies are extracted with the HTML parser, NOT a regex. CodeQL's
+#: py/bad-tag-filter flagged the regex form on PR 301 and was right about the
+#: code even though the severity does not apply here (this parses the
+#: project's own templates, there is no untrusted input). A regex
+#: `</script>` matcher misses `</script >` and `</SCRIPT>`, and a missed
+#: closing tag means the fields inside that block are never checked, which is
+#: a blind spot in the one guard whose whole job is not to have any.
+def _script_bodies(html_text):
+    """Every <script> element's text, via the parser rather than a pattern."""
+    soup = BeautifulSoup(html_text, 'html.parser')
+    return [script.string or script.get_text() or '' for script in soup.find_all('script')]
 
 
 def _strip_jinja_comments(text):
@@ -146,7 +156,7 @@ def _fragment_violations(fragment_html, source):
 
 def _script_fragment_violations(html_text, filename):
     violations = []
-    for script_idx, script in enumerate(_SCRIPT_BLOCK.findall(html_text)):
+    for script_idx, script in enumerate(_script_bodies(html_text)):
         for string_idx, match in enumerate(_JS_HTML_STRING.finditer(script)):
             source = '%s (script %d, template string %d)' % (filename, script_idx, string_idx)
             violations.extend(_fragment_violations(match.group(1), source))

--- a/tests/unit/test_wizard_form_labels_a11y.py
+++ b/tests/unit/test_wizard_form_labels_a11y.py
@@ -1,0 +1,312 @@
+"""A11Y-001: every interactive field in the templates listed in Scope must
+have an accessible name. AC-A11Y-1/AC-A11Y-2/AC-QA-4.
+
+`specs/A11Y-001-form-labels-not-associated.md` measured wizard.html at 61
+`<label>`s, 63 inputs, 0 `for=`, 0 `aria-label`. axe-core never sees most of
+it: the wizard is a multi-step form, later steps are `x-show`-gated so axe
+correctly skips them as hidden, and
+`tests/e2e/accessibility.a11y.spec.ts:247` only scans the first step. SonarQube
+reads the template source instead and reports 118 findings.
+
+This guard reads the template source too, the same way SonarQube does, so it
+does not depend on which step happens to be visible when it runs.
+
+Three routes give a field an accessible name and all three are accepted, on
+purpose (AC-A11Y-1): an explicit `for`/`id` pair (static OR Alpine-bound,
+`:for`/`:id`, matched by comparing the two expression strings), the field
+wrapped by its `<label>`, or a non-empty `aria-label`/`aria-labelledby`
+(static or `:aria-label`/`:aria-labelledby`). A guard that only accepted the
+first would be wrong and would force bad markup onto the three fields that
+live inside `x-for` loops, where a static id would create duplicate ids
+instead (AC-A11Y-2) -- `partials/settings/profiles.html` already does this
+correctly (`:for="'profile-name-' + _uid"` paired with
+`:id="'profile-name-' + _uid"`) and is the exemplar the wizard fix should
+copy.
+
+A field discovered while writing this guard and NOT mentioned by name in the
+spec: `wizard.html`'s `getDownloaderFields()` builds each download client's
+host/username/password/API-key fields as HTML inside a JS template-literal
+string and injects it with `x-html`. That markup is real and reachable (it is
+what a user actually sees once they pick a download client), but it is
+invisible to a plain BeautifulSoup parse of the file, because the parser
+correctly treats `<script>` content as text, not tags -- the same blind spot
+that hides it from axe, for a different reason. `_script_fragment_violations`
+below pulls those strings out and checks them the same way, or the exact
+fields the spec calls out by name ("every download client's API key and
+token field") stay unchecked by this guard too.
+"""
+import re
+from pathlib import Path
+
+import pytest
+from bs4 import BeautifulSoup, Tag
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEMPLATES_DIR = REPO_ROOT / 'couchpotato' / 'ui' / 'templates'
+
+#: specs/A11Y-001-form-labels-not-associated.md, Scope section.
+SCOPE_FILES = [
+    TEMPLATES_DIR / 'wizard.html',
+    TEMPLATES_DIR / 'partials' / 'movie_cards.html',
+    TEMPLATES_DIR / 'partials' / 'settings' / 'field_types.html',
+    TEMPLATES_DIR / 'partials' / 'settings' / 'combined_basics_card.html',
+    TEMPLATES_DIR / 'partials' / 'settings' / 'header.html',
+    TEMPLATES_DIR / 'partials' / 'settings' / 'provider_card.html',
+    TEMPLATES_DIR / 'partials' / 'settings' / 'profiles.html',
+    TEMPLATES_DIR / 'partials' / 'settings' / 'logs_tab.html',
+    TEMPLATES_DIR / 'logs.html',
+]
+
+FIELD_TAGS = ('input', 'select', 'textarea')
+
+#: Jinja comments (`{# ... #}`) are not HTML comments, so an HTML parser does
+#: not know to skip them. One exists in movie_cards.html whose prose mentions
+#: "<label>" in plain English -- left in, that reads as a real, empty <label>
+#: tag opening in the middle of a sentence and can distort the tree around
+#: it. Strip Jinja comments before parsing, the same way a real browser would
+#: never see them (Jinja removes them before the response is ever sent).
+_JINJA_COMMENT = re.compile(r'{#.*?#}', re.S)
+
+#: A JS template-literal string, inside a <script> block, that contains form
+#: markup -- see the getDownloaderFields() note above.
+_JS_HTML_STRING = re.compile(r'`([^`]*<(?:input|label|select|textarea)[^`]*)`', re.S)
+_SCRIPT_BLOCK = re.compile(r'<script\b[^>]*>(.*?)</script>', re.S)
+
+
+def _strip_jinja_comments(text):
+    return _JINJA_COMMENT.sub('', text)
+
+
+def _non_empty_attr(tag, *names):
+    """True if any of `names`, static or Alpine-bound (`:name`), is present
+    with a non-blank value. A quoted empty-string expression (`''`, `""`) is
+    treated as blank, the same as a bare `aria-label=""`."""
+    for name in names:
+        for attr in (name, ':' + name):
+            value = tag.get(attr)
+            if value is None:
+                continue
+            if value.strip().strip("'\"").strip():
+                return True
+    return False
+
+
+def _wrapped_by_label(tag):
+    for parent in tag.parents:
+        if isinstance(parent, Tag) and parent.name == 'label':
+            return True
+    return False
+
+
+def _describe(tag):
+    bits = [tag.name]
+    for attr in ('type', ':type', 'id', ':id', 'name', 'x-model', 'placeholder'):
+        value = tag.get(attr)
+        if value:
+            bits.append('%s=%r' % (attr, value))
+    return '<%s>' % ' '.join(bits)
+
+
+def _fragment_violations(fragment_html, source):
+    """Accessible-name violations in one parsed HTML fragment.
+
+    A fragment is either a whole template file, or one JS template-literal
+    string pulled out of a <script> block -- each is checked as its own
+    little document, which is correct here: every id/for pair this codebase
+    uses is scoped to a single fragment (one tracker's fields, one downloader
+    client's fields), never referencing across the boundary.
+    """
+    soup = BeautifulSoup(fragment_html, 'html.parser')
+
+    for_targets = set()
+    for label in soup.find_all('label'):
+        for attr in ('for', ':for'):
+            value = label.get(attr)
+            if value:
+                for_targets.add(value.strip())
+
+    violations = []
+    for field in soup.find_all(FIELD_TAGS):
+        field_type = (field.get('type') or '').strip().lower()
+        if field_type == 'hidden':
+            continue
+
+        field_id = (field.get('id') or '').strip()
+        bound_id = (field.get(':id') or '').strip()
+
+        has_for_id = bool(field_id and field_id in for_targets)
+        has_bound_for = bool(bound_id and bound_id in for_targets)
+        has_wrap = _wrapped_by_label(field)
+        has_aria = _non_empty_attr(field, 'aria-label', 'aria-labelledby')
+
+        if not (has_for_id or has_bound_for or has_wrap or has_aria):
+            violations.append('%s: %s has no accessible name' % (source, _describe(field)))
+    return violations
+
+
+def _script_fragment_violations(html_text, filename):
+    violations = []
+    for script_idx, script in enumerate(_SCRIPT_BLOCK.findall(html_text)):
+        for string_idx, match in enumerate(_JS_HTML_STRING.finditer(script)):
+            source = '%s (script %d, template string %d)' % (filename, script_idx, string_idx)
+            violations.extend(_fragment_violations(match.group(1), source))
+    return violations
+
+
+def find_accessible_name_violations(path):
+    """Every accessible-name violation in `path`, across both its own markup
+    and any JS-template-literal HTML it injects via x-html."""
+    text = _strip_jinja_comments(path.read_text())
+    violations = _fragment_violations(text, path.name)
+    violations.extend(_script_fragment_violations(text, path.name))
+    return violations
+
+
+def find_static_id_in_loop_violations(path):
+    """AC-A11Y-2: a static `id`/`for` inside an Alpine `x-for` loop is a worse
+    defect than the missing label it would "fix" -- every iteration renders
+    the same id, so the DOM ends up with duplicates. Fields in a loop must use
+    a bound `:id` (unique per iteration, e.g. from the loop item), not a
+    static one."""
+    text = _strip_jinja_comments(path.read_text())
+    soup = BeautifulSoup(text, 'html.parser')
+
+    violations = []
+    for loop in soup.find_all('template', attrs={'x-for': True}):
+        for el in loop.find_all(list(FIELD_TAGS) + ['label']):
+            if el.get('id'):
+                violations.append(
+                    '%s: %s inside an x-for loop has a static id -- this '
+                    'produces duplicate ids at runtime, one per iteration'
+                    % (path.name, _describe(el)))
+            if el.name == 'label' and el.get('for'):
+                violations.append(
+                    '%s: <label for=%r> inside an x-for loop has a static '
+                    'for -- every iteration points at the same id'
+                    % (path.name, el.get('for')))
+    return violations
+
+
+# --- guard the guard ---------------------------------------------------------
+# Pure logic, checked against synthetic fixtures rather than the real
+# templates, the same role test_login_page_a11y.py's
+# test_the_arithmetic_is_right() plays for contrast_ratio(): if this fails,
+# nothing below can be trusted, whichever way it fails.
+
+def test_the_checker_accepts_all_three_accessible_name_routes():
+    for_id_pair = '<div><label for="x">Name</label><input id="x"></div>'
+    bound_for_id_pair = '<div><label :for="\'f-\' + i">Name</label><input :id="\'f-\' + i"></div>'
+    wrapped = '<label>Name<input></label>'
+    static_aria_label = '<input aria-label="Name">'
+    bound_aria_label = '<input :aria-label="opt.label || opt.name">'
+    aria_labelledby = '<div id="hint">Name</div><input aria-labelledby="hint">'
+
+    for good in (for_id_pair, bound_for_id_pair, wrapped, static_aria_label,
+                 bound_aria_label, aria_labelledby):
+        assert _fragment_violations(good, 'fixture') == [], (
+            'a compliant fixture was rejected: %r' % good)
+
+
+def test_the_checker_rejects_a_field_with_no_accessible_name():
+    naked = '<div><label>Username</label><input x-model="formData.username"></div>'
+
+    violations = _fragment_violations(naked, 'fixture')
+
+    assert len(violations) == 1, (
+        'an unassociated visible label + input must be flagged exactly once, got %r'
+        % violations)
+    assert 'no accessible name' in violations[0]
+
+
+def test_the_checker_treats_an_empty_aria_label_as_no_name():
+    """An empty aria-label is worse than none: it suppresses the fallback
+    name-from-content a reader would otherwise get, and announces nothing."""
+    empty_static = '<input aria-label="">'
+    empty_bound = "<input :aria-label=\"''\">"
+
+    for bad in (empty_static, empty_bound):
+        violations = _fragment_violations(bad, 'fixture')
+        assert violations, 'an empty aria-label must not count as a name: %r' % bad
+
+
+def test_the_checker_ignores_jinja_comment_text_that_looks_like_a_tag():
+    """movie_cards.html's own comment prose ('the wrapping <label> holds
+    only...') must not be parsed as a real element, or it can pull a real
+    input inside it and hide a genuine violation."""
+    html = (
+        '{# The wrapping <label> holds only an icon. #}\n'
+        '<input x-model="formData.selected">'
+    )
+    violations = _fragment_violations(_strip_jinja_comments(html), 'fixture')
+    assert len(violations) == 1, (
+        'stripping the Jinja comment should leave exactly one real, '
+        'unassociated input -- got %r' % violations)
+
+
+def test_the_loop_checker_flags_a_static_id_inside_x_for():
+    bad = (
+        '<template x-for="field in tracker.fields" :key="field.name">'
+        '<div><label for="field-id">X</label><input id="field-id"></div>'
+        '</template>'
+    )
+    good = (
+        '<template x-for="field in tracker.fields" :key="field.name">'
+        '<div><label :for="\'field-\' + field.name">X</label>'
+        '<input :id="\'field-\' + field.name"></div>'
+        '</template>'
+    )
+
+    soup_helper_violations = find_static_id_in_loop_violations
+    # Exercise the real function against an in-memory file-like path is
+    # unnecessary plumbing here; call the parsing it wraps directly via a
+    # throwaway file so the test still drives the real function, not a copy
+    # of its logic.
+    import tempfile
+    with tempfile.NamedTemporaryFile('w', suffix='.html', delete=False) as f:
+        f.write(bad)
+        bad_path = Path(f.name)
+    with tempfile.NamedTemporaryFile('w', suffix='.html', delete=False) as f:
+        f.write(good)
+        good_path = Path(f.name)
+
+    try:
+        assert soup_helper_violations(bad_path), 'a static id inside x-for must be flagged'
+        assert soup_helper_violations(good_path) == [], (
+            'a bound :id/:for pair inside x-for must NOT be flagged: %r'
+            % soup_helper_violations(good_path))
+    finally:
+        bad_path.unlink()
+        good_path.unlink()
+
+
+# --- the guard, run against the real templates -------------------------------
+
+@pytest.mark.parametrize('path', SCOPE_FILES, ids=lambda p: p.name)
+def test_every_interactive_field_has_an_accessible_name(path):
+    """AC-A11Y-1 / AC-QA-4. Currently RED for wizard.html: 61 labels, 63
+    inputs, none associated by any of the three valid routes."""
+    violations = find_accessible_name_violations(path)
+
+    assert violations == [], (
+        'found %d field(s) in %s with no accessible name (need one of: an '
+        'explicit for/id pair -- static or Alpine-bound, wrapping by a '
+        '<label>, or a non-empty aria-label/aria-labelledby):\n%s'
+        % (len(violations), path.name, '\n'.join(violations))
+    )
+
+
+@pytest.mark.parametrize('path', SCOPE_FILES, ids=lambda p: p.name)
+def test_no_static_id_inside_an_alpine_loop(path):
+    """AC-A11Y-2, forward guard. Passes trivially today (wizard.html has zero
+    ids of any kind yet, static or bound) -- it exists so the fix that adds
+    ids cannot reintroduce a static one inside the three fields the spec
+    identifies as living in x-for loops. See
+    test_the_loop_checker_flags_a_static_id_inside_x_for for proof this logic
+    itself can fail."""
+    violations = find_static_id_in_loop_violations(path)
+
+    assert violations == [], (
+        'static id/for inside an x-for loop in %s (must be a bound :id/:for '
+        'instead, or every iteration renders the same id):\n%s'
+        % (path.name, '\n'.join(violations))
+    )


### PR DESCRIPTION
The setup wizard had 61 `<label>` elements and 63 fields, with not one
association between them. Every label sat visually above its input and was
invisible to assistive technology, which announced those fields as unlabelled.
That includes the step where a new user sets a username and password, and every
download client's API key and token field. Clicking a label also did nothing,
which costs every user, not only screen reader users.

WCAG 2.2 AA: 1.3.1 Info and Relationships, 3.3.2 Labels or Instructions, 4.1.2
Name, Role, Value.

## Why nothing caught it

The existing tests were not wrong; they were looking at a different thing. `axe`
scans the rendered DOM and correctly ignores hidden elements. The wizard is a
multi-step form whose later steps are `x-show`-gated, so at the moment the scan
ran, most fields were not visible and were never evaluated. SonarQube reads the
template source and saw all of them.

## What changed

All 63 fields now carry an accessible name, by whichever route suits each:
60 explicit `for`/`id` pairs, one bound pair inside an `x-for` loop, and two
`aria-label`s where a visible label would force a layout change.

Three real markup gaps found in review are also fixed: the repeated Newznab
indexer rows announced identically (now indexed), identically named sibling
fields on the Providers and Downloader steps are distinguishable via
`role="group"`, and two icon-only buttons that delete an indexer and close the
directory browser had no accessible name at all (WCAG 4.1.2, Level A).

**No visual change.** Verified by comparing the multiset of `class="..."`
strings before and after: 408 both sides, zero added, zero removed.

## The review found my first attempt's guards were mostly theatre

Stated plainly because it is the more useful half of this PR.

The first commit extended the E2E scan to walk the wizard's later steps and I
claimed that closed the blind spot. It did not. `axe`'s `label` rule accepts a
field's `placeholder` as an accessible name, and 41 of the 63 fields carry one.
Demonstrated: removing a label association on the Library step left the whole
accessibility suite green; removing it from the single visited field with no
placeholder went red. The scan had teeth on roughly one field in twenty.

Worse, the focus test could not tell a correct `for`/`id` pair from a swapped
one. Swapping the Security step's two labels gave `wizard-username` the
accessible name "Password" and vice versa, and the unit guard, the axe scan and
the focus test all passed. A person setting up authentication would have heard
"Password" while typing their username.

Both are now closed by a DOM-level per-step assertion that rejects a name equal
to its own placeholder, plus `toHaveAccessibleName` on the focus tests. Verified
by hand: both mutations now fail, and the file restores byte-identical.

Two dead axe rules were also removed. `duplicate-id` and `duplicate-id-active`
are deprecated and disabled in the installed axe-core 4.13.0, and the case
AC-A11Y-2 exists to prevent returns `incomplete` rather than `violations`, which
the assertion never read. `select-name` and `aria-input-field-name` were
inapplicable to a page with zero `<select>` elements.

The scan now also asserts a coverage floor per step, so it cannot silently
degrade to scanning nothing, and asserts it actually arrived on the step it
claims to be scanning. Blocking the wizard at step 3 previously left the scan
labelled "Library" passing while rescanning Downloader.

## Correction to the spec's own headline

26 of the 63 fields sit inside `x-if="false && formData.downloader"`, a block
that can never render, verified at runtime. The reachable win is 37 fields, not
63. The spec said 63; it now says 37 and records the dead block as debt.

The spec also listed 8 other templates as needing work. They were already
compliant, and two contain no field at all. Corrected, so the next reader does
not go looking for a diff that was never needed.

## Guards, and proof each is load-bearing

Every one broken deliberately, watched to fail, restored by file copy with a
hash check.

| Guard | Proven by |
|---|---|
| Field has an accessible name | Removing the password field's id fails, naming that field |
| Not fooled by a placeholder | Removing a label from a placeholder-bearing field now fails both checks |
| Label names the RIGHT field | Swapping two labels now fails; it passed everything before |
| Step actually arrived | Capping the wizard at step 3 fails instead of rescanning |
| Coverage floor | Pointing the check at an empty step fails; it passes vacuously with the floor at zero |
| Loop ids stay unique | Making the tracker loop's bound id static fails |
| Buttons are named | Removing either `aria-label` fails |

## Not in this PR, recorded and worth doing

1. **The dark theme has no visible focus outline.** `focus:outline-none`
   (specificity 0,2,0) beats `:focus-visible` (0,1,0), so the outline is painted
   transparent. Light theme escapes only because `:root.light :focus-visible`
   (0,3,0) wins the colour back; there is no `:root.dark` equivalent, and dark
   is the default. 100 occurrences across 17 templates. WCAG 1.4.11. One CSS
   line fixes it.
2. The directory browser opens with no focus move, no focus trap and no Escape
   handler, and is the only non-typing route into four fields.
3. Nothing is announced when the wizard changes step, and after "Skip" the
   focused element is removed with no replacement.
4. The dead `x-if="false"` block, 26 fields duplicating live ones.
5. `Web:S6819`, 39 findings, ARIA roles where a semantic element exists.

Local gate green. One `lens-accessibility` pass and one adversarial
`reviewer-verification` pass, plus my own mutation testing of the two guards
that failed in round one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
