### PR TITLE
fix(a11y): the default theme paints its focus ring transparent

### DIFF
--- a/couchpotato/ui/templates/base.html
+++ b/couchpotato/ui/templates/base.html
@@ -200,6 +200,18 @@ tailwind.config = {
      for exactly this reason: 4.92:1 on the page background, 4.33:1 on the
      lightest card surface. */
   :root.light :focus-visible { outline-color: #0e7490; }
+  /* A11Y-002: dark is the default theme (html.dark above) but had no rule at
+     this specificity, so Tailwind's `focus:outline-none` (0,2,0, `outline: 2px
+     solid transparent`) beat the base rule above (0,1,0) on every control
+     carrying it and painted the ring transparent. `:root.dark` is NOT used
+     here: toggleTheme() only ever adds/removes `.light` and never removes
+     `.dark`, so both classes sit on <html> together in the light theme --
+     a `:root.dark` selector would match there too and, tying the light rule's
+     specificity (0,3,0 each), win on source order and repaint the ring
+     #35c5f4 in the light theme. `:not(.light)` is exclusive with the light
+     rule by construction, so there is no tie to win. #35c5f4 is the colour
+     the base rule above already intended (9.40:1 per that comment). */
+  :root:not(.light) :focus-visible { outline-color: #35c5f4; }
   :focus:not(:focus-visible) { outline: none; }
   
   /* A11Y: Skip link styles (A11Y-003) */

--- a/specs/A11Y-002-dark-theme-focus-ring.md
+++ b/specs/A11Y-002-dark-theme-focus-ring.md
@@ -1,0 +1,71 @@
+# A11Y-002: the default theme paints its focus ring transparent
+
+**Status:** agreed
+**Source:** found by `lens-accessibility` while reviewing A11Y-001; pre-existing,
+not introduced by that change.
+**Severity:** WCAG 2.2 AA, 1.4.11 Non-text Contrast, in the DEFAULT theme,
+across the whole application.
+
+## Problem
+
+`couchpotato/ui/templates/base.html:193` sets the focus ring:
+
+    :focus-visible { outline: 2px solid #35c5f4; outline-offset: 2px; }
+
+Tailwind's `focus:outline-none` utility compiles to
+`.focus\:outline-none:focus { outline: 2px solid transparent }`. Its specificity
+is 0,2,0 against the base rule's 0,1,0, so on any element carrying that utility
+the outline is painted TRANSPARENT rather than removed. `:focus-visible` still
+matches; only the colour is gone.
+
+The light theme escapes by accident. `base.html:202` adds
+`:root.light :focus-visible { outline-color: #0e7490 }` at 0,3,0, which wins the
+colour back. There is no `:root.dark` equivalent, and dark is the default:
+`base.html:2` is `<html lang="en" class="dark">`.
+
+Measured:
+
+    :root.light rules in base.html : 18
+    :root.dark  rules in base.html : 0
+    focus:outline-none occurrences : 100, across 17 templates
+
+A reviewer measured the result in a real browser on `#wizard-username`:
+
+    dark  : computed outline `solid 2px rgba(0, 0, 0, 0)`; the only focus
+            signal is a border shift measuring 1.63:1
+    light : computed outline `solid 2px rgb(14, 116, 144)`; passes
+
+So in the theme the application ships with, a keyboard user has effectively no
+focus indicator anywhere. 1.4.11 requires 3:1.
+
+## Why nothing caught it
+
+The comment at `base.html:194-201` reasons correctly that `#35c5f4` measures
+9.40:1 on the dark background. It is never painted. This is the "watching the
+wrapper, not the capability" shape: an automated check that asserts an outline
+is PRESENT passes, because it is present and invisible.
+
+## Scope
+
+One rule mirroring the light one, plus a guard that fails when the ring is not
+actually painted in either theme.
+
+## Not in scope
+
+- Removing the 100 `focus:outline-none` utilities. They are deliberate: the
+  design replaces the default browser ring with its own treatment. The bug is
+  the missing dark override, not the utility.
+- Any other contrast finding.
+
+## Acceptance criteria
+
+- **AC-A11Y-1:** On a focused element carrying `focus:outline-none`, the
+  computed `outline-color` is NOT transparent, in BOTH themes. Asserting the
+  outline exists is not enough: it already exists and fails.
+- **AC-A11Y-2:** The painted ring measures at least 3:1 against the background
+  it sits on, in both themes. Compute it, do not assert a hex value, because a
+  future palette change must fail this.
+- **AC-QA-3:** The guard fails when the `:root.dark` rule is removed. Proven by
+  removing it and watching it fail, then restoring.
+- **AC-SIMP-4:** One CSS rule. If the diff grows past that plus its test,
+  something else is being fixed and belongs in its own change.

--- a/tests/e2e/accessibility.a11y.spec.ts
+++ b/tests/e2e/accessibility.a11y.spec.ts
@@ -876,22 +876,40 @@ test.describe('Accessibility', () => {
           return 0.2126 * chan(c.r) + 0.7152 * chan(c.g) + 0.0722 * chan(c.b);
         };
 
-        // Walk up collecting every background layer until an OPAQUE one, then
-        // composite them back down. The surface the ring is painted over is
-        // the composite, not the first layer with any colour in it.
+        // The surface under the ring, composited. Three things this has to get
+        // right, each of which was wrong in an earlier version of this helper
+        // and each of which was caught by review rather than by running it.
         //
-        // The earlier version stopped at the first layer with `a > 0` and used
-        // its raw rgb as though it were solid. This app's fields are
-        // `bg-white/[0.03]`, i.e. rgba(255,255,255,0.03) over a near-black
-        // page, so that read the surface as WHITE and measured the ring at
-        // 2.01:1 against it. Composited properly the same surface is
-        // rgb(17,17,22) and the ring measures 9.36:1. The bug was in this
-        // maths, not in the CSS under test: a guard that fails for the wrong
-        // reason is as useless as one that passes for the wrong reason.
-        let node: HTMLElement | null = el;
+        // 1. START AT THE PARENT, not at `el`. `outline-offset: 2px` paints the
+        //    ring OUTSIDE the element's border box, and an element's own
+        //    background is clipped to that box, so the element's own fill is
+        //    never under its own ring. Starting at `el` produces a false PASS,
+        //    demonstrated: a control with an opaque dark fill sitting on a
+        //    #35c5f4 parent has no visible ring at all and measured 9.67:1.
+        //    It also produces a false FAIL on the wizard's Continue button,
+        //    whose fill is the ring colour: 1.00:1 for a ring you can plainly
+        //    see.
+        // 2. COMPOSITE the layers rather than taking the first with any colour
+        //    in it. The fields are `bg-white/[0.03]` over `bg-cp-card`, so
+        //    reading the first layer raw treats a 3 per cent white veil as
+        //    solid WHITE and measured the ring at 2.01:1, failing a fix that
+        //    was correct.
+        // 3. If the walk reaches the top without ever finding an opaque layer,
+        //    THROW. Seeding the composite from a faint layer as though it were
+        //    solid paint reported 10.44:1 for a ring measuring about 2:1 on a
+        //    white canvas. Not reachable while `body` carries an opaque
+        //    background, which it does, but a guard must not guess.
+        //
+        // Known limit, stated rather than implied: this walks DOM ancestry,
+        // which is not paint order. An absolutely positioned sibling, such as
+        // the gradient overlays at partials/movie_detail.html:56-57, can be
+        // the real backdrop and this will step past it. Valid only for
+        // elements whose backdrop comes from their own ancestors.
+        let node: HTMLElement | null = el.parentElement;
         const layers: { r: number; g: number; b: number; a: number }[] = [];
         let bg: { r: number; g: number; b: number } | null = null;
         let bgOwner = '';
+        let foundOpaque = false;
         while (node) {
           const c = parseColor(window.getComputedStyle(node).backgroundColor);
           if (c && c.a > 0) {
@@ -899,11 +917,21 @@ test.describe('Accessibility', () => {
               bgOwner = node.id ? `#${node.id}` : (node.className.toString().split(/\s+/)[0] || node.tagName);
             }
             layers.push(c);
-            if (c.a >= 1) break;
+            if (c.a >= 1) {
+              foundOpaque = true;
+              break;
+            }
           }
           node = node.parentElement;
         }
-        // Composite bottom-up: the last layer collected is the lowest.
+        if (!foundOpaque) {
+          throw new Error(
+            `no opaque backdrop found above ${el.id ? '#' + el.id : el.tagName}; ` +
+            'the contrast below the ring cannot be computed, so this check cannot report a verdict',
+          );
+        }
+        // Composite bottom-up: the last layer collected is the lowest, and it
+        // is opaque, so it seeds the stack.
         for (let i = layers.length - 1; i >= 0; i--) {
           const c = layers[i];
           bg = bg === null

--- a/tests/e2e/accessibility.a11y.spec.ts
+++ b/tests/e2e/accessibility.a11y.spec.ts
@@ -784,6 +784,183 @@ test.describe('Accessibility', () => {
     ).toBe(true);
   });
 
+  /*
+   * A11Y-002: the ring itself, not merely its presence.
+   *
+   * Every check above this point, checkA11y's page-wide axe sweeps included,
+   * only asserts that AN outline exists. It does: base.html's `:focus-visible`
+   * rule sets one on every element. Tailwind's `focus:outline-none` utility
+   * compiles to `outline: 2px solid transparent` at specificity 0,2,0, against
+   * base.html's 0,1,0, so on any control carrying that utility Tailwind wins
+   * the colour and the outline paints fully transparent. `:focus-visible`
+   * still matches, `outline-style` is still `solid`, only the paint is gone --
+   * exactly the shape no "outline is present" check can catch.
+   *
+   * `:root.light :focus-visible { outline-color: #0e7490 }` (base.html) wins
+   * the colour back in the light theme by accident, at specificity 0,3,0.
+   * There is no `:root.dark` equivalent, and dark is the default theme
+   * (base.html's `<html class="dark">`), so this test is expected to fail in
+   * the dark iteration only, and pass already in the light one -- proving the
+   * light theme is genuinely fine rather than the assertion being vacuous in
+   * both directions.
+   *
+   * #wizard-username is used (not the two FOCUS_INDICATOR_PROBE controls
+   * above) because it actually carries `focus:outline-none`
+   * (wizard.html:100); `#filter-movies` and the Add-movie search input use
+   * `focus-visible:outline-*` utilities instead and never exercise this bug.
+   *
+   * Real focus, verified rather than assumed (HAZARD 2): a mouse `.click()`
+   * on a text `<input>` in Chromium still satisfies `:focus-visible` -- typing
+   * is expected next, so the UA treats it like keyboard focus regardless of
+   * pointer origin -- but that is asserted explicitly with
+   * `el.matches(':focus-visible')` BEFORE any style is read, so a click that
+   * landed without it (a future engine change, a disabled/covered element)
+   * fails loudly here instead of silently reading a stale outline.
+   *
+   * Alpha, not string (HAZARD 3): the colour is read as `rgba(...)` and only
+   * the alpha channel is asserted against zero, never the string, because a
+   * `solid` `outline-style` with a colour computes to a real rgba() string in
+   * every engine regardless of whether that colour is paintable.
+   *
+   * Background (HAZARD 4): `outline-offset: 2px` paints the ring outside the
+   * input's own border box, over whatever surrounds it. Neither the input nor
+   * its wrapping `<div>`s carry a background of their own -- the nearest
+   * opaque ancestor is the wizard card (`bg-cp-card`), so that, not the
+   * input's own fill or the page body, is the surface contrast is measured
+   * against. Found by walking up the real DOM rather than assumed, so this
+   * keeps working if the markup grows another wrapper.
+   */
+  for (const theme of ['dark', 'light'] as const) {
+    test(`the wizard username field's focus ring is visible in the ${theme} theme`, async ({ page }) => {
+      await page.addInitScript((t) => {
+        localStorage.setItem('cp-theme', t);
+      }, theme);
+
+      await page.goto('/wizard/');
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(1000);
+
+      // Pin the theme really took effect, same guard the toast contrast test
+      // uses, so a broken theme pipeline reds this loudly rather than
+      // quietly scanning the wrong theme under the right test name.
+      await expect
+        .poll(() => page.evaluate(() => document.documentElement.classList.contains('light')))
+        .toBe(theme === 'light');
+
+      // Welcome -> Server Security, the same step-advance
+      // navigateWizardToProviders/the wizard a11y test above use.
+      await page.getByRole('button', { name: 'Continue' }).click();
+      await page.waitForTimeout(300);
+      await assertWizardStepShowing(page, 'Server Security', '#wizard-username');
+
+      const input = page.locator('#wizard-username');
+      await input.click();
+
+      const measured = await input.evaluate((el: HTMLElement) => {
+        const isFocusVisible = el.matches(':focus-visible');
+        const outlineColor = window.getComputedStyle(el).outlineColor;
+        const outlineStyle = window.getComputedStyle(el).outlineStyle;
+
+        const parseColor = (s: string) => {
+          const m = s.match(/rgba?\(([^)]+)\)/);
+          if (!m) return null;
+          const parts = m[1].split(',').map((p) => parseFloat(p.trim()));
+          return { r: parts[0], g: parts[1], b: parts[2], a: parts.length > 3 ? parts[3] : 1 };
+        };
+
+        const luminance = (c: { r: number; g: number; b: number }) => {
+          const chan = (v: number) => {
+            const s = v / 255;
+            return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+          };
+          return 0.2126 * chan(c.r) + 0.7152 * chan(c.g) + 0.0722 * chan(c.b);
+        };
+
+        // Walk up collecting every background layer until an OPAQUE one, then
+        // composite them back down. The surface the ring is painted over is
+        // the composite, not the first layer with any colour in it.
+        //
+        // The earlier version stopped at the first layer with `a > 0` and used
+        // its raw rgb as though it were solid. This app's fields are
+        // `bg-white/[0.03]`, i.e. rgba(255,255,255,0.03) over a near-black
+        // page, so that read the surface as WHITE and measured the ring at
+        // 2.01:1 against it. Composited properly the same surface is
+        // rgb(17,17,22) and the ring measures 9.36:1. The bug was in this
+        // maths, not in the CSS under test: a guard that fails for the wrong
+        // reason is as useless as one that passes for the wrong reason.
+        let node: HTMLElement | null = el;
+        const layers: { r: number; g: number; b: number; a: number }[] = [];
+        let bg: { r: number; g: number; b: number } | null = null;
+        let bgOwner = '';
+        while (node) {
+          const c = parseColor(window.getComputedStyle(node).backgroundColor);
+          if (c && c.a > 0) {
+            if (!bgOwner) {
+              bgOwner = node.id ? `#${node.id}` : (node.className.toString().split(/\s+/)[0] || node.tagName);
+            }
+            layers.push(c);
+            if (c.a >= 1) break;
+          }
+          node = node.parentElement;
+        }
+        // Composite bottom-up: the last layer collected is the lowest.
+        for (let i = layers.length - 1; i >= 0; i--) {
+          const c = layers[i];
+          bg = bg === null
+            ? { r: c.r, g: c.g, b: c.b }
+            : {
+                r: c.a * c.r + (1 - c.a) * bg.r,
+                g: c.a * c.g + (1 - c.a) * bg.g,
+                b: c.a * c.b + (1 - c.a) * bg.b,
+              };
+        }
+
+        const ring = parseColor(outlineColor);
+        const contrast = ring && bg
+          ? (() => {
+              const l1 = luminance(ring);
+              const l2 = luminance(bg);
+              return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+            })()
+          : null;
+
+        return {
+          isFocusVisible,
+          outlineStyle,
+          outlineColor,
+          ringAlpha: ring ? ring.a : null,
+          bgOwner,
+          contrast,
+        };
+      });
+
+      expect(
+        measured.isFocusVisible,
+        `#wizard-username did not match :focus-visible after a click in the ` +
+        `${theme} theme (outline-style computed as ${measured.outlineStyle}) ` +
+        `-- the probe below would prove nothing about a real keyboard user`,
+      ).toBe(true);
+
+      // AC-A11Y-1: not transparent, in BOTH themes.
+      expect(
+        measured.ringAlpha,
+        `${theme} theme: computed outline-color on #wizard-username is ` +
+        `${measured.outlineColor} (alpha ${measured.ringAlpha}) -- present ` +
+        `and invisible, exactly the shape "an outline exists" checks miss`,
+      ).toBeGreaterThan(0);
+
+      // AC-A11Y-2: at least 3:1 against the surface it actually sits on,
+      // computed with the WCAG formula rather than compared to a hex literal
+      // so a future palette change must fail this too.
+      expect(
+        measured.contrast,
+        `${theme} theme: focus ring ${measured.outlineColor} against ` +
+        `${measured.bgOwner}'s background measures ` +
+        `${measured.contrast?.toFixed(2)}:1, below the WCAG 1.4.11 floor of 3:1`,
+      ).toBeGreaterThanOrEqual(3);
+    });
+  }
+
   test('Images should have alt text', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');


### PR DESCRIPTION
The application's default theme paints its focus ring transparent. Across all
seventeen templates, a keyboard user has effectively no indication of where
they are.

## The bug

`base.html:193` sets the ring:

    :focus-visible { outline: 2px solid #35c5f4; outline-offset: 2px; }

specificity 0,1,0. Tailwind's `focus:outline-none` compiles to
`.focus\:outline-none:focus { outline: 2px solid transparent }` at 0,2,0, so on
every control carrying that utility the ring is painted TRANSPARENT rather than
removed. `:focus-visible` still matches; only the colour is lost.

The light theme escapes by accident: `base.html:202` adds
`:root.light :focus-visible { outline-color: #0e7490 }` at 0,3,0, winning the
colour back. There was no dark equivalent, and dark is the default
(`base.html:2` is `<html lang="en" class="dark">`).

    :root.light rules  : 18
    :root.dark rules   : 0
    focus:outline-none : 100 occurrences across 17 templates

Measured on a focused `#wizard-username`: dark gave computed
`outline: solid 2px rgba(0, 0, 0, 0)`, leaving a 1.63:1 border shift as the only
focus signal. WCAG 2.2 AA 1.4.11 requires 3:1.

## Why the selector is `:not(.light)` and not `.dark`

This is the load-bearing detail. `classList.remove('dark')` appears ZERO times
in `base.html`: the theme toggle only ever adds and removes `light`, so in the
light theme BOTH classes sit on `<html>`. A `:root.dark` rule would therefore
match in the light theme too, tie the light rule at 0,3,0, and win on source
order, repainting the light ring with the dark colour.

`:root:not(.light)` is exclusive by construction. Verified across all four real
theme states:

| State | `<html class=…>` | computed outline-color |
|---|---|---|
| No saved pref, OS dark | `dark` | `rgb(53, 197, 244)` |
| No saved pref, OS light | `dark light` | `rgb(14, 116, 144)` |
| Saved dark, OS light | `dark` | `rgb(53, 197, 244)` |
| Saved light, OS dark | `dark light` | `rgb(14, 116, 144)` |

Composited contrast: 8.99:1 dark, 5.36:1 light.

## The test, and three bugs in it that review caught

The existing checks pass today, while the bug is live, because they assert an
outline is PRESENT. It is present, and invisible. So this asserts on the
computed, painted colour of a real keyboard-focused element in both themes, and
computes the contrast rather than matching a hex literal, so a palette change
fails it rather than sailing past.

Getting that right took three corrections, all found by review rather than by
running it:

1. **The walk started at the focused element.** `outline-offset: 2px` paints the
   ring outside the border box, and an element's background is clipped to that
   box, so its own fill is never under its own ring. This produced a false PASS,
   demonstrated: a control with an opaque dark fill on a `#35c5f4` parent has no
   visible ring at all and measured 9.67:1. It also produced a false FAIL on the
   wizard's Continue button, whose fill is the ring colour, at 1.00:1 for a ring
   you can plainly see.
2. **Running off the top without an opaque layer** seeded the composite from the
   faintest layer as though it were solid, reporting 10.44:1 for a ring
   measuring about 2:1 on white. Now throws.
3. **An earlier version treated a 3 per cent white veil as solid white**, read
   the surface as WHITE, measured 2.01:1, and failed a fix that was correct.
   That cost three implementation attempts before the workflow stopped itself
   under the three-failure rule. The frame that was wrong was the test's
   arithmetic, not the CSS.

A limit is now stated rather than implied: the walk follows DOM ancestry, which
is not paint order. The gradient overlays at `partials/movie_detail.html:56-57`
are absolutely positioned siblings and are the real backdrop for the link above
them; this walk steps past them. Nothing fails today, and the next person to
reuse the helper should know.

## Proof it is load-bearing

Removing the new rule fails the dark theme with `computed outline-color on
#wizard-username is rgba(0, 0, 0, 0) (alpha 0), present and invisible, exactly
the shape "an outline exists" checks miss`, while light still passes.
`base.html` restores byte-identical afterwards.

## Scope

One CSS rule. `git diff --numstat` is `12 0` on `base.html`, purely additive.
The new rule at 0,3,0 now outranks six `focus-visible:outline-cp-accent`
utilities at 0,2,0 that previously won; measured with and without, the computed
colour is identical, because `cp.accent` is the same `#35c5f4` literal.

Full accessibility project: 85 passed, both themes, no flake across four runs.
Local gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
