### PR TITLE
fix(BUG-018): the scanner files every remake under the original

### DIFF
--- a/couchpotato/core/media/movie/providers/info/themoviedb.py
+++ b/couchpotato/core/media/movie/providers/info/themoviedb.py
@@ -92,7 +92,11 @@ class TheMovieDb(MovieProvider):
         0dc9e9a78, FIX 6). The extra per-result detail requests that same
         review attributed to the `search_type` flip are actually caused by
         `limit`: `parseMovie` below issues one detail request per result
-        returned, regardless of `search_type`. """
+        returned PER CONFIGURED LANGUAGE (each entry in `self.languages`,
+        plus the default language if it differs from English, plus the
+        English fetch itself), regardless of `search_type` -- so raising
+        `limit` multiplies the request count by however many languages are
+        configured, not by one per result. """
 
         if self.isDisabled():
             return False

--- a/couchpotato/core/media/movie/providers/info/themoviedb.py
+++ b/couchpotato/core/media/movie/providers/info/themoviedb.py
@@ -66,8 +66,21 @@ class TheMovieDb(MovieProvider):
         if configuration:
             self.configuration = configuration
 
-    def search(self, q, limit = 3):
-        """ Find movie by name """
+    def search(self, q, limit = 3, search_type = None):
+        """ Find movie by name
+
+        `search_type` is normally derived from `limit` (a broad,
+        multi-result UI search wants fuzzy `ngram` matching; a single
+        assertive lookup wants exact `phrase` matching), but a caller that
+        needs several results back to inspect them WITHOUT relaxing what is
+        being asked -- BUG-018's scanner fallback wants extra candidates to
+        pick a year from, not a fuzzier match -- can pin it explicitly.
+        Round-one review of 0dc9e9a78 (FIX 6): raising that fallback's
+        result limit from 1 to 5 flipped `search_type` from `phrase` to
+        `ngram` as an unintended side effect of the `limit > 1` rule, and
+        `search_type` is part of the request URL and therefore the cache
+        key, so this also silently changed what a cached search was keyed
+        on and multiplied downstream per-result detail requests. """
 
         if self.isDisabled():
             return False
@@ -80,7 +93,7 @@ class TheMovieDb(MovieProvider):
             raw = self.request('search/movie', {
                 'query': name_year.get('name', q),
                 'year': name_year.get('year'),
-                'search_type': 'ngram' if limit > 1 else 'phrase'
+                'search_type': search_type if search_type else ('ngram' if limit > 1 else 'phrase')
             }, return_key = 'results')
         except Exception:
             log.error('Failed searching TMDB for "%s": %s', q, traceback.format_exc())

--- a/couchpotato/core/media/movie/providers/info/themoviedb.py
+++ b/couchpotato/core/media/movie/providers/info/themoviedb.py
@@ -69,18 +69,30 @@ class TheMovieDb(MovieProvider):
     def search(self, q, limit = 3, search_type = None):
         """ Find movie by name
 
-        `search_type` is normally derived from `limit` (a broad,
-        multi-result UI search wants fuzzy `ngram` matching; a single
-        assertive lookup wants exact `phrase` matching), but a caller that
-        needs several results back to inspect them WITHOUT relaxing what is
-        being asked -- BUG-018's scanner fallback wants extra candidates to
-        pick a year from, not a fuzzier match -- can pin it explicitly.
-        Round-one review of 0dc9e9a78 (FIX 6): raising that fallback's
-        result limit from 1 to 5 flipped `search_type` from `phrase` to
-        `ngram` as an unintended side effect of the `limit > 1` rule, and
-        `search_type` is part of the request URL and therefore the cache
-        key, so this also silently changed what a cached search was keyed
-        on and multiplied downstream per-result detail requests. """
+        `search_type` is normally derived from `limit` (`phrase` for
+        `limit == 1`, `ngram` otherwise), but a caller can pin it
+        explicitly regardless of `limit`.
+
+        Round-two review of BUG-018 (2026-09): `search_type` is a TMDB v2.1
+        parameter. Measured live against TMDB v3 with `search_type` set to
+        `phrase`, `ngram`, absent, and a garbage value, all four returned
+        byte-identical results in the same order -- v3 ignores it entirely.
+        So pinning it does NOT make a search more exact or more fuzzy here;
+        an earlier version of this docstring claimed it did, and that claim
+        was never measured against the live API.
+
+        The one thing pinning it still buys: `search_type` is part of the
+        request URL and therefore the cache key. BUG-018's scanner fallback
+        raises `limit` from 1 to 5 to inspect several candidates for a year
+        match, and without pinning `search_type` explicitly that raised
+        limit would flip the derived value from `phrase` to `ngram`,
+        keying that fallback's cache entries differently from every other
+        `limit=1` caller for no behavioural gain -- purely a cache-key
+        alignment concern, not a matching one (round-one review of
+        0dc9e9a78, FIX 6). The extra per-result detail requests that same
+        review attributed to the `search_type` flip are actually caused by
+        `limit`: `parseMovie` below issues one detail request per result
+        returned, regardless of `search_type`. """
 
         if self.isDisabled():
             return False

--- a/couchpotato/core/plugins/scanner/folder_scanner.py
+++ b/couchpotato/core/plugins/scanner/folder_scanner.py
@@ -17,17 +17,30 @@ log = CPLog(__name__)
 
 # BUG-018: the fifth `determineMedia` fallback used to ask the search
 # provider for exactly one result and take it, so a remake sorted ahead of
-# its original (both measured cases were only two results deep) was never
-# even offered as an alternative. 5 gives enough headroom to see past a
-# remake pair without an unbounded fetch.
+# its original (all four measured cases were only two results deep) was
+# never even offered as an alternative. 5 gives enough headroom to see past
+# a remake pair without an unbounded fetch.
+#
+# This is pinned as a result COUNT only. `search_type` is pinned separately,
+# below the fallback's two `movie.search` calls, so raising this limit can
+# never silently change the query TheMovieDb is asked (see FIX 6, round-one
+# review of 0dc9e9a78).
 SEARCH_YEAR_DISAMBIGUATION_LIMIT = 5
 
 # A provider's release year can legitimately differ from the year parsed out
 # of a filename by one (region release dates, festival versus wide release).
 # 0 would treat every honest off-by-one provider year as a non-match and
-# always fall back to the first result; anything above 1 starts risking the
-# very remake collisions this bug is about -- the closest of the four
-# measured remake pairs is still 7 years apart.
+# always fall back to the first result.
+#
+# The binding constraint on raising this above 1 is not the remake pairs --
+# computed from the spec's own seven merged records, the year gaps are
+# 1, 1, 3, 36, 27, 22, 20: the closest of the four MEASURED remake pairs
+# (Mulan, Aladdin, Mean Girls, Lion King) is 20 years apart, comfortably
+# clear of any tolerance this constant could sanely hold. The real
+# constraint is the two CONSECUTIVE-YEAR SEQUEL pairs in the same catalogue
+# (Deathly Hallows Part 1/2, Mockingjay Part 1/2), a gap of 1 -- tolerance
+# 1 is already flush against that boundary, and going any higher starts
+# admitting the wrong half of a duology as a "match".
 SEARCH_YEAR_TOLERANCE = 1
 
 
@@ -467,38 +480,61 @@ class FolderScannerMixin:
             for identifier in group['identifiers']:
                 if len(identifier) > 2:
                     try:
-                        filename = list(group['files'].get('movie'))[0]
+                        try:
+                            filename = list(group['files'].get('movie'))[0]
+                        except Exception:
+                            filename = None
+
+                        name_year = self.getReleaseNameYear(identifier, file_name=filename if not group['is_dvd'] else None)
+                        if name_year.get('name') and name_year.get('year'):
+                            search_q = '%(name)s %(year)s' % name_year
+                            # `search_type` is pinned explicitly, not left to
+                            # follow `limit` -- see SEARCH_YEAR_DISAMBIGUATION_LIMIT's
+                            # comment (FIX 6, round-one review of 0dc9e9a78).
+                            movie = fireEvent('movie.search', q=search_q, merge=True,
+                                               limit=SEARCH_YEAR_DISAMBIGUATION_LIMIT,
+                                               search_type='phrase')
+                            parsed_year = name_year.get('year')
+
+                            if len(movie) == 0 and name_year.get('other') and name_year['other'].get('name') and name_year['other'].get('year'):
+                                search_q2 = '%(name)s %(year)s' % name_year.get('other')
+                                if search_q2 != search_q:
+                                    movie = fireEvent('movie.search', q=search_q2, merge=True,
+                                                       limit=SEARCH_YEAR_DISAMBIGUATION_LIMIT,
+                                                       search_type='phrase')
+                                    # The "other" query carries its own parsed
+                                    # year (a differently-parsed title can imply
+                                    # a different year) -- match against that,
+                                    # not the primary query's.
+                                    parsed_year = name_year['other'].get('year')
+
+                            if len(movie) > 0:
+                                chosen = self.pickSearchYearMatch(movie, parsed_year, filename)
+                                imdb_id = chosen.get('imdb')
+                                # A GUESS, not an assertion: the best match for a
+                                # parsed title and year. Recorded as such so the
+                                # destructive path can refuse it.
+                                group['identity_source'] = 'search'
+                                log.debug('Found movie via search: %s', identifier)
+                                if imdb_id:
+                                    break
                     except Exception:
-                        filename = None
-
-                    name_year = self.getReleaseNameYear(identifier, file_name=filename if not group['is_dvd'] else None)
-                    if name_year.get('name') and name_year.get('year'):
-                        search_q = '%(name)s %(year)s' % name_year
-                        movie = fireEvent('movie.search', q=search_q, merge=True,
-                                           limit=SEARCH_YEAR_DISAMBIGUATION_LIMIT)
-                        parsed_year = name_year.get('year')
-
-                        if len(movie) == 0 and name_year.get('other') and name_year['other'].get('name') and name_year['other'].get('year'):
-                            search_q2 = '%(name)s %(year)s' % name_year.get('other')
-                            if search_q2 != search_q:
-                                movie = fireEvent('movie.search', q=search_q2, merge=True,
-                                                   limit=SEARCH_YEAR_DISAMBIGUATION_LIMIT)
-                                # The "other" query carries its own parsed
-                                # year (a differently-parsed title can imply
-                                # a different year) -- match against that,
-                                # not the primary query's.
-                                parsed_year = name_year['other'].get('year')
-
-                        if len(movie) > 0:
-                            chosen = self.pickSearchYearMatch(movie, parsed_year, filename)
-                            imdb_id = chosen.get('imdb')
-                            # A GUESS, not an assertion: the best match for a
-                            # parsed title and year. Recorded as such so the
-                            # destructive path can refuse it.
-                            group['identity_source'] = 'search'
-                            log.debug('Found movie via search: %s', identifier)
-                            if imdb_id:
-                                break
+                        # BUG-018 round-one review (FIX 2): this was the only
+                        # one of the five identification fallbacks with no
+                        # exception guard. `candidate.get('year')` and similar
+                        # dict access assume every search result is a dict --
+                        # true for the single shipped provider today, not
+                        # guaranteed the moment a second one is registered.
+                        # Left unguarded, that raises out of `determineMedia`,
+                        # out of `scan()`, mid-directory: `fireEvent` swallows
+                        # it, but `added_identifiers` is then left PARTIAL and
+                        # non-empty, so `manage.updateLibrary`'s cleanup runs
+                        # against a truncated scan and deletes every 'done'
+                        # movie the scan had not reached yet. Falling through
+                        # to the next identifier is always safe; letting this
+                        # propagate is not.
+                        log.debug('Search-based identification failed for %s: %s',
+                                  identifier, traceback.format_exc())
                 else:
                     log.debug('Identifier to short to use for search: %s', identifier)
 
@@ -524,35 +560,81 @@ class FolderScannerMixin:
         remake's original release ahead of the film actually named in the
         filename (measured live: Mulan 2020, Aladdin 2019, Mean Girls 2024
         and Lion King 2019 were all in second place). Prefer whichever
-        candidate's year is within `SEARCH_YEAR_TOLERANCE` of the parsed
-        year, regardless of position.
+        candidate's year is CLOSEST to the parsed year, among candidates
+        within `SEARCH_YEAR_TOLERANCE`, regardless of position -- ties keep
+        whichever was listed first. Taking the first in-tolerance hit
+        (round one) rather than the closest one let an off-by-one candidate
+        listed ahead of an exact match win, which is exactly the failure
+        mode this bug is about, just one match closer.
+
+        Round-one review of 0dc9e9a78 (FIX 1): having an id is part of the
+        SELECTION PREDICATE, not a property checked on the result
+        afterwards. A candidate is only eligible to be chosen for its year
+        at all if it also carries a non-empty `imdb`, so this function is
+        structurally unable to return a candidate with no id, an empty id,
+        or `imdb: None` -- there is no code path that returns one. Without
+        that filter, a year-matching candidate lacking an id (a live hazard:
+        TMDB's own `movie.get('imdb_id')` is `None` for some records) would
+        starve `imdb_id` in the caller even though a DIFFERENT, id-bearing
+        candidate was available in the same list.
 
         `candidates` is assumed non-empty; the caller only reaches here
-        after checking `len(movie) > 0`. When nothing matches, the FIRST
-        candidate is returned -- exactly what the pre-BUG-018 code always
-        returned. This is the safety property the withdrawn first design
-        broke: returning `None` here, where the old code returned an id,
-        makes `manage.updateLibrary` believe a still-owned film is gone and
-        delete it. A mismatched guess is logged so the operator can see it;
-        it is never refused.
+        after checking `len(movie) > 0`. When nothing both has an id AND
+        matches within tolerance, `candidates[0]` is returned UNCHANGED --
+        exactly what the pre-BUG-018 code always returned, id or no id.
+        This is the safety property the withdrawn first design broke:
+        returning `None` here, where the old code returned an id, makes
+        `manage.updateLibrary` believe a still-owned film is gone and
+        delete it. The result of this function is therefore never worse
+        than taking `candidates[0]` unconditionally; it can only ever
+        differ by choosing a BETTER identifier for the same input. A
+        mismatched guess is logged so the operator can see it; it is
+        never refused.
         """
+        def _imdb(candidate):
+            try:
+                return candidate.get('imdb')
+            except AttributeError:
+                return None
+
+        def _year(candidate):
+            try:
+                return candidate.get('year')
+            except AttributeError:
+                return None
+
+        best, best_diff = None, None
         for candidate in candidates:
-            year = candidate.get('year')
+            if not _imdb(candidate):
+                continue
+            year = _year(candidate)
             if year is None:
                 continue
             try:
-                if abs(int(year) - int(parsed_year)) <= SEARCH_YEAR_TOLERANCE:
-                    return candidate
+                diff = abs(int(year) - int(parsed_year))
             except (TypeError, ValueError):
                 continue
+            if diff <= SEARCH_YEAR_TOLERANCE and (best_diff is None or diff < best_diff):
+                best, best_diff = candidate, diff
+
+        if best is not None:
+            return best
 
         first = candidates[0]
+        offered_years = [_year(c) for c in candidates]
         log.warning(
             'No search result for "%s" matched the parsed year %s within '
             'tolerance (years offered: %s) -- taking the first result %s. '
             'This guess is not destructive on its own, but is worth '
             'checking.',
-            filename, parsed_year, [c.get('year') for c in candidates], first.get('imdb'),
+            # A basename, not the full path: matches the DEBUG-level path
+            # logging elsewhere in this module, and this is the one path in
+            # the fallback that reaches WARNING (project security floor: no
+            # private filesystem paths in logs). The filename is still
+            # enough for an operator to find the release; the download
+            # folder structure around it is not needed to do that.
+            os.path.basename(filename) if filename else filename,
+            parsed_year, offered_years, _imdb(first),
         )
         return first
 

--- a/couchpotato/core/plugins/scanner/folder_scanner.py
+++ b/couchpotato/core/plugins/scanner/folder_scanner.py
@@ -665,7 +665,12 @@ class FolderScannerMixin:
             # the search itself.
             logged_filename = os.path.basename(filename) if filename else filename
         except TypeError:
-            logged_filename = filename
+            # `filename` is not str/bytes/PathLike, so there is no basename
+            # to take -- and the value itself might still be, or contain, a
+            # full path (round-two review of BUG-018, FIX 5). Log only the
+            # type, never the raw value, to honour the basename-only
+            # promise below.
+            logged_filename = type(filename).__name__
         log.warning(
             'No search result for "%s" matched the parsed year %s within '
             'tolerance (years offered: %s) -- taking the first result %s. '

--- a/couchpotato/core/plugins/scanner/folder_scanner.py
+++ b/couchpotato/core/plugins/scanner/folder_scanner.py
@@ -15,6 +15,21 @@ from guessit import guessit as guess_movie_info
 
 log = CPLog(__name__)
 
+# BUG-018: the fifth `determineMedia` fallback used to ask the search
+# provider for exactly one result and take it, so a remake sorted ahead of
+# its original (both measured cases were only two results deep) was never
+# even offered as an alternative. 5 gives enough headroom to see past a
+# remake pair without an unbounded fetch.
+SEARCH_YEAR_DISAMBIGUATION_LIMIT = 5
+
+# A provider's release year can legitimately differ from the year parsed out
+# of a filename by one (region release dates, festival versus wide release).
+# 0 would treat every honest off-by-one provider year as a non-match and
+# always fall back to the first result; anything above 1 starts risking the
+# very remake collisions this bug is about -- the closest of the four
+# measured remake pairs is still 7 years apart.
+SEARCH_YEAR_TOLERANCE = 1
+
 
 class FolderScannerMixin:
     """Mixin providing directory scanning, file grouping, and identifier creation."""
@@ -459,15 +474,24 @@ class FolderScannerMixin:
                     name_year = self.getReleaseNameYear(identifier, file_name=filename if not group['is_dvd'] else None)
                     if name_year.get('name') and name_year.get('year'):
                         search_q = '%(name)s %(year)s' % name_year
-                        movie = fireEvent('movie.search', q=search_q, merge=True, limit=1)
+                        movie = fireEvent('movie.search', q=search_q, merge=True,
+                                           limit=SEARCH_YEAR_DISAMBIGUATION_LIMIT)
+                        parsed_year = name_year.get('year')
 
                         if len(movie) == 0 and name_year.get('other') and name_year['other'].get('name') and name_year['other'].get('year'):
                             search_q2 = '%(name)s %(year)s' % name_year.get('other')
                             if search_q2 != search_q:
-                                movie = fireEvent('movie.search', q=search_q2, merge=True, limit=1)
+                                movie = fireEvent('movie.search', q=search_q2, merge=True,
+                                                   limit=SEARCH_YEAR_DISAMBIGUATION_LIMIT)
+                                # The "other" query carries its own parsed
+                                # year (a differently-parsed title can imply
+                                # a different year) -- match against that,
+                                # not the primary query's.
+                                parsed_year = name_year['other'].get('year')
 
                         if len(movie) > 0:
-                            imdb_id = movie[0].get('imdb')
+                            chosen = self.pickSearchYearMatch(movie, parsed_year, filename)
+                            imdb_id = chosen.get('imdb')
                             # A GUESS, not an assertion: the best match for a
                             # parsed title and year. Recorded as such so the
                             # destructive path can refuse it.
@@ -492,6 +516,45 @@ class FolderScannerMixin:
         log.error('No imdb_id found for %s. Add a NFO file with IMDB id or add the year to the filename.',
                   group['identifiers'])
         return {}
+
+    def pickSearchYearMatch(self, candidates, parsed_year, filename):
+        """BUG-018: choose which search result to trust as the identity.
+
+        The provider does not rank on year, so it routinely returns a
+        remake's original release ahead of the film actually named in the
+        filename (measured live: Mulan 2020, Aladdin 2019, Mean Girls 2024
+        and Lion King 2019 were all in second place). Prefer whichever
+        candidate's year is within `SEARCH_YEAR_TOLERANCE` of the parsed
+        year, regardless of position.
+
+        `candidates` is assumed non-empty; the caller only reaches here
+        after checking `len(movie) > 0`. When nothing matches, the FIRST
+        candidate is returned -- exactly what the pre-BUG-018 code always
+        returned. This is the safety property the withdrawn first design
+        broke: returning `None` here, where the old code returned an id,
+        makes `manage.updateLibrary` believe a still-owned film is gone and
+        delete it. A mismatched guess is logged so the operator can see it;
+        it is never refused.
+        """
+        for candidate in candidates:
+            year = candidate.get('year')
+            if year is None:
+                continue
+            try:
+                if abs(int(year) - int(parsed_year)) <= SEARCH_YEAR_TOLERANCE:
+                    return candidate
+            except (TypeError, ValueError):
+                continue
+
+        first = candidates[0]
+        log.warning(
+            'No search result for "%s" matched the parsed year %s within '
+            'tolerance (years offered: %s) -- taking the first result %s. '
+            'This guess is not destructive on its own, but is worth '
+            'checking.',
+            filename, parsed_year, [c.get('year') for c in candidates], first.get('imdb'),
+        )
+        return first
 
     def getCPImdb(self, string):
         try:

--- a/couchpotato/core/plugins/scanner/folder_scanner.py
+++ b/couchpotato/core/plugins/scanner/folder_scanner.py
@@ -38,9 +38,21 @@ SEARCH_YEAR_DISAMBIGUATION_LIMIT = 5
 # (Mulan, Aladdin, Mean Girls, Lion King) is 20 years apart, comfortably
 # clear of any tolerance this constant could sanely hold. The real
 # constraint is the two CONSECUTIVE-YEAR SEQUEL pairs in the same catalogue
-# (Deathly Hallows Part 1/2, Mockingjay Part 1/2), a gap of 1 -- tolerance
-# 1 is already flush against that boundary, and going any higher starts
-# admitting the wrong half of a duology as a "match".
+# (Deathly Hallows Part 1/2, Mockingjay Part 1/2), a gap of 1.
+#
+# Round two tried closing that gap by scoring candidates on closest year
+# rather than taking the first in-tolerance one, and reverted it: measured
+# live, the query this fallback sends carries `year=<parsed year>`, so an
+# exact-year decoy is a near-certain second result whenever the correct
+# film differs from the parsed year by one -- closest-wins hands the win
+# to that decoy every time (Wicked, Nosferatu and Anora's 2025 reissues
+# all beat the correct 2024 film this way; see `pickSearchYearMatch` and
+# the spec's Recorded debt item 1). `pickSearchYearMatch` is back to
+# first-within-tolerance, which means the sequel pairs stay UNFIXED at
+# tolerance 1 whenever the provider lists the earlier part first -- that
+# risk is accepted, not eliminated. Raising tolerance above 1 would not
+# fix the sequel pairs either; it would only admit candidates two years
+# off, widening the same collision to non-adjacent sequels and prequels.
 SEARCH_YEAR_TOLERANCE = 1
 
 
@@ -559,13 +571,30 @@ class FolderScannerMixin:
         The provider does not rank on year, so it routinely returns a
         remake's original release ahead of the film actually named in the
         filename (measured live: Mulan 2020, Aladdin 2019, Mean Girls 2024
-        and Lion King 2019 were all in second place). Prefer whichever
-        candidate's year is CLOSEST to the parsed year, among candidates
-        within `SEARCH_YEAR_TOLERANCE`, regardless of position -- ties keep
-        whichever was listed first. Taking the first in-tolerance hit
-        (round one) rather than the closest one let an off-by-one candidate
-        listed ahead of an exact match win, which is exactly the failure
-        mode this bug is about, just one match closer.
+        and Lion King 2019 were all in second place). Return the FIRST
+        candidate whose year is within `SEARCH_YEAR_TOLERANCE` of the parsed
+        year, in list order, among candidates that carry an id.
+
+        Round two tried scoring every candidate and taking the CLOSEST one
+        within tolerance instead of the first, to close the two
+        consecutive-year sequel merges recorded as debt below -- and
+        reverted it after measuring it live. The query this fallback sends
+        carries `year=<parsed year>`, so the result set is routinely stuffed
+        with exact-parsed-year candidates. Closest-wins hands the win to
+        that exact-year candidate whenever the CORRECT film is the one an
+        honest one-year discrepancy applies to -- which is exactly the case
+        `SEARCH_YEAR_TOLERANCE` exists to absorb, not a rare edge:
+
+            search "Wicked 2025"     -> 0. Wicked (2024) CORRECT   1. Wicked: For Good (2025)
+            search "Nosferatu 2025"  -> 0. Nosferatu (2024) CORRECT 1. Nosferatu (2025)
+            search "Anora 2025"      -> 0. Anora (2024) CORRECT     1. Anora: Stripped Down (2025)
+
+        Under closest-wins the position-1 exact-year decoy beats the correct
+        film at position 0 in all three. First-within-tolerance gets all
+        three right, and is what this function does again. The consecutive-
+        year sequel merges closest-wins was meant to fix stay UNFIXED at
+        tolerance 1 whenever the provider lists the earlier part first --
+        see the spec's Recorded debt item 1.
 
         Round-one review of 0dc9e9a78 (FIX 1): having an id is part of the
         SELECTION PREDICATE, not a property checked on the result
@@ -594,34 +623,49 @@ class FolderScannerMixin:
         def _imdb(candidate):
             try:
                 return candidate.get('imdb')
-            except AttributeError:
+            except Exception:
+                # Round-two review of 0dc9e9a78 (FIX 4b): the comment above
+                # this function already justifies the guard as "the moment
+                # a second provider is registered", which is broader than
+                # AttributeError alone -- a malformed candidate could raise
+                # anything out of `.get`, not only from lacking the method.
                 return None
 
         def _year(candidate):
             try:
                 return candidate.get('year')
-            except AttributeError:
+            except Exception:
                 return None
 
-        best, best_diff = None, None
         for candidate in candidates:
             if not _imdb(candidate):
                 continue
             year = _year(candidate)
-            if year is None:
-                continue
+            # No separate `year is None` check: `int(None)` raises
+            # TypeError, already caught below, so the check would be dead
+            # code -- it can never short-circuit anything the except clause
+            # does not already handle.
             try:
                 diff = abs(int(year) - int(parsed_year))
             except (TypeError, ValueError):
                 continue
-            if diff <= SEARCH_YEAR_TOLERANCE and (best_diff is None or diff < best_diff):
-                best, best_diff = candidate, diff
-
-        if best is not None:
-            return best
+            if diff <= SEARCH_YEAR_TOLERANCE:
+                return candidate
 
         first = candidates[0]
         offered_years = [_year(c) for c in candidates]
+        try:
+            # Round-two review of 0dc9e9a78 (FIX 4a): this used to sit
+            # unguarded inside the caller's `except Exception:` (determineMedia's
+            # search try/except). A non-str/bytes/PathLike `filename` makes
+            # `os.path.basename` raise TypeError, which that outer guard then
+            # swallows -- aborting identification for this identifier
+            # entirely, exactly the data-loss shape the guard exists to
+            # prevent, just triggered from inside this warning instead of
+            # the search itself.
+            logged_filename = os.path.basename(filename) if filename else filename
+        except TypeError:
+            logged_filename = filename
         log.warning(
             'No search result for "%s" matched the parsed year %s within '
             'tolerance (years offered: %s) -- taking the first result %s. '
@@ -633,7 +677,7 @@ class FolderScannerMixin:
             # private filesystem paths in logs). The filename is still
             # enough for an operator to find the release; the download
             # folder structure around it is not needed to do that.
-            os.path.basename(filename) if filename else filename,
+            logged_filename,
             parsed_year, offered_years, _imdb(first),
         )
         return first

--- a/specs/BUG-018-scanner-files-remakes-under-the-original.md
+++ b/specs/BUG-018-scanner-files-remakes-under-the-original.md
@@ -75,7 +75,9 @@ replaced by a guard on the invariant above rather than deleted.
 - The cleanup in `manage.updateLibrary`. It is already hardened once
   (`library_fully_scanned`) and rewriting its inference is its own change.
 - Splitting the seven merged records. Deliberately after this.
-- The two sequel cases, whose cause is not established.
+- The two sequel cases. Round-one review of 0dc9e9a78 partly establishes
+  the cause (see Recorded debt item 1) but stops short of confirming it
+  against the actual production data.
 
 ## Acceptance criteria
 
@@ -107,7 +109,36 @@ replaced by a guard on the invariant above rather than deleted.
 
 ## Recorded debt
 
-1. The two sequel merges have a different, unestablished cause.
+1. The two sequel merges (Deathly Hallows Part 1/2, Mockingjay Part 1/2) are
+   PARTLY explained, not fully established. Round-one review of 0dc9e9a78
+   found `pickSearchYearMatch` returned the first candidate within
+   `SEARCH_YEAR_TOLERANCE`, not the closest one -- so if a search ever
+   returned both parts of a duology (a gap of 1 year, inside tolerance)
+   with the wrong part listed first, the wrong part would win. Fixed as
+   part of this round (score by closest year diff, ties keep the
+   earlier-listed candidate). Not fully established as THE cause, because
+   the actual candidate order the provider returned for these two specific
+   folders was never captured before the merge happened.
 2. Five films are on disk with no record; two return nothing from the provider.
 3. `manage.updateLibrary`'s "absent means deleted" inference remains a
    single-point data-loss risk, mitigated but not removed.
+4. Round-one review asked whether a NARROWED freeze -- covering `scan()`
+   and identification routes one to four, where `TestFolderScannerIsUntouched`
+   protected something and `TestFolderScannerNeverReducesTheScanResult` has
+   no reach -- was worth restoring, since BUG-018 needed no change there at
+   all. Decided NOT to add one: a hash/diff freeze over any region is the
+   same proxy AC-QA-7 retired, just drawn smaller, and it fails the same
+   way -- the day a legitimate change touches that region, whoever hits it
+   either updates the recorded hash without reading why it exists (ceremony)
+   or is genuinely blocked by something that was never actually at risk.
+   Routes one to four are assertions (an id claimed by the download, a CP
+   tag, an NFO, an id in the filename), not guesses, so what actually wants
+   protecting is "an id claimed this way is still trusted, and this loop's
+   iteration-order bugs (see the comment above the filename-in-files route)
+   don't come back" -- both already have their own targeted tests
+   (`test_identity_provenance.py` and this module's own history). A new
+   test asserting each route still resolves known-good input to its known
+   id would be more honest protection than a freeze, but building it is new
+   test infrastructure for code this bug did not touch, and is left for
+   whoever next has reason to change one of those four routes rather than
+   built speculatively here.

--- a/specs/BUG-018-scanner-files-remakes-under-the-original.md
+++ b/specs/BUG-018-scanner-files-remakes-under-the-original.md
@@ -110,15 +110,43 @@ replaced by a guard on the invariant above rather than deleted.
 ## Recorded debt
 
 1. The two sequel merges (Deathly Hallows Part 1/2, Mockingjay Part 1/2) are
-   PARTLY explained, not fully established. Round-one review of 0dc9e9a78
-   found `pickSearchYearMatch` returned the first candidate within
-   `SEARCH_YEAR_TOLERANCE`, not the closest one -- so if a search ever
-   returned both parts of a duology (a gap of 1 year, inside tolerance)
-   with the wrong part listed first, the wrong part would win. Fixed as
-   part of this round (score by closest year diff, ties keep the
-   earlier-listed candidate). Not fully established as THE cause, because
-   the actual candidate order the provider returned for these two specific
-   folders was never captured before the merge happened.
+   PARTLY explained, not fully established, and remain UNFIXED. Round-one
+   review of 0dc9e9a78 found `pickSearchYearMatch` returned the first
+   candidate within `SEARCH_YEAR_TOLERANCE`, not the closest one -- so if a
+   search ever returned both parts of a duology (a gap of 1 year, inside
+   tolerance) with the wrong part listed first, the wrong part would win.
+   Round one tried fixing this by scoring candidates on closest year
+   rather than taking the first in-tolerance one (ties keeping the
+   earlier-listed candidate).
+
+   Round-two review of that change measured it live against the real
+   provider and reverted it: `SEARCH_YEAR_DISAMBIGUATION_LIMIT`'s query
+   sends `year=<parsed year>`, so the result set is routinely stuffed with
+   candidates carrying the EXACT parsed year. Closest-wins hands the win to
+   that exact-year candidate whenever the correct film is the one an
+   honest off-by-one applies to -- which is exactly the case
+   `SEARCH_YEAR_TOLERANCE` exists to absorb, not a rare edge. Three cases
+   measured live 2026-09-06 (a December release ripped the following
+   January carries the following year in its filename, which is common):
+
+       search "Wicked 2025"     -> 0. Wicked (2024) CORRECT   1. Wicked: For Good (2025)
+       search "Nosferatu 2025"  -> 0. Nosferatu (2024) CORRECT 1. Nosferatu (2025)
+       search "Anora 2025"      -> 0. Anora (2024) CORRECT     1. Anora: Stripped Down (2025)
+
+   Under closest-wins the exact-year decoy at position 1 beat the correct
+   film at position 0 in all three, and a review of 0dc9e9a78 found seven
+   regressions out of eleven adversarially chosen cases, first-within-
+   tolerance getting all seven right. `pickSearchYearMatch` is back to
+   first-within-tolerance. The two sequel merges this round-one attempt was
+   meant to close therefore stay UNFIXED whenever the provider lists the
+   earlier part first, and this is an accepted, recorded limitation, not an
+   oversight -- do not try closest-wins again without a way to tell "an
+   honest off-by-one on the correct film" apart from "an exact-year decoy
+   for the wrong film", which the three cases above show is not simply a
+   matter of scoring distance. Not fully established as THE cause of the
+   two merges either way, because the actual candidate order the provider
+   returned for these two specific folders was never captured before the
+   merge happened.
 2. Five films are on disk with no record; two return nothing from the provider.
 3. `manage.updateLibrary`'s "absent means deleted" inference remains a
    single-point data-loss risk, mitigated but not removed.

--- a/specs/BUG-018-scanner-files-remakes-under-the-original.md
+++ b/specs/BUG-018-scanner-files-remakes-under-the-original.md
@@ -1,20 +1,15 @@
 # BUG-018: the scanner files every remake under the original
 
-**Status:** agreed
-**Reported:** 2026-09-06, found while auditing library-to-disk mismatches
+**Status:** agreed, REDESIGNED 2026-09-06 after the first design was shown to be
+dangerous
 **Severity:** wrong data, recoverable. No file is touched; the library record is
 wrong.
 
 ## What happens
 
-Seven media records in the production library hold files from more than one
-film. Measured:
-
-    records holding files from more than one folder : 9
-      same year, so a genuine duplicate copy        : 2
-      DIFFERENT years, so distinct films merged     : 7
-
-The seven:
+Seven media records in production hold files from two distinct films. The
+second film therefore has no record of its own: CouchPotato believes it already
+owns it, so it never appears and is never searched for.
 
     Harry Potter Deathly Hallows Part 1  <- Part 1 (2010) and Part 2 (2011)
     Hunger Games Mockingjay Part 1       <- Part 1 (2014) and Part 2 (2015)
@@ -24,86 +19,95 @@ The seven:
     Mulan                                <- 1998 and 2020
     Mean Girls                           <- 2004 and 2024
 
-The consequence is not a wrong file playing. It is that the second film has no
-library record: CouchPotato believes it already owns it, so it never appears and
-is never searched for. The original is the record that survives, so a user
-looking for their 1994 Lion King finds a record pointing at the 2019 remake.
-
 ## Root cause
 
-`couchpotato/core/plugins/scanner/folder_scanner.py`, `determineMedia`, has five
-identification routes. The first four are assertions: an imdb id from the
-download, a CP tag, an NFO, an id in the filename. The fifth is a fuzzy search
-and the module's own docstring calls it a guess, which is why the renamer
-refuses to delete a destination file on a `search` identity.
+`couchpotato/core/plugins/scanner/folder_scanner.py`, `determineMedia`, fifth
+fallback. It builds a query containing the year, asks for ONE result, and takes
+it. The provider does not rank on year. Measured against the live provider:
 
-That fifth route, at roughly line 459:
+    "Mulan 2020"      -> 0. Mulan 1998          1. Mulan 2020
+    "Aladdin 2019"    -> 0. Aladdin 1992        1. Aladdin 2019
+    "Mean Girls 2024" -> 0. Mean Girls 2004     1. Mean Girls 2024
+    "Lion King 2019"  -> 0. The Lion King 1994  1. The Lion King 2019
 
-    name_year = self.getReleaseNameYear(...)
-    if name_year.get('name') and name_year.get('year'):
-        search_q = '%(name)s %(year)s' % name_year
-        movie = fireEvent('movie.search', q=search_q, merge=True, limit=1)
-        ...
-        if len(movie) > 0:
-            imdb_id = movie[0].get('imdb')
+The correct film is position 1 every time. `limit=1` guarantees it is never
+seen. The parsed year is already in hand and already in the query; it is simply
+never used to choose between results.
 
-It builds a query containing the year, asks for exactly ONE result, and takes
-it. The search does not rank on year, so a remake's query returns the original
-first.
+## Why the FIRST design was withdrawn, and this matters more than the fix
 
-Measured against the live provider:
+The first version of this spec said: when the year is known and no candidate
+matches it, REFUSE to identify the file, on the reasoning that an unidentified
+file is visible as missing while a wrongly identified one is invisible.
 
-    search "Mulan 2020"       -> 0. Mulan 1998        1. Mulan 2020
-    search "Aladdin 2019"     -> 0. Aladdin 1992      1. Aladdin 2019
-    search "Mean Girls 2024"  -> 0. Mean Girls 2004   1. Mean Girls 2024
-    search "Lion King 2019"   -> 0. The Lion King 1994  1. The Lion King 2019
+That reasoning is correct in isolation and catastrophic in this system.
 
-**The correct film is position 1 in every case.** The parsed year is already in
-hand and already in the query; it is simply never used to choose between the
-results. `limit=1` guarantees the right answer is never even seen.
+`manage.updateLibrary` deletes every terminal movie absent from the scan result,
+with `delete_from='all'`: the media document, every release document, the
+library entry, watch state, tags, profile and review state. It infers "this
+movie is gone" from "this scan did not find it". A refused file produces no
+identifier, so it is absent from `added_identifiers`, so a film owned ONLY as a
+remake, a 2024 Mean Girls with no 2004 copy, would be deleted outright by the
+next nightly scan.
 
-Sequels are not affected the same way: "Beetlejuice 2 2024" and "Hunger Games
-Mockingjay Part 2 2015" both return the correct film first. The seven merged
-records include two sequel cases that arrived by a different route, so fixing
-this will not by itself explain those two.
+The implementation built the refusal exactly as specified. It was caught by
+`tests/unit/test_renamer_decision_memory.py::TestFolderScannerIsUntouched`,
+which freezes this module against master precisely because it feeds that
+cleanup. The freeze did its job: it is a stop-and-think device, and the thinking
+changed the design.
+
+## The invariant this change must preserve
+
+**The scan must never produce fewer identifiers than it does today.** This
+change may only alter WHICH identifier the fallback returns, never WHETHER one
+is returned. Any design that can return None where the current code returns an
+id is a data-loss design in this system, regardless of how correct it looks in
+isolation.
 
 ## Scope
 
-The fifth fallback in `determineMedia` only. Raise the result limit, choose the
-candidate whose year matches the parsed year, and refuse rather than guess when
-none does.
+The fifth fallback in `determineMedia` only, plus the freeze test, which must be
+replaced by a guard on the invariant above rather than deleted.
 
 ## Not in scope
 
-- The first four identification routes. They are assertions and they are fine.
-- Splitting the seven existing records. Separate, and deliberately AFTER this,
-  because a cleanup before the fix would be re-merged by the next daily scan.
+- The first four identification routes. They are assertions and are fine.
+- The cleanup in `manage.updateLibrary`. It is already hardened once
+  (`library_fully_scanned`) and rewriting its inference is its own change.
+- Splitting the seven merged records. Deliberately after this.
 - The two sequel cases, whose cause is not established.
-- Ranking or scoring beyond the year.
 
 ## Acceptance criteria
 
 - **AC-DATA-1:** When the parsed year is known and a candidate's year matches
-  it, that candidate is chosen, even when it is not first. Proven with the four
-  measured cases above, driven through the real function.
-- **AC-DATA-2:** When the parsed year is known and NO candidate matches it, the
-  scanner refuses to identify the file rather than taking the first result. A
-  wrong record is worse than an unidentified file, because an unidentified file
-  is visible as missing while a wrong one is invisible.
-- **AC-DATA-3:** When the parsed year is unknown, behaviour is unchanged. This
-  fix must not make previously identifiable files unidentifiable.
-- **AC-OPS-4:** A refusal under AC-DATA-2 is logged with the filename, the
-  parsed year, and the years that were offered, so an operator can see why a
-  file was skipped. A silent skip reproduces the invisibility this bug is about.
+  within tolerance, that candidate is chosen even when it is not first. Proven
+  with the four measured cases, driven through the real function.
+- **AC-DATA-2 (REPLACES the withdrawn refusal):** When the parsed year is known
+  and NO candidate matches, the fallback returns the FIRST candidate, exactly as
+  today. It must never return None in a case where the current code returns an
+  id. This is the safety property; it is not negotiable and it is the reason the
+  first design was withdrawn.
+- **AC-DATA-3:** When the parsed year is unknown, behaviour is unchanged.
+- **AC-OPS-4:** Choosing a candidate whose year disagrees with the parsed year
+  is logged at warning level with the filename, the parsed year and the years
+  offered. The operator can then see a bad guess without the guess being
+  destructive.
 - **AC-QA-5:** A guard fails if the fallback takes a candidate whose year
-  disagrees with the parsed year. Proven by restoring the `limit=1`
+  disagrees when a matching one was available. Proven by restoring the
   take-the-first behaviour and watching it fail on the Mulan case.
-- **AC-SIMP-6:** Confined to that one fallback block. The other four routes are
-  untouched.
+- **AC-QA-6:** A guard proves the invariant directly: for every input where the
+  pre-change code produced an identifier, the changed code also produces one.
+  Drive both, do not reason about it.
+- **AC-QA-7:** `TestFolderScannerIsUntouched` is replaced, not deleted. The
+  freeze was a proxy for "this module must not reduce the scan result"; the
+  replacement must assert that property, and must fail if a change reintroduces
+  a path returning None where an id was returned before.
+- **AC-SIMP-8:** Confined to that one fallback and its guard. The other four
+  routes are untouched.
 
 ## Recorded debt
 
-1. The two sequel merges (Deathly Hallows, Mockingjay) have a different and
-   unestablished cause.
-2. Five films are on disk with no record at all; two of them return nothing from
-   the provider and may not be addable by lookup.
+1. The two sequel merges have a different, unestablished cause.
+2. Five films are on disk with no record; two return nothing from the provider.
+3. `manage.updateLibrary`'s "absent means deleted" inference remains a
+   single-point data-loss risk, mitigated but not removed.

--- a/specs/BUG-018-scanner-files-remakes-under-the-original.md
+++ b/specs/BUG-018-scanner-files-remakes-under-the-original.md
@@ -1,0 +1,109 @@
+# BUG-018: the scanner files every remake under the original
+
+**Status:** agreed
+**Reported:** 2026-09-06, found while auditing library-to-disk mismatches
+**Severity:** wrong data, recoverable. No file is touched; the library record is
+wrong.
+
+## What happens
+
+Seven media records in the production library hold files from more than one
+film. Measured:
+
+    records holding files from more than one folder : 9
+      same year, so a genuine duplicate copy        : 2
+      DIFFERENT years, so distinct films merged     : 7
+
+The seven:
+
+    Harry Potter Deathly Hallows Part 1  <- Part 1 (2010) and Part 2 (2011)
+    Hunger Games Mockingjay Part 1       <- Part 1 (2014) and Part 2 (2015)
+    The Lion King                        <- Lion King (2019) and Lion (2016)
+    Beetlejuice                          <- 1988, Beetlejuice 2 (2024), and one more
+    Aladdin                              <- 1992 and 2019
+    Mulan                                <- 1998 and 2020
+    Mean Girls                           <- 2004 and 2024
+
+The consequence is not a wrong file playing. It is that the second film has no
+library record: CouchPotato believes it already owns it, so it never appears and
+is never searched for. The original is the record that survives, so a user
+looking for their 1994 Lion King finds a record pointing at the 2019 remake.
+
+## Root cause
+
+`couchpotato/core/plugins/scanner/folder_scanner.py`, `determineMedia`, has five
+identification routes. The first four are assertions: an imdb id from the
+download, a CP tag, an NFO, an id in the filename. The fifth is a fuzzy search
+and the module's own docstring calls it a guess, which is why the renamer
+refuses to delete a destination file on a `search` identity.
+
+That fifth route, at roughly line 459:
+
+    name_year = self.getReleaseNameYear(...)
+    if name_year.get('name') and name_year.get('year'):
+        search_q = '%(name)s %(year)s' % name_year
+        movie = fireEvent('movie.search', q=search_q, merge=True, limit=1)
+        ...
+        if len(movie) > 0:
+            imdb_id = movie[0].get('imdb')
+
+It builds a query containing the year, asks for exactly ONE result, and takes
+it. The search does not rank on year, so a remake's query returns the original
+first.
+
+Measured against the live provider:
+
+    search "Mulan 2020"       -> 0. Mulan 1998        1. Mulan 2020
+    search "Aladdin 2019"     -> 0. Aladdin 1992      1. Aladdin 2019
+    search "Mean Girls 2024"  -> 0. Mean Girls 2004   1. Mean Girls 2024
+    search "Lion King 2019"   -> 0. The Lion King 1994  1. The Lion King 2019
+
+**The correct film is position 1 in every case.** The parsed year is already in
+hand and already in the query; it is simply never used to choose between the
+results. `limit=1` guarantees the right answer is never even seen.
+
+Sequels are not affected the same way: "Beetlejuice 2 2024" and "Hunger Games
+Mockingjay Part 2 2015" both return the correct film first. The seven merged
+records include two sequel cases that arrived by a different route, so fixing
+this will not by itself explain those two.
+
+## Scope
+
+The fifth fallback in `determineMedia` only. Raise the result limit, choose the
+candidate whose year matches the parsed year, and refuse rather than guess when
+none does.
+
+## Not in scope
+
+- The first four identification routes. They are assertions and they are fine.
+- Splitting the seven existing records. Separate, and deliberately AFTER this,
+  because a cleanup before the fix would be re-merged by the next daily scan.
+- The two sequel cases, whose cause is not established.
+- Ranking or scoring beyond the year.
+
+## Acceptance criteria
+
+- **AC-DATA-1:** When the parsed year is known and a candidate's year matches
+  it, that candidate is chosen, even when it is not first. Proven with the four
+  measured cases above, driven through the real function.
+- **AC-DATA-2:** When the parsed year is known and NO candidate matches it, the
+  scanner refuses to identify the file rather than taking the first result. A
+  wrong record is worse than an unidentified file, because an unidentified file
+  is visible as missing while a wrong one is invisible.
+- **AC-DATA-3:** When the parsed year is unknown, behaviour is unchanged. This
+  fix must not make previously identifiable files unidentifiable.
+- **AC-OPS-4:** A refusal under AC-DATA-2 is logged with the filename, the
+  parsed year, and the years that were offered, so an operator can see why a
+  file was skipped. A silent skip reproduces the invisibility this bug is about.
+- **AC-QA-5:** A guard fails if the fallback takes a candidate whose year
+  disagrees with the parsed year. Proven by restoring the `limit=1`
+  take-the-first behaviour and watching it fail on the Mulan case.
+- **AC-SIMP-6:** Confined to that one fallback block. The other four routes are
+  untouched.
+
+## Recorded debt
+
+1. The two sequel merges (Deathly Hallows, Mockingjay) have a different and
+   unestablished cause.
+2. Five films are on disk with no record at all; two of them return nothing from
+   the provider and may not be addable by lookup.

--- a/tests/unit/bug018_selection_helper.py
+++ b/tests/unit/bug018_selection_helper.py
@@ -1,0 +1,22 @@
+"""Shared reference oracle for BUG-018's invariant tests.
+
+`pre_bug_018_selection` is the fallback's selection before BUG-018:
+`fireEvent('movie.search', ..., limit=1)`, then `movie[0]`, with nothing else
+read from the result. It is a plain function of the candidate list, not
+imported from production, because production is exactly what these tests
+guard -- importing the (now fixed) selection would compare the fix with
+itself and could never fail.
+
+Round-two review of 0dc9e9a78 (FIX 5c): this used to be copy-pasted into
+`test_scanner_search_year_disambiguation.py` and
+`test_renamer_decision_memory.py`. Two copies of one reference oracle in two
+files is a drift hazard -- a fix to one copy (a bug in the oracle itself, or
+a change to what "pre-BUG-018" means) silently leaves the other stale. Shared
+here instead.
+"""
+
+
+def pre_bug_018_selection(candidates):
+    if not candidates:
+        return None
+    return candidates[0].get('imdb')

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -197,6 +197,57 @@ class TestTMDBProvider:
                 'explicit search_type must win'
             )
 
+    def test_search_returns_exactly_limit_results_from_a_larger_raw_list(self):
+        """BUG-018 round-two review, FIX 1: `search`'s truncation loop
+        (`if nr == limit: break`) is the ONLY place the requested limit is
+        honoured -- the scanner's year-disambiguation fallback depends on
+        getting back as many candidates as it asks for so it has something
+        to disambiguate between. Every test up to now stubs the scanner
+        side and never drives this loop with more raw results than the
+        limit, so a truncation bug here (e.g. breaking after the first
+        result regardless of what was asked for) would pass the whole
+        suite unnoticed.
+
+        Hand the provider 10 parseable raw results and assert it returns
+        exactly 5 when asked for 5, and exactly 1 when asked for 1."""
+        p = self._make_provider()
+
+        def make_movie(i):
+            return {
+                'id': i, 'title': 'Movie %d' % i, 'original_title': 'Movie %d' % i,
+                'release_date': '2000-01-01', 'overview': 'Test', 'genres': [],
+                'runtime': 100, 'imdb_id': 'tt%07d' % i, 'poster_path': None,
+                'backdrop_path': None, 'belongs_to_collection': None,
+                'alternative_titles': {'titles': []},
+                'casts': {'cast': []}, 'images': {'backdrops': []},
+            }
+
+        raw = [make_movie(i) for i in range(1, 11)]
+
+        with patch.object(p, 'conf', return_value='mykey'), \
+             patch.object(p, 'isDisabled', return_value=False), \
+             patch('couchpotato.core.media.movie.providers.info.themoviedb.fireEvent',
+                   return_value={'name': 'Test', 'year': 2000}):
+
+            # parseMovie issues one further `request` per candidate it is
+            # given (the per-language detail fetch); `p.languages` is []
+            # and `default_language` is 'en', so that is exactly one extra
+            # call per candidate, not per configured language.
+            with patch.object(p, 'request', side_effect=[raw] + raw[:5]):
+                results = p.search('Test', limit=5)
+                assert len(results) == 5, (
+                    'asked for 5 candidates out of 10 available but got %d -- '
+                    'the scanner year-disambiguation fallback needs several '
+                    'candidates to choose between, and a truncation bug here '
+                    'would starve it silently' % len(results)
+                )
+
+            with patch.object(p, 'request', side_effect=[raw] + raw[:1]):
+                results = p.search('Test', limit=1)
+                assert len(results) == 1, (
+                    'asked for 1 candidate but got %d' % len(results)
+                )
+
 
 # ===========================================================================
 # ===========================================================================

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -150,9 +150,15 @@ class TestTMDBProvider:
                 assert len(results) >= 0  # May be empty due to mock chain
 
     def test_search_type_derives_from_limit_by_default(self):
-        """`search_type` is `phrase` for a single, assertive lookup and
-        `ngram` for a broader multi-result one, UNLESS a caller pins it
-        explicitly (see FIX 6 test below)."""
+        """`search_type` is `phrase` for `limit == 1` and `ngram`
+        otherwise, unless a caller pins it explicitly (see the test below).
+        This is purely a MECHANICAL check of what value is derived and sent
+        -- round-two review of BUG-018 (2026-09) measured live against TMDB
+        v3 that `search_type` has no effect on which results come back or
+        in what order, so neither value should be read as "exact" or
+        "fuzzy" here. What still matters is that the derived value reaches
+        the request, because it is part of the cache key (see the pinning
+        test below and `TheMovieDb.search`'s docstring)."""
         p = self._make_provider()
         with patch.object(p, 'conf', return_value='mykey'), \
              patch.object(p, 'isDisabled', return_value=False), \
@@ -166,13 +172,18 @@ class TestTMDBProvider:
             assert mock_request.call_args[0][1]['search_type'] == 'ngram'
 
     def test_search_type_can_be_pinned_regardless_of_limit(self):
-        """FIX 6 (round-one review of BUG-018, 0dc9e9a78): raising `limit`
-        so a caller sees more results to inspect (the scanner's year-
-        disambiguation fallback wants extra candidates, not a fuzzier
-        match) used to silently flip `search_type` to `ngram` as a side
-        effect. `search_type` is part of the request URL and therefore the
-        cache key, so this also changed what a cached search was keyed on.
-        An explicit `search_type` must win over the `limit`-derived
+        """FIX 6 (round-one review of BUG-018, 0dc9e9a78), corrected by
+        round-two review (2026-09): raising `limit` so a caller sees more
+        results to inspect (the scanner's year-disambiguation fallback
+        wants extra candidates) used to silently flip the derived
+        `search_type` to `ngram` as a side effect. Measured live against
+        TMDB v3, `search_type` does not change matching at all -- it is a
+        TMDB v2.1 parameter that v3 ignores -- so the ONLY thing this
+        pinning buys is a stable cache key: `search_type` is part of the
+        request URL, so without pinning it, that fallback's `limit=5`
+        calls would key their cache entries differently from every other
+        `limit=1` caller in the codebase for no behavioural gain. An
+        explicit `search_type` must win over the `limit`-derived
         default."""
         p = self._make_provider()
         with patch.object(p, 'conf', return_value='mykey'), \

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -149,6 +149,43 @@ class TestTMDBProvider:
                 results = p.search('Fight Club', limit=1)
                 assert len(results) >= 0  # May be empty due to mock chain
 
+    def test_search_type_derives_from_limit_by_default(self):
+        """`search_type` is `phrase` for a single, assertive lookup and
+        `ngram` for a broader multi-result one, UNLESS a caller pins it
+        explicitly (see FIX 6 test below)."""
+        p = self._make_provider()
+        with patch.object(p, 'conf', return_value='mykey'), \
+             patch.object(p, 'isDisabled', return_value=False), \
+             patch('couchpotato.core.media.movie.providers.info.themoviedb.fireEvent',
+                   return_value={'name': 'Fight Club', 'year': 1999}), \
+             patch.object(p, 'request', return_value=None) as mock_request:
+            p.search('Fight Club', limit=1)
+            assert mock_request.call_args[0][1]['search_type'] == 'phrase'
+
+            p.search('Fight Club', limit=5)
+            assert mock_request.call_args[0][1]['search_type'] == 'ngram'
+
+    def test_search_type_can_be_pinned_regardless_of_limit(self):
+        """FIX 6 (round-one review of BUG-018, 0dc9e9a78): raising `limit`
+        so a caller sees more results to inspect (the scanner's year-
+        disambiguation fallback wants extra candidates, not a fuzzier
+        match) used to silently flip `search_type` to `ngram` as a side
+        effect. `search_type` is part of the request URL and therefore the
+        cache key, so this also changed what a cached search was keyed on.
+        An explicit `search_type` must win over the `limit`-derived
+        default."""
+        p = self._make_provider()
+        with patch.object(p, 'conf', return_value='mykey'), \
+             patch.object(p, 'isDisabled', return_value=False), \
+             patch('couchpotato.core.media.movie.providers.info.themoviedb.fireEvent',
+                   return_value={'name': 'Fight Club', 'year': 1999}), \
+             patch.object(p, 'request', return_value=None) as mock_request:
+            p.search('Fight Club', limit=5, search_type='phrase')
+            assert mock_request.call_args[0][1]['search_type'] == 'phrase', (
+                'limit=5 would normally flip search_type to "ngram", but an '
+                'explicit search_type must win'
+            )
+
 
 # ===========================================================================
 # ===========================================================================

--- a/tests/unit/test_renamer_decision_memory.py
+++ b/tests/unit/test_renamer_decision_memory.py
@@ -299,7 +299,22 @@ class TestFolderScannerNeverReducesTheScanResult:
 
         def _fire(event, *args, **kwargs):
             if event == 'movie.search':
-                return list(candidates) if kwargs.get('q') == search_q else []
+                if kwargs.get('q') != search_q:
+                    return []
+                results = list(candidates)
+                # Round-two review of BUG-018 (FIX 2): truncate to `limit`
+                # like the real provider does, matching the sibling stub in
+                # test_scanner_search_year_disambiguation.py. This module's
+                # own assertions only check that SOME identifier came back,
+                # which holds even at limit 1, so this stub being gentler
+                # than production has not yet produced a false green here --
+                # but it must not drift further from the real behaviour, or
+                # the day it does the two files will disagree about what a
+                # limit means.
+                limit = kwargs.get('limit')
+                if limit is not None:
+                    results = results[:limit]
+                return results
             return None
 
         monkeypatch.setattr(folder_scanner_module, 'fireEvent', _fire)

--- a/tests/unit/test_renamer_decision_memory.py
+++ b/tests/unit/test_renamer_decision_memory.py
@@ -27,7 +27,6 @@ identical scans of one unchanged group currently ask the scanner five times.
 """
 import logging
 import os
-import subprocess
 import time
 
 import pytest
@@ -47,18 +46,8 @@ from couchpotato.core.plugins.renamer.replacement import (
     DECLINED_UNVERIFIED_IDENTITY,
     REPLACE,
 )
-from tests.unit.conftest import sanitized_git_env
-
-# env=sanitized_git_env() on every git call here, enforced by
-# tests/unit/test_fixtures_do_not_leak_gitdir.py and not optional: git exports
-# GIT_DIR into a pre-push hook launched from a worktree, so an unsanitised
-# call operates on the REAL repository rather than its own cwd. That is a
-# recorded incident in this repo, not a hypothetical.
-REPO_ROOT = subprocess.run(
-    ['git', 'rev-parse', '--show-toplevel'],
-    capture_output=True, text=True, check=True,
-    env=sanitized_git_env(),
-).stdout.strip()
+import couchpotato.core.plugins.scanner.folder_scanner as folder_scanner_module
+from couchpotato.core.plugins.scanner.folder_scanner import FolderScannerMixin
 
 
 @pytest.fixture(autouse=True)
@@ -221,81 +210,105 @@ class TestAnUnchangedDeclinedGroupIsNotRescanned:
         )
 
 
-class TestFolderScannerIsUntouched:
-    """AC-SIMP-2 / binding decision 1 -- the data-loss guard.
+class TestFolderScannerNeverReducesTheScanResult:
+    """AC-QA-7 (BUG-018) -- replaces the withdrawn `TestFolderScannerIsUntouched`.
 
     `folder_scanner.py` is shared with `manage.updateLibrary`, whose cleanup
     at `manage.py:274-275` deletes any 'done' movie absent from the scan
     result: the media document, its releases, watch history, tags, profile
-    and review state, with no backup taken automatically. Nothing about the
-    renamer's memory may ever change what that shared scanner returns.
+    and review state, with no backup taken automatically. The class this
+    replaces asserted an empty `git diff` against master as a PROXY for
+    "this module must never start feeding that cleanup a false negative" --
+    a proxy that only worked as long as nothing legitimate ever needed to
+    change the module. BUG-018 does need to change it (the year-
+    disambiguation fix for the fifth identification fallback), so the freeze
+    is retired in favour of the property it always stood in for.
 
-    This is a structural guard, not a missing-behaviour test: the diff is
-    genuinely empty right now, so this assertion PASSES today, by design.
-    Its value is as a tripwire for a LATER change, and CLAUDE.md's guard
-    doctrine (search "load-bearing") requires proving a guard by breaking
-    the thing it protects and watching the guard fail -- which means
-    editing `folder_scanner.py`, even transiently. That mutate-observe-
-    restore proof is deliberately NOT done in this step: this step writes
-    tests only and touches no production file. The proof belongs to the
-    step that commits this test.
+    The property: a group the pre-BUG-018 fallback could identify must still
+    come out identified afterwards, even when the identifier it returns
+    names a DIFFERENT film -- WHICH film is exactly what BUG-018 is allowed
+    to change. Returning nothing at all, where the old code returned
+    something, is what would starve `manage.updateLibrary` into believing a
+    still-owned film is gone.
     """
 
-    def test_folder_scanner_has_no_diff_against_master(self):
-        # The base ref is resolved rather than named, because a bare
-        # `master` does NOT fall back to `origin/master`: git's
-        # disambiguation tries refs/remotes/<name>, which is
-        # refs/remotes/master, never refs/remotes/origin/master. A CI
-        # checkout has no local master branch, so `git diff master` exits
-        # 128 "bad revision" there while passing on a developer's machine.
-        # Measured on this branch: CI reported this guard as "folder_scanner
-        # differs from master" when git had not managed to look at all.
-        #
-        # That is the defect this guard exists to prevent, turned on itself:
-        # it could not tell "the protected file changed" from "I could not
-        # check". Those now have different outcomes and different messages.
-        base = None
-        for candidate in ('origin/master', 'master'):
-            probe = subprocess.run(
-                ['git', 'rev-parse', '--verify', '--quiet', candidate],
-                cwd=REPO_ROOT, env=sanitized_git_env(), capture_output=True,
-            )
-            if probe.returncode == 0:
-                base = candidate
-                break
+    @staticmethod
+    def _pre_bug_018_selection(candidates):
+        """The fallback's selection before BUG-018:
+        `fireEvent('movie.search', ..., limit=1)`, then `movie[0]`, nothing
+        else read from the result. Kept as a plain function of the
+        candidate list rather than imported from production, because
+        production is exactly what this guards -- importing the (now
+        fixed) selection would compare it with itself and could never
+        fail."""
+        if not candidates:
+            return None
+        return candidates[0].get('imdb')
 
-        assert base is not None, (
-            'neither origin/master nor master resolves in this checkout, so '
-            'this guard cannot compare folder_scanner.py against the base at '
-            'all. Failing rather than passing: an unverifiable data-loss '
-            'guard must not report success. Fetch the base ref (CI uses '
-            'fetch-depth: 0) and re-run.'
+    @pytest.fixture
+    def bug018_scanner(self, monkeypatch):
+        plugin = FolderScannerMixin()
+        monkeypatch.setattr(
+            folder_scanner_module, 'get_db',
+            lambda: (_ for _ in ()).throw(RuntimeError('no db in this test')),
+        )
+        monkeypatch.setattr(type(plugin), 'getCPImdb', lambda _s, _f: None, raising=False)
+        monkeypatch.setattr(folder_scanner_module, 'getImdb', lambda path, check_inside=False: None)
+        return plugin
+
+    @pytest.mark.parametrize('candidates', [
+        pytest.param(
+            [{'imdb': 'tt0120762', 'year': 1998}, {'imdb': 'tt3480796', 'year': 2020}],
+            id='remake_ordered_before_the_correct_film',
+        ),
+        pytest.param(
+            [{'imdb': 'tt0058331', 'year': 1975}],
+            id='single_candidate_whose_year_does_not_match',
+        ),
+        pytest.param(
+            [{'imdb': 'ttNOYEARFIELD'}],
+            id='candidate_with_no_year_field_at_all',
+        ),
+    ])
+    def test_a_group_the_old_code_could_identify_is_still_identified(
+        self, bug018_scanner, monkeypatch, candidates,
+    ):
+        name_year = {'name': 'Some Movie', 'year': 2020}
+        search_q = '%(name)s %(year)s' % name_year
+
+        def _fire(event, *args, **kwargs):
+            if event == 'movie.search':
+                return list(candidates) if kwargs.get('q') == search_q else []
+            return None
+
+        monkeypatch.setattr(folder_scanner_module, 'fireEvent', _fire)
+        monkeypatch.setattr(
+            type(bug018_scanner), 'getReleaseNameYear',
+            lambda _s, i, file_name=None: dict(name_year), raising=False,
         )
 
-        result = subprocess.run(
-            ['git', 'diff', '--quiet', base, '--',
-             'couchpotato/core/plugins/scanner/folder_scanner.py'],
-            cwd=REPO_ROOT,
-            env=sanitized_git_env(),
+        group = {
+            'files': {'movie': ['/dl/Some.Movie.2020.mkv'], 'nfo': []},
+            'identifiers': ['Some Movie 2020'],
+            'is_dvd': False,
+        }
+
+        pre = self._pre_bug_018_selection(candidates)
+        assert pre is not None, (
+            'test setup error: the reference selection found nothing in %r '
+            'to compare against' % candidates
         )
 
-        # `git diff --quiet` exits 0 for no difference and 1 for a
-        # difference. Anything else is git failing, which is not the same
-        # finding and must not be reported as one.
-        assert result.returncode in (0, 1), (
-            'git could not compare folder_scanner.py against %s (exit %d). '
-            'This is a broken check, not a detected change: fix the checkout '
-            'rather than reading this as a diff.' % (base, result.returncode)
-        )
+        result = bug018_scanner.determineMedia(group)
 
-        assert result.returncode == 0, (
-            'couchpotato/core/plugins/scanner/folder_scanner.py differs '
-            'from %s. This module is shared with manage.updateLibrary, '
-            'whose cleanup deletes any "done" movie absent from the scan '
-            'result -- the one irrecoverable loss AC-SIMP-2 exists to '
-            'prevent. Run `git diff %s -- '
-            'couchpotato/core/plugins/scanner/folder_scanner.py` to see '
-            'what changed.' % (base, base)
+        assert result.get('identifier') is not None, (
+            'the pre-BUG-018 selection would have identified this group as '
+            '%r, but the current fallback returned no identifier at all. '
+            'manage.updateLibrary deletes any "done" movie absent from the '
+            'scan result -- this is exactly the data-loss shape BUG-018\'s '
+            'first, withdrawn design built, and the empty-diff guard it '
+            'replaced would not have caught it once folder_scanner.py was '
+            'allowed to change at all.' % pre
         )
 
 

--- a/tests/unit/test_renamer_decision_memory.py
+++ b/tests/unit/test_renamer_decision_memory.py
@@ -230,6 +230,14 @@ class TestFolderScannerNeverReducesTheScanResult:
     to change. Returning nothing at all, where the old code returned
     something, is what would starve `manage.updateLibrary` into believing a
     still-owned film is gone.
+
+    This class drives the PRIMARY `movie.search` call site only. The
+    `name_year['other']` call site (reached only when the primary query
+    comes back empty) is exercised against the same candidate shapes,
+    parametrized over both sites, in
+    `tests/unit/test_scanner_search_year_disambiguation.py::TestTheInvariantNeverFewerIdentifiersThanBefore`
+    -- duplicating that parametrization here would test the same production
+    code path twice for no added protection.
     """
 
     @staticmethod
@@ -268,6 +276,24 @@ class TestFolderScannerNeverReducesTheScanResult:
         pytest.param(
             [{'imdb': 'ttNOYEARFIELD'}],
             id='candidate_with_no_year_field_at_all',
+        ),
+        # Round-one review of 0dc9e9a78 (FIX 5): every fixture above carries
+        # an `imdb` key on every candidate, so none of them could ever have
+        # caught FIX 1's defect -- a YEAR-MATCHING candidate with no id at
+        # all starving `imdb_id` even though an older, id-bearing candidate
+        # sat right next to it. Three shapes for "no id": the key absent,
+        # an empty string, and an explicit `None`.
+        pytest.param(
+            [{'imdb': 'ttOLD', 'year': 1998}, {'year': 2020}],
+            id='year_match_missing_imdb_key_entirely',
+        ),
+        pytest.param(
+            [{'imdb': 'ttOLD', 'year': 1998}, {'imdb': '', 'year': 2020}],
+            id='year_match_empty_imdb',
+        ),
+        pytest.param(
+            [{'imdb': 'ttOLD', 'year': 1998}, {'imdb': None, 'year': 2020}],
+            id='year_match_imdb_explicitly_none',
         ),
     ])
     def test_a_group_the_old_code_could_identify_is_still_identified(

--- a/tests/unit/test_renamer_decision_memory.py
+++ b/tests/unit/test_renamer_decision_memory.py
@@ -48,6 +48,7 @@ from couchpotato.core.plugins.renamer.replacement import (
 )
 import couchpotato.core.plugins.scanner.folder_scanner as folder_scanner_module
 from couchpotato.core.plugins.scanner.folder_scanner import FolderScannerMixin
+from tests.unit.bug018_selection_helper import pre_bug_018_selection
 
 
 @pytest.fixture(autouse=True)
@@ -240,18 +241,12 @@ class TestFolderScannerNeverReducesTheScanResult:
     code path twice for no added protection.
     """
 
-    @staticmethod
-    def _pre_bug_018_selection(candidates):
-        """The fallback's selection before BUG-018:
-        `fireEvent('movie.search', ..., limit=1)`, then `movie[0]`, nothing
-        else read from the result. Kept as a plain function of the
-        candidate list rather than imported from production, because
-        production is exactly what this guards -- importing the (now
-        fixed) selection would compare it with itself and could never
-        fail."""
-        if not candidates:
-            return None
-        return candidates[0].get('imdb')
+    # Round-two review of 0dc9e9a78 (FIX 5c): this used to be its own
+    # `_pre_bug_018_selection` copy-pasted from
+    # `test_scanner_search_year_disambiguation.py`. Shared in
+    # `bug018_selection_helper.py` instead -- two copies of one reference
+    # oracle is a drift hazard.
+    _pre_bug_018_selection = staticmethod(pre_bug_018_selection)
 
     @pytest.fixture
     def bug018_scanner(self, monkeypatch):

--- a/tests/unit/test_scanner_search_year_disambiguation.py
+++ b/tests/unit/test_scanner_search_year_disambiguation.py
@@ -191,6 +191,26 @@ MEASURED_CASES = [
         'tt6105098',
         id='lion_king_2019_over_1994_remake',
     ),
+    # Round-two review of BUG-018 (FIX 4): every case above puts the
+    # correct film no deeper than second place, so `SEARCH_YEAR_DISAMBIGUATION_LIMIT`
+    # could be lowered all the way to 2 and this suite would not notice --
+    # the constant's own comment claims headroom for candidates further
+    # down the list, and nothing was pinning that claim. Here the correct
+    # film sits fourth (index 3), behind three decoys that all carry the
+    # wrong year, so a limit below 4 truncates it out of the candidate list
+    # before the year preference ever sees it.
+    pytest.param(
+        {'name': 'Some Buried Sequel', 'year': 2020},
+        [
+            {'imdb': 'ttDECOY1', 'year': 2001},
+            {'imdb': 'ttDECOY2', 'year': 2005},
+            {'imdb': 'ttDECOY3', 'year': 2010},
+            {'imdb': 'ttCORRECT', 'year': 2020},
+            {'imdb': 'ttDECOY4', 'year': 2015},
+        ],
+        'ttCORRECT',
+        id='correct_film_buried_at_fourth_position',
+    ),
 ]
 
 
@@ -416,11 +436,17 @@ class TestTheSequelMergesStayUnfixed:
     """Recorded debt item 1 (spec): the two consecutive-year sequel pairs
     (Deathly Hallows Part 1/2, Mockingjay Part 1/2) that motivated round
     one's closest-wins attempt are NOT fixed by reverting to
-    first-within-tolerance. This test documents the known, accepted
-    limitation directly rather than leaving it undiscoverable -- if a
-    future change fixes this case, this test should be UPDATED to expect
-    the correct part, not deleted, since a passing test with the wrong
-    expectation is worse than an honest failing one.
+    first-within-tolerance.
+
+    Round-two review of BUG-018 suggested this read better as
+    `xfail(strict=True)` with the assertion written as the DESIRED answer,
+    so the accepted debt shows up in every run's summary line (as an
+    xfail) instead of hiding among the passes, and still fails loudly
+    (XPASS, which `strict=True` turns into a suite failure) the day someone
+    fixes it -- taken here, since the repo already uses the idiom four
+    times (`test_renamer_mover.py`, `test_operator_route_does_not_forge_its_own_baseline.py`)
+    and it gives this specific debt item better visibility for the same
+    assertion, with no change in what is actually verified.
 
     This is expected behaviour, not a regression: AC-DATA-2's safety
     property (never fewer identifiers than before) still holds -- the group
@@ -428,7 +454,17 @@ class TestTheSequelMergesStayUnfixed:
     pre-BUG-018 code would also have done had it seen Part 1 listed first.
     """
 
-    def test_deathly_hallows_part_2_is_still_filed_as_part_1_when_listed_first(
+    @pytest.mark.xfail(strict=True, reason=(
+        "BUG-018 spec, recorded debt item 1: first-within-tolerance still "
+        "files Part 2 under Part 1's identifier when the provider lists "
+        "Part 1 first (an honest off-by-one on the correct film is "
+        "indistinguishable from an exact-year decoy for the wrong one -- "
+        "see the spec for why closest-wins was tried and reverted). "
+        "strict=True: if this now XPASSes, the sequel-merge case has been "
+        "fixed and the spec's debt item 1 should be closed, not just this "
+        "test updated."
+    ))
+    def test_deathly_hallows_part_2_resolves_to_its_own_identifier_when_listed_first(
         self, scanner, monkeypatch,
     ):
         name_year = {'name': 'Harry Potter Deathly Hallows Part 2', 'year': 2011}
@@ -440,11 +476,13 @@ class TestTheSequelMergesStayUnfixed:
 
         result = scanner.determineMedia(_group())
 
-        assert result.get('identifier') == 'ttHP1', (
-            'this pins the KNOWN, ACCEPTED limitation recorded in the '
-            'spec\'s debt item 1 -- if this now returns \'ttHP2\', the '
-            'sequel-merge case has been fixed and this test should be '
-            'updated (not deleted) to say so, got %r' % result.get('identifier')
+        # Written as the DESIRED answer, not today's actual one (ttHP1).
+        assert result.get('identifier') == 'ttHP2', (
+            'Part 2 should resolve to its own identifier even when the '
+            'provider lists Part 1 first -- got %r. This is the accepted, '
+            'currently-unfixed limitation from the spec\'s debt item 1' % (
+                result.get('identifier'),
+            )
         )
 
 
@@ -603,6 +641,40 @@ class TestAMalformedFilenameDuringTheWarningDoesNotStarveIdentification:
             'candidate -- got %r' % result.get('identifier')
         )
 
+    def test_a_non_string_filename_is_never_logged_verbatim(
+        self, scanner, monkeypatch, caplog,
+    ):
+        """Round-two review of BUG-018 (FIX 5): the comment three lines
+        below the `except TypeError:` branch promises a basename only,
+        citing this project's no-private-paths-in-logs floor -- but the
+        branch itself fell back to `filename` unchanged, so a non-string
+        filename that happens to BE or CONTAIN a private path (a list, for
+        instance, is not str/bytes/PathLike either) was logged raw at
+        WARNING. Only reachable with a non-string filename, which cannot
+        happen today, but the guard should not defeat the promise it sits
+        next to."""
+        name_year = {'name': 'Some Movie', 'year': 2020}
+        candidates = [{'imdb': 'ttAAA', 'year': 1999}, {'imdb': 'ttBBB', 'year': 1950}]
+        _stub_for_site(monkeypatch, scanner, 'primary', name_year, candidates)
+
+        hostile_filename = ['/home/realuser/private/Some.Movie.2020.mkv']
+        group = _group(filename=hostile_filename)
+
+        with caplog.at_level(logging.WARNING):
+            scanner.determineMedia(group)
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, 'setup: expected the mismatched-guess warning to fire'
+        for message in warnings:
+            assert 'realuser' not in message and 'private' not in message, (
+                'the raw non-string filename value leaked into a WARNING log '
+                'line -- got %r' % message
+            )
+            assert 'list' in message, (
+                'expected the type name ("list") to stand in for the '
+                'unloggable filename -- got %r' % message
+            )
+
 
 class TestAHostileCandidateGetIsSkippedNotFatal:
     """FIX 4b (round-two review of 0dc9e9a78). `_imdb`/`_year` inside
@@ -693,10 +765,12 @@ class TestSearchTypePinnedRegardlessOfLimit:
             'cache key TMDB is queried under.' % calls[0].get('search_type')
         )
         assert calls[0].get('limit', 1) > 1, (
-            'the primary movie.search call asked for only %r result(s) -- '
-            'setting SEARCH_YEAR_DISAMBIGUATION_LIMIT back to 1 would make '
-            'this pass too, which is exactly how a full revert of the '
-            'production fix slipped past this suite unnoticed' % calls[0].get('limit')
+            'the primary movie.search call asked for only %r result(s), so '
+            'SEARCH_YEAR_DISAMBIGUATION_LIMIT has been reverted to 1 (or '
+            'never raised) -- the year-disambiguation fallback has nothing '
+            'to disambiguate between when the provider can only ever return '
+            'a single candidate, which is exactly the shape of the bug '
+            'BUG-018 fixed' % calls[0].get('limit')
         )
 
     def test_the_other_search_also_pins_search_type_to_phrase(self, scanner, monkeypatch):
@@ -726,9 +800,10 @@ class TestSearchTypePinnedRegardlessOfLimit:
             '"phrase" -- got %r' % calls[1].get('search_type')
         )
         assert calls[1].get('limit', 1) > 1, (
-            'the "other" movie.search call asked for only %r result(s) -- '
-            'setting SEARCH_YEAR_DISAMBIGUATION_LIMIT back to 1 would make '
-            'this pass too' % calls[1].get('limit')
+            'the "other" movie.search call asked for only %r result(s), so '
+            'SEARCH_YEAR_DISAMBIGUATION_LIMIT has been reverted to 1 (or '
+            'never raised) -- same defect as the primary search, one call '
+            'site later' % calls[1].get('limit')
         )
 
 

--- a/tests/unit/test_scanner_search_year_disambiguation.py
+++ b/tests/unit/test_scanner_search_year_disambiguation.py
@@ -35,6 +35,7 @@ gives: production events are never touched, only the two this fallback
 actually calls (`movie.search`, and `movie.info` on the fallback tail).
 """
 import logging
+import os
 
 import pytest
 
@@ -100,6 +101,51 @@ def _stub_name_year(monkeypatch, scanner_instance, name_year):
     )
 
 
+# There are TWO `movie.search` call sites in the fallback: the primary
+# query, always tried first, and a second one built from `name_year['other']`
+# -- reached only when the primary query returns nothing. FIX 5 (round-one
+# review of 0dc9e9a78): a candidate list can violate the safety invariant at
+# EITHER site, and until now only one ad-hoc test
+# (`test_the_second_other_search_gets_the_same_year_preference`, kept below
+# for the call-ORDER assertion it makes) drove the `other` site at all, and
+# it checked year preference only, not the "never fewer identifiers" safety
+# property. `_stub_for_site` lets every test below run unchanged against
+# either site.
+SEARCH_SITES = ['primary', 'other']
+
+
+def _stub_for_site(monkeypatch, scanner_instance, site, name_year, candidates):
+    """Wires `candidates` to be returned from whichever call site `site`
+    names, and stubs `getReleaseNameYear` to match. For `'other'`, the
+    primary query is made to return nothing (its own distinct query string,
+    so the fallback still reaches the `other` query) and `candidates` are
+    returned only from the `other` query -- the fallback's own
+    `parsed_year` for that branch is `name_year['other']['year']`, so
+    `name_year` here is treated as the `other` payload rather than the
+    primary one.
+    """
+    if site == 'primary':
+        search_q = '%(name)s %(year)s' % name_year
+        _stub_search(monkeypatch, {search_q: candidates})
+        _stub_name_year(monkeypatch, scanner_instance, name_year)
+        return
+    if site == 'other':
+        primary = dict(name_year)
+        # A distinct name so the primary and `other` queries never collide
+        # -- the fallback only tries `other` when the primary query string
+        # differs AND the primary search came back empty.
+        primary['name'] = name_year['name'] + ' Primary Only'
+        primary_q = '%(name)s %(year)s' % primary
+        other_q = '%(name)s %(year)s' % name_year
+        assert primary_q != other_q, 'test setup error: primary and other queries collided'
+        _stub_search(monkeypatch, {primary_q: [], other_q: candidates})
+        combined = dict(primary)
+        combined['other'] = dict(name_year)
+        _stub_name_year(monkeypatch, scanner_instance, combined)
+        return
+    raise ValueError('unknown site %r' % site)
+
+
 # The four production cases from the spec, each as (name_year, candidates,
 # expected_imdb) -- candidates are given in the buggy provider order (wrong
 # film first), so a test asserting `expected_imdb` fails today and passes
@@ -140,50 +186,56 @@ class TestTheYearMatchWinsOverPosition:
     RED today: the production fallback calls `movie.search(..., limit=1)`
     and takes `movie[0]` unconditionally, so it returns the WRONG (first)
     candidate for every one of these measured cases.
+
+    FIX 5: parametrized over `SEARCH_SITES` so both `movie.search` call
+    sites the fallback owns -- the primary query and the `name_year['other']`
+    query -- are driven through the same assertions, not just the primary
+    one.
     """
 
+    @pytest.mark.parametrize('site', SEARCH_SITES)
     @pytest.mark.parametrize('name_year, candidates, expected_imdb', MEASURED_CASES)
     def test_candidate_matching_the_parsed_year_wins_even_when_listed_second(
-        self, scanner, monkeypatch, name_year, candidates, expected_imdb,
+        self, scanner, monkeypatch, site, name_year, candidates, expected_imdb,
     ):
-        search_q = '%(name)s %(year)s' % name_year
-        _stub_search(monkeypatch, {search_q: candidates})
-        _stub_name_year(monkeypatch, scanner, name_year)
+        _stub_for_site(monkeypatch, scanner, site, name_year, candidates)
 
         result = scanner.determineMedia(_group())
 
         assert result.get('identifier') == expected_imdb, (
             'expected the candidate whose year matches the parsed year %r '
-            'to win regardless of position, got %r from candidates %r -- '
-            'this is the exact merge BUG-018 measured in production' % (
-                name_year['year'], result.get('identifier'), candidates,
+            'to win regardless of position, got %r from candidates %r at '
+            'the %s call site -- this is the exact merge BUG-018 measured '
+            'in production' % (
+                name_year['year'], result.get('identifier'), candidates, site,
             )
         )
 
-    def test_a_one_year_provider_discrepancy_still_matches(self, scanner, monkeypatch):
+    @pytest.mark.parametrize('site', SEARCH_SITES)
+    def test_a_one_year_provider_discrepancy_still_matches(self, scanner, monkeypatch, site):
         """Hazard 1: `getReleaseNameYear` parses a year from the filename,
         and a provider's release year can legitimately differ from that by
         one (region release dates, festival vs. wide release). Tolerance
         of exactly 1 is used -- not 0, which would treat every honestly
         off-by-one provider year as a non-match and always fall back to
         the first result; not more than 1, which starts risking exactly
-        the remake collisions this bug is about (the closest two of the
-        four measured remake pairs are still 7 years apart)."""
+        the remake collisions this bug is about (measured against the
+        spec's own seven merged records, the closest of the four remake
+        pairs is 20 years apart -- the binding constraint is the
+        consecutive-year SEQUEL pairs, at a gap of 1)."""
         name_year = {'name': 'Some Movie', 'year': 2020}
         candidates = [
             {'imdb': 'ttOLD', 'year': 1998},
             {'imdb': 'ttNEW', 'year': 2019},  # one year off the parsed 2020
         ]
-        search_q = '%(name)s %(year)s' % name_year
-        _stub_search(monkeypatch, {search_q: candidates})
-        _stub_name_year(monkeypatch, scanner, name_year)
+        _stub_for_site(monkeypatch, scanner, site, name_year, candidates)
 
         result = scanner.determineMedia(_group())
 
         assert result.get('identifier') == 'ttNEW', (
             'a candidate one year off the parsed year should still count '
             'as a match ahead of an unrelated candidate decades away; got '
-            '%r' % result.get('identifier')
+            '%r at the %s call site' % (result.get('identifier'), site)
         )
 
     def test_the_second_other_search_gets_the_same_year_preference(
@@ -220,6 +272,102 @@ class TestTheYearMatchWinsOverPosition:
         )
 
 
+class TestClosestYearWinsOverFirstWithinTolerance:
+    """FIX 3 (round-one review of 0dc9e9a78). Round one returned the FIRST
+    candidate within `SEARCH_YEAR_TOLERANCE`, not the CLOSEST one, so an
+    off-by-one candidate listed ahead of an exact match won. Two of the
+    seven merged records this bug is about are consecutive-year sequel
+    pairs (Deathly Hallows, Mockingjay), a gap of exactly 1 -- inside
+    tolerance -- so this is not a hypothetical: it is one plausible partial
+    cause of those two merges (see the spec's Recorded debt item 1).
+
+    RED against round one: each case here has an off-by-one candidate
+    listed BEFORE the exact match, so "first within tolerance" picks the
+    off-by-one one every time.
+    """
+
+    @pytest.mark.parametrize('site', SEARCH_SITES)
+    def test_deathly_hallows_part_2_is_not_filed_as_part_1(self, scanner, monkeypatch, site):
+        name_year = {'name': 'Harry Potter Deathly Hallows Part 2', 'year': 2011}
+        candidates = [
+            {'imdb': 'ttHP1', 'year': 2010},  # Part 1, one year off, listed first
+            {'imdb': 'ttHP2', 'year': 2011},  # Part 2, the exact match
+        ]
+        _stub_for_site(monkeypatch, scanner, site, name_year, candidates)
+
+        result = scanner.determineMedia(_group())
+
+        assert result.get('identifier') == 'ttHP2', (
+            'the file is Deathly Hallows Part 2 (2011); with Part 1 (2010, '
+            'one year off) listed first, "first within tolerance" would '
+            'pick Part 1 -- got %r at the %s call site' % (
+                result.get('identifier'), site,
+            )
+        )
+
+    @pytest.mark.parametrize('site', SEARCH_SITES)
+    def test_mockingjay_part_2_is_not_filed_as_part_1(self, scanner, monkeypatch, site):
+        name_year = {'name': 'Hunger Games Mockingjay Part 2', 'year': 2015}
+        candidates = [
+            {'imdb': 'ttMJ1', 'year': 2014},  # Part 1, one year off, listed first
+            {'imdb': 'ttMJ2', 'year': 2015},  # Part 2, the exact match
+        ]
+        _stub_for_site(monkeypatch, scanner, site, name_year, candidates)
+
+        result = scanner.determineMedia(_group())
+
+        assert result.get('identifier') == 'ttMJ2', (
+            'the file is Mockingjay Part 2 (2015); with Part 1 (2014, one '
+            'year off) listed first, "first within tolerance" would pick '
+            'Part 1 -- got %r at the %s call site' % (result.get('identifier'), site)
+        )
+
+    @pytest.mark.parametrize('site', SEARCH_SITES)
+    def test_an_exact_match_wins_over_an_earlier_listed_off_by_one(
+        self, scanner, monkeypatch, site,
+    ):
+        """The general case behind the two sequel-specific ones above: ANY
+        off-by-one candidate listed before an exact match must lose to the
+        exact match, not just the two named sequel pairs."""
+        name_year = {'name': 'Some Movie', 'year': 2020}
+        candidates = [
+            {'imdb': 'ttOFFBYONE', 'year': 2019},
+            {'imdb': 'ttEXACT', 'year': 2020},
+        ]
+        _stub_for_site(monkeypatch, scanner, site, name_year, candidates)
+
+        result = scanner.determineMedia(_group())
+
+        assert result.get('identifier') == 'ttEXACT', (
+            'an exact year match listed SECOND lost to an off-by-one '
+            'candidate listed first -- got %r at the %s call site' % (
+                result.get('identifier'), site,
+            )
+        )
+
+    @pytest.mark.parametrize('site', SEARCH_SITES)
+    def test_a_tie_in_year_distance_keeps_the_earlier_listed_candidate(
+        self, scanner, monkeypatch, site,
+    ):
+        """The docstring's stated tie-break: when two candidates are
+        EQUALLY close (both an exact match, or both off by the same amount),
+        the earlier-listed one wins -- this is what "closest, not first"
+        must NOT change relative to today's behaviour."""
+        name_year = {'name': 'Some Movie', 'year': 2020}
+        candidates = [
+            {'imdb': 'ttFIRST', 'year': 2020},
+            {'imdb': 'ttSECOND', 'year': 2020},
+        ]
+        _stub_for_site(monkeypatch, scanner, site, name_year, candidates)
+
+        result = scanner.determineMedia(_group())
+
+        assert result.get('identifier') == 'ttFIRST', (
+            'two equally-close candidates should keep the earlier-listed '
+            'one on a tie -- got %r at the %s call site' % (result.get('identifier'), site)
+        )
+
+
 class TestNoMatchFallsBackToTheFirstCandidate:
     """AC-DATA-2, the safety property that replaced the withdrawn refusal
     design. A candidate list where NOTHING matches the parsed year must
@@ -227,24 +375,120 @@ class TestNoMatchFallsBackToTheFirstCandidate:
     never None. This is expected to hold both before and after the fix (the
     current code already always takes the first result); its job is to
     catch a FUTURE regression back toward refusal, not to be RED today.
+
+    FIX 5: parametrized over both call sites, per `SEARCH_SITES`.
     """
 
-    def test_takes_the_first_candidate_when_no_year_matches(self, scanner, monkeypatch):
+    @pytest.mark.parametrize('site', SEARCH_SITES)
+    def test_takes_the_first_candidate_when_no_year_matches(self, scanner, monkeypatch, site):
         name_year = {'name': 'Some Movie', 'year': 2020}
         candidates = [{'imdb': 'ttAAA', 'year': 1999}, {'imdb': 'ttBBB', 'year': 1950}]
-        search_q = '%(name)s %(year)s' % name_year
-        _stub_search(monkeypatch, {search_q: candidates})
-        _stub_name_year(monkeypatch, scanner, name_year)
+        _stub_for_site(monkeypatch, scanner, site, name_year, candidates)
 
         result = scanner.determineMedia(_group())
 
         assert result.get('identifier') == 'ttAAA', (
             'must return the FIRST candidate exactly as the pre-BUG-018 '
-            'code did when no candidate matches the parsed year -- '
-            'refusing to guess here is the data-loss design BUG-018 '
-            'withdrew, since a refused file is invisible to '
+            'code did when no candidate matches the parsed year at the %s '
+            'call site -- refusing to guess here is the data-loss design '
+            'BUG-018 withdrew, since a refused file is invisible to '
             'manage.updateLibrary\'s "still present" check and would be '
-            'deleted on the next scan'
+            'deleted on the next scan' % site
+        )
+
+
+class TestAMalformedSearchResultDoesNotAbortIdentification:
+    """FIX 2 (round-one review of 0dc9e9a78). The fifth fallback was the
+    only one of the five identification routes with no exception guard
+    around its search: `candidate.get('year')` sat ABOVE the `try`, and the
+    warning's `[c.get('year') for c in candidates]` had no guard either. Not
+    reachable with the single shipped search provider today (it always
+    returns dicts) -- reachable the moment a second provider is registered,
+    or a provider bug returns something unexpected. Left unguarded, this
+    raises out of `determineMedia`, out of `scan()`, mid-directory:
+    `fireEvent` swallows it, but `added_identifiers` is then left PARTIAL
+    and non-empty, so `manage.updateLibrary`'s cleanup runs against a
+    truncated scan and deletes every 'done' movie the scan had not reached
+    yet.
+    """
+
+    def test_a_non_dict_candidate_among_dict_candidates_is_skipped_not_fatal(
+        self, scanner, monkeypatch,
+    ):
+        name_year = {'name': 'Some Movie', 'year': 2020}
+        candidates = ['a malformed string result', {'imdb': 'ttGOOD', 'year': 2020}]
+        _stub_for_site(monkeypatch, scanner, 'primary', name_year, candidates)
+
+        result = scanner.determineMedia(_group())
+
+        assert result.get('identifier') == 'ttGOOD', (
+            'a non-dict entry among otherwise-good candidates must not '
+            'prevent the good one from being chosen -- got %r' % result.get('identifier')
+        )
+
+    def test_a_non_list_search_result_does_not_raise_and_moves_on(
+        self, scanner, monkeypatch,
+    ):
+        """The search event itself misbehaving (returns something with no
+        `len()`) must not raise out of `determineMedia` -- it must be
+        treated as this identifier failing to resolve, exactly like a
+        provider returning nothing."""
+        def _fire(event, *args, **kwargs):
+            if event == 'movie.search':
+                return 42  # not list-like: len(42) raises TypeError
+            return None
+
+        monkeypatch.setattr(folder_scanner_module, 'fireEvent', _fire)
+        _stub_name_year(monkeypatch, scanner, {'name': 'Some Movie', 'year': 2020})
+
+        result = scanner.determineMedia(_group())  # must not raise
+
+        assert result == {}, (
+            'a malformed (non-list) search result should leave this '
+            'identifier unresolved, not raise -- got %r' % result
+        )
+
+    def test_a_later_identifier_still_resolves_after_an_earlier_one_raises(
+        self, scanner, monkeypatch,
+    ):
+        """The scan-level stakes: `group['identifiers']` can hold several
+        candidate strings, tried in order until one resolves. A malformed
+        result for the FIRST identifier must not stop the loop from trying
+        the second -- an uncaught exception here would raise out of
+        `determineMedia` entirely, leaving the group unidentified even
+        though a later identifier could have resolved it."""
+        calls = []
+
+        def _fire(event, *args, **kwargs):
+            if event == 'movie.search':
+                calls.append(kwargs.get('q'))
+                if kwargs.get('q') == 'Bad Movie 2020':
+                    return 42  # malformed: raises inside determineMedia
+                if kwargs.get('q') == 'Good Movie 2020':
+                    return [{'imdb': 'ttGOOD', 'year': 2020}]
+            return []
+
+        monkeypatch.setattr(folder_scanner_module, 'fireEvent', _fire)
+
+        name_years = {
+            'Bad Movie Identifier': {'name': 'Bad Movie', 'year': 2020},
+            'Good Movie Identifier': {'name': 'Good Movie', 'year': 2020},
+        }
+        monkeypatch.setattr(
+            type(scanner), 'getReleaseNameYear',
+            lambda _s, identifier, file_name=None: dict(name_years[identifier]),
+            raising=False,
+        )
+
+        group = _group(identifiers=['Bad Movie Identifier', 'Good Movie Identifier'])
+        result = scanner.determineMedia(group)
+
+        assert calls == ['Bad Movie 2020', 'Good Movie 2020'], (
+            'setup: expected both identifiers to be tried in order, got %r' % calls
+        )
+        assert result.get('identifier') == 'ttGOOD', (
+            'the first identifier\'s malformed search result stopped the '
+            'loop from trying the second, resolvable one -- got %r' % result.get('identifier')
         )
 
 
@@ -265,6 +509,61 @@ class TestUnknownParsedYearBehaviourIsUnchanged:
         assert scanner  # keep the fixture referenced for readability
 
 
+class TestSearchTypePinnedRegardlessOfLimit:
+    """FIX 6 (round-one review of 0dc9e9a78). `TheMovieDb.search` flips
+    `search_type` from `phrase` to `ngram` purely as a side effect of
+    `limit > 1` -- and `search_type` is part of the request URL, therefore
+    the cache key, and TMDB's own `ngram` mode fans out into far more
+    per-result detail requests. Raising `SEARCH_YEAR_DISAMBIGUATION_LIMIT`
+    from 1 to 5 (BUG-018's own fix) silently asked the provider a DIFFERENT
+    question. `search_type='phrase'` must reach `fireEvent` on both call
+    sites regardless of the limit, so raising or lowering the limit later
+    can never repeat this."""
+
+    def test_the_primary_search_pins_search_type_to_phrase(self, scanner, monkeypatch):
+        name_year = {'name': 'Some Movie', 'year': 2020}
+        candidates = [{'imdb': 'ttAAA', 'year': 2020}]
+        calls = _stub_search(monkeypatch, {'%(name)s %(year)s' % name_year: candidates})
+        _stub_name_year(monkeypatch, scanner, name_year)
+
+        scanner.determineMedia(_group())
+
+        assert calls, 'setup: the primary search never fired'
+        assert calls[0].get('search_type') == 'phrase', (
+            'the primary movie.search call did not pin search_type to '
+            '"phrase" -- got %r. Without this, raising '
+            'SEARCH_YEAR_DISAMBIGUATION_LIMIT above 1 silently flips TMDB '
+            'from an exact to a fuzzy search.' % calls[0].get('search_type')
+        )
+
+    def test_the_other_search_also_pins_search_type_to_phrase(self, scanner, monkeypatch):
+        name_year = {'name': 'Some Movie', 'year': 2020}
+        candidates = [{'imdb': 'ttAAA', 'year': 2020}]
+        _stub_for_site(monkeypatch, scanner, 'other', name_year, candidates)
+        # `_stub_for_site('other', ...)` replaces `fireEvent` again, so
+        # re-wrap it here to also record the calls it makes.
+        calls = []
+        real_fire = folder_scanner_module.fireEvent
+
+        def _recording_fire(event, *args, **kwargs):
+            if event == 'movie.search':
+                calls.append(kwargs)
+            return real_fire(event, *args, **kwargs)
+
+        monkeypatch.setattr(folder_scanner_module, 'fireEvent', _recording_fire)
+
+        scanner.determineMedia(_group())
+
+        assert len(calls) == 2, (
+            'setup: expected exactly two movie.search calls (primary then '
+            'other), got %r' % calls
+        )
+        assert calls[1].get('search_type') == 'phrase', (
+            'the "other" movie.search call did not pin search_type to '
+            '"phrase" -- got %r' % calls[1].get('search_type')
+        )
+
+
 class TestAMismatchedGuessIsLoggedAtWarning:
     """AC-OPS-4. Taking the first candidate when nothing matches must be
     visible to the operator: a bad guess this way is not destructive (the
@@ -272,48 +571,61 @@ class TestAMismatchedGuessIsLoggedAtWarning:
     today. RED today: the current code logs nothing but a debug line with
     the identifier string, naming neither the parsed year nor the years on
     offer.
+
+    FIX 7 (round-one review of 0dc9e9a78): the filename is logged as a
+    BASENAME, not the full path -- this is the one line in the fallback
+    that reaches WARNING, and the project's security floor is no private
+    filesystem paths in logs. The basename still lets an operator find the
+    release; the download folder structure around it does not.
+
+    FIX 5: parametrized over both call sites, per `SEARCH_SITES`.
     """
 
+    @pytest.mark.parametrize('site', SEARCH_SITES)
     def test_warns_with_filename_parsed_year_and_offered_years(
-        self, scanner, monkeypatch, caplog,
+        self, scanner, monkeypatch, caplog, site,
     ):
         name_year = {'name': 'Some Movie', 'year': 2020}
         candidates = [{'imdb': 'ttAAA', 'year': 1999}, {'imdb': 'ttBBB', 'year': 1950}]
-        search_q = '%(name)s %(year)s' % name_year
-        _stub_search(monkeypatch, {search_q: candidates})
-        _stub_name_year(monkeypatch, scanner, name_year)
+        _stub_for_site(monkeypatch, scanner, site, name_year, candidates)
 
         with caplog.at_level(logging.WARNING):
             scanner.determineMedia(_group(filename=DEFAULT_FILENAME))
 
         warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        basename = os.path.basename(DEFAULT_FILENAME)
         assert any(
-            DEFAULT_FILENAME in w and '2020' in w and '1999' in w and '1950' in w
+            basename in w and '2020' in w and '1999' in w and '1950' in w
             for w in warnings
         ), (
-            'expected a warning naming the filename, the parsed year (2020) '
-            'and the years offered (1999, 1950) when a mismatched guess was '
-            'taken; got warnings: %r' % warnings
+            'expected a warning naming the filename\'s basename, the parsed '
+            'year (2020) and the years offered (1999, 1950) when a '
+            'mismatched guess was taken at the %s call site; got warnings: '
+            '%r' % (site, warnings)
+        )
+        assert not any(os.path.dirname(DEFAULT_FILENAME) in w for w in warnings), (
+            'the warning still carries the download folder path (%r) -- '
+            'FIX 7 redacts the directory, keeping only the basename, so '
+            'this must never appear: %r' % (os.path.dirname(DEFAULT_FILENAME), warnings)
         )
 
-    def test_a_matching_candidate_does_not_warn(self, scanner, monkeypatch, caplog):
+    @pytest.mark.parametrize('site', SEARCH_SITES)
+    def test_a_matching_candidate_does_not_warn(self, scanner, monkeypatch, caplog, site):
         """Negative control: the warning is for bad guesses specifically,
         not for every successful search -- otherwise AC-OPS-4 would be
         satisfied by warning unconditionally, which teaches operators to
         ignore it."""
         name_year = {'name': 'Mulan', 'year': 2020}
         candidates = [{'imdb': 'tt0120762', 'year': 1998}, {'imdb': 'tt3480796', 'year': 2020}]
-        search_q = '%(name)s %(year)s' % name_year
-        _stub_search(monkeypatch, {search_q: candidates})
-        _stub_name_year(monkeypatch, scanner, name_year)
+        _stub_for_site(monkeypatch, scanner, site, name_year, candidates)
 
         with caplog.at_level(logging.WARNING):
             scanner.determineMedia(_group())
 
         warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
         assert warnings == [], (
-            'a matching candidate was found (tt3480796, year 2020) yet a '
-            'warning fired anyway: %r' % warnings
+            'a matching candidate was found (tt3480796, year 2020) at the '
+            '%s call site yet a warning fired anyway: %r' % (site, warnings)
         )
 
 
@@ -336,13 +648,24 @@ class TestTheInvariantNeverFewerIdentifiersThanBefore:
     that wherever the old selection found an id, the new code finds one too
     -- not necessarily the SAME one, which is the entire point of AC-DATA-1.
 
-    Covers the four measured cases plus the three edge shapes the spec
-    names explicitly: a candidate missing its year field, a candidate whose
-    year is explicitly `None`, and an empty result set. A fifth case (the
-    parsed year itself being unknown) is proven separately below, since
-    there the OLD selection is not "call search and take movie[0]" at all
-    -- no search happens on either side of the fix, so there is nothing to
-    drive through `_pre_bug_018_selection`.
+    Covers the four measured cases, the three edge shapes the spec names
+    explicitly (a candidate missing its year field, a candidate whose year
+    is explicitly `None`, and an empty result set), and three more added by
+    round-one review of 0dc9e9a78 (FIX 1 / FIX 5): a YEAR-MATCHING candidate
+    that carries no id at all, an empty id, or an explicit `imdb: None`.
+    Every one of the original three fixtures in the freeze this class
+    replaces (`TestFolderScannerNeverReducesTheScanResult`,
+    `test_renamer_decision_memory.py`) carried an `imdb` key on every
+    candidate, so none of them could ever have caught FIX 1's defect -- a
+    year match with no id STARVING `imdb_id` even though an older,
+    id-bearing candidate was sitting right next to it in the same list. A
+    fifth case (the parsed year itself being unknown) is proven separately
+    below, since there the OLD selection is not "call search and take
+    movie[0]" at all -- no search happens on either side of the fix, so
+    there is nothing to drive through `_pre_bug_018_selection`.
+
+    FIX 5: also parametrized over both `movie.search` call sites, per
+    `SEARCH_SITES` -- previously only the primary site was driven here.
     """
 
     CANDIDATE_CASES = [
@@ -374,14 +697,25 @@ class TestTheInvariantNeverFewerIdentifiersThanBefore:
             [{'imdb': 'ttNULLYEAR', 'year': None}],
             id='null_year_candidate_explicit_none',
         ),
+        pytest.param(
+            [{'imdb': 'ttOLD', 'year': 1998}, {'year': 2020}],
+            id='year_match_missing_imdb_key_entirely',
+        ),
+        pytest.param(
+            [{'imdb': 'ttOLD', 'year': 1998}, {'imdb': '', 'year': 2020}],
+            id='year_match_empty_imdb',
+        ),
+        pytest.param(
+            [{'imdb': 'ttOLD', 'year': 1998}, {'imdb': None, 'year': 2020}],
+            id='year_match_imdb_explicitly_none',
+        ),
     ]
 
+    @pytest.mark.parametrize('site', SEARCH_SITES)
     @pytest.mark.parametrize('candidates', CANDIDATE_CASES)
-    def test_an_id_the_old_code_found_is_still_found(self, scanner, monkeypatch, candidates):
+    def test_an_id_the_old_code_found_is_still_found(self, scanner, monkeypatch, candidates, site):
         name_year = {'name': 'Some Movie', 'year': 2020}
-        search_q = '%(name)s %(year)s' % name_year
-        _stub_search(monkeypatch, {search_q: candidates})
-        _stub_name_year(monkeypatch, scanner, name_year)
+        _stub_for_site(monkeypatch, scanner, site, name_year, candidates)
 
         pre = _pre_bug_018_selection(candidates)
         assert pre is not None, (
@@ -393,23 +727,23 @@ class TestTheInvariantNeverFewerIdentifiersThanBefore:
         post = result.get('identifier')
 
         assert post is not None, (
-            'the pre-BUG-018 selection returned %r for candidates %r, but '
-            'the changed code returned no identifier at all. This is the '
-            'exact data-loss shape BUG-018\'s withdrawn first design '
-            'built: manage.updateLibrary treats "no identifier" as "movie '
-            'gone" and deletes it on the next scan.' % (pre, candidates)
+            'the pre-BUG-018 selection returned %r for candidates %r at '
+            'the %s call site, but the changed code returned no identifier '
+            'at all. This is the exact data-loss shape BUG-018\'s withdrawn '
+            'first design built: manage.updateLibrary treats "no '
+            'identifier" as "movie gone" and deletes it on the next scan.'
+            % (pre, candidates, site)
         )
 
-    def test_empty_results_produce_no_identifier_on_either_side(self, scanner, monkeypatch):
+    @pytest.mark.parametrize('site', SEARCH_SITES)
+    def test_empty_results_produce_no_identifier_on_either_side(self, scanner, monkeypatch, site):
         """Not a regression -- included so the parametrized cases above are
         not vacuously satisfied only because every fixture happens to be
         non-empty. The pre-BUG-018 selection also returns nothing when the
         provider returns nothing, so both sides agreeing on None here is
         correct, not a violation of the invariant."""
         name_year = {'name': 'Some Movie', 'year': 2020}
-        search_q = '%(name)s %(year)s' % name_year
-        _stub_search(monkeypatch, {search_q: []})
-        _stub_name_year(monkeypatch, scanner, name_year)
+        _stub_for_site(monkeypatch, scanner, site, name_year, [])
 
         assert _pre_bug_018_selection([]) is None
 

--- a/tests/unit/test_scanner_search_year_disambiguation.py
+++ b/tests/unit/test_scanner_search_year_disambiguation.py
@@ -41,6 +41,7 @@ import pytest
 
 import couchpotato.core.plugins.scanner.folder_scanner as folder_scanner_module
 from couchpotato.core.plugins.scanner.folder_scanner import FolderScannerMixin
+from tests.unit.bug018_selection_helper import pre_bug_018_selection as _pre_bug_018_selection
 
 DEFAULT_FILENAME = '/dl/Some.Movie.2020.mkv'
 DEFAULT_IDENTIFIER = 'Some Movie 2020'
@@ -80,13 +81,28 @@ def _stub_search(monkeypatch, results_by_query):
     Every call is recorded so tests can assert on how many searches fired
     and with which queries -- needed for the hazard-3 fallback-to-`other`
     cases below.
+
+    Round-two review of 0dc9e9a78 (FIX 2): the real provider truncates to
+    `limit`. This stub used to ignore `limit` entirely and hand back the
+    whole configured list regardless -- which meant setting
+    `SEARCH_YEAR_DISAMBIGUATION_LIMIT` back to 1 (a full revert of the fix
+    in production, since a limit of 1 means the provider itself never
+    returns a second candidate for the year preference to choose between)
+    left the ENTIRE suite green, because no fixture here ever depended on
+    getting more than one result back. Honouring `limit` here makes every
+    case that relies on seeing a second candidate genuinely depend on the
+    limit the production code asks for.
     """
     calls = []
 
     def _fire(event, *args, **kwargs):
         if event == 'movie.search':
             calls.append(kwargs)
-            return list(results_by_query.get(kwargs.get('q'), []))
+            results = list(results_by_query.get(kwargs.get('q'), []))
+            limit = kwargs.get('limit')
+            if limit is not None:
+                results = results[:limit]
+            return results
         return None
 
     monkeypatch.setattr(folder_scanner_module, 'fireEvent', _fire)
@@ -272,63 +288,91 @@ class TestTheYearMatchWinsOverPosition:
         )
 
 
-class TestClosestYearWinsOverFirstWithinTolerance:
-    """FIX 3 (round-one review of 0dc9e9a78). Round one returned the FIRST
-    candidate within `SEARCH_YEAR_TOLERANCE`, not the CLOSEST one, so an
-    off-by-one candidate listed ahead of an exact match won. Two of the
-    seven merged records this bug is about are consecutive-year sequel
-    pairs (Deathly Hallows, Mockingjay), a gap of exactly 1 -- inside
-    tolerance -- so this is not a hypothetical: it is one plausible partial
-    cause of those two merges (see the spec's Recorded debt item 1).
+class TestFirstWithinToleranceWinsOverAnExactMatchListedSecond:
+    """FIX 1, round two of BUG-018's review (reverts round one's own FIX 3).
 
-    RED against round one: each case here has an off-by-one candidate
-    listed BEFORE the exact match, so "first within tolerance" picks the
-    off-by-one one every time.
+    Round one changed the selection from "first candidate within
+    `SEARCH_YEAR_TOLERANCE`" to "closest candidate within tolerance", to try
+    to close the two consecutive-year sequel merges recorded as debt (see
+    the spec's Recorded debt item 1: Deathly Hallows Part 1/2, Mockingjay
+    Part 1/2, a gap of exactly 1). Measured live against the real provider,
+    that traded a smaller bug for a bigger one: `SEARCH_YEAR_DISAMBIGUATION_LIMIT`'s
+    query sends `year=<parsed year>`, so the result set is routinely stuffed
+    with candidates carrying the EXACT parsed year -- and an honest
+    one-year discrepancy between a filename and its provider record is
+    exactly the case `SEARCH_YEAR_TOLERANCE` exists to absorb, not a rare
+    edge. Three cases measured live 2026-09-06 (a December release ripped
+    the following January carries the following year in its filename,
+    which is common):
+
+        search "Wicked 2025"     -> 0. Wicked (2024) CORRECT   1. Wicked: For Good (2025)
+        search "Nosferatu 2025"  -> 0. Nosferatu (2024) CORRECT 1. Nosferatu (2025)
+        search "Anora 2025"      -> 0. Anora (2024) CORRECT     1. Anora: Stripped Down (2025)
+
+    Under closest-wins the exact-year decoy at position 1 beats the correct
+    film at position 0 in all three -- the tolerance is defeated in exactly
+    the case it was added for. Reverted to first-within-tolerance, which
+    gets all three right, at the acknowledged cost that the two
+    consecutive-year sequel merges closest-wins was meant to fix stay
+    UNFIXED whenever the provider lists the earlier part first. RED against
+    round one's closest-wins: each case here has an EXACT match listed
+    SECOND, which closest-wins would prefer over the off-by-one candidate
+    listed first.
     """
 
     @pytest.mark.parametrize('site', SEARCH_SITES)
-    def test_deathly_hallows_part_2_is_not_filed_as_part_1(self, scanner, monkeypatch, site):
-        name_year = {'name': 'Harry Potter Deathly Hallows Part 2', 'year': 2011}
-        candidates = [
-            {'imdb': 'ttHP1', 'year': 2010},  # Part 1, one year off, listed first
-            {'imdb': 'ttHP2', 'year': 2011},  # Part 2, the exact match
-        ]
+    @pytest.mark.parametrize('name_year, candidates, expected_imdb', [
+        pytest.param(
+            {'name': 'Wicked', 'year': 2025},
+            [
+                {'imdb': 'ttWICKED2024', 'year': 2024},  # correct, one year off, listed first
+                {'imdb': 'ttWICKED2025', 'year': 2025},  # decoy, exact parsed year
+            ],
+            'ttWICKED2024',
+            id='wicked_2024_correct_over_2025_exact_year_decoy',
+        ),
+        pytest.param(
+            {'name': 'Nosferatu', 'year': 2025},
+            [
+                {'imdb': 'ttNOSFERATU2024', 'year': 2024},
+                {'imdb': 'ttNOSFERATU2025', 'year': 2025},
+            ],
+            'ttNOSFERATU2024',
+            id='nosferatu_2024_correct_over_2025_exact_year_decoy',
+        ),
+        pytest.param(
+            {'name': 'Anora', 'year': 2025},
+            [
+                {'imdb': 'ttANORA2024', 'year': 2024},
+                {'imdb': 'ttANORA2025', 'year': 2025},
+            ],
+            'ttANORA2024',
+            id='anora_2024_correct_over_2025_exact_year_decoy',
+        ),
+    ])
+    def test_the_correct_off_by_one_film_beats_an_exact_year_decoy_listed_second(
+        self, scanner, monkeypatch, site, name_year, candidates, expected_imdb,
+    ):
         _stub_for_site(monkeypatch, scanner, site, name_year, candidates)
 
         result = scanner.determineMedia(_group())
 
-        assert result.get('identifier') == 'ttHP2', (
-            'the file is Deathly Hallows Part 2 (2011); with Part 1 (2010, '
-            'one year off) listed first, "first within tolerance" would '
-            'pick Part 1 -- got %r at the %s call site' % (
-                result.get('identifier'), site,
-            )
+        assert result.get('identifier') == expected_imdb, (
+            'the correct film, one year off the parsed year and listed '
+            'FIRST, lost to an exact-parsed-year decoy listed second -- got '
+            '%r at the %s call site. This is closest-wins coming back: it '
+            'defeats SEARCH_YEAR_TOLERANCE in exactly the case it exists '
+            'for.' % (result.get('identifier'), site)
         )
 
     @pytest.mark.parametrize('site', SEARCH_SITES)
-    def test_mockingjay_part_2_is_not_filed_as_part_1(self, scanner, monkeypatch, site):
-        name_year = {'name': 'Hunger Games Mockingjay Part 2', 'year': 2015}
-        candidates = [
-            {'imdb': 'ttMJ1', 'year': 2014},  # Part 1, one year off, listed first
-            {'imdb': 'ttMJ2', 'year': 2015},  # Part 2, the exact match
-        ]
-        _stub_for_site(monkeypatch, scanner, site, name_year, candidates)
-
-        result = scanner.determineMedia(_group())
-
-        assert result.get('identifier') == 'ttMJ2', (
-            'the file is Mockingjay Part 2 (2015); with Part 1 (2014, one '
-            'year off) listed first, "first within tolerance" would pick '
-            'Part 1 -- got %r at the %s call site' % (result.get('identifier'), site)
-        )
-
-    @pytest.mark.parametrize('site', SEARCH_SITES)
-    def test_an_exact_match_wins_over_an_earlier_listed_off_by_one(
+    def test_an_off_by_one_candidate_wins_over_an_exact_match_listed_second(
         self, scanner, monkeypatch, site,
     ):
-        """The general case behind the two sequel-specific ones above: ANY
-        off-by-one candidate listed before an exact match must lose to the
-        exact match, not just the two named sequel pairs."""
+        """The general case behind the three measured ones above: ANY
+        off-by-one candidate listed before an exact match must win, not
+        just the three named productions -- first-within-tolerance, not
+        closest-within-tolerance."""
         name_year = {'name': 'Some Movie', 'year': 2020}
         candidates = [
             {'imdb': 'ttOFFBYONE', 'year': 2019},
@@ -338,21 +382,21 @@ class TestClosestYearWinsOverFirstWithinTolerance:
 
         result = scanner.determineMedia(_group())
 
-        assert result.get('identifier') == 'ttEXACT', (
-            'an exact year match listed SECOND lost to an off-by-one '
-            'candidate listed first -- got %r at the %s call site' % (
-                result.get('identifier'), site,
-            )
+        assert result.get('identifier') == 'ttOFFBYONE', (
+            'an off-by-one candidate listed FIRST lost to an exact year '
+            'match listed second -- got %r at the %s call site. '
+            'First-within-tolerance must take the first in-tolerance '
+            'candidate, not the closest one.' % (result.get('identifier'), site)
         )
 
     @pytest.mark.parametrize('site', SEARCH_SITES)
     def test_a_tie_in_year_distance_keeps_the_earlier_listed_candidate(
         self, scanner, monkeypatch, site,
     ):
-        """The docstring's stated tie-break: when two candidates are
-        EQUALLY close (both an exact match, or both off by the same amount),
-        the earlier-listed one wins -- this is what "closest, not first"
-        must NOT change relative to today's behaviour."""
+        """Two candidates equally close to the parsed year (here, both an
+        exact match) must resolve to the earlier-listed one -- true of
+        first-within-tolerance by construction, since it returns as soon as
+        it finds an in-tolerance candidate and never looks further."""
         name_year = {'name': 'Some Movie', 'year': 2020}
         candidates = [
             {'imdb': 'ttFIRST', 'year': 2020},
@@ -364,7 +408,43 @@ class TestClosestYearWinsOverFirstWithinTolerance:
 
         assert result.get('identifier') == 'ttFIRST', (
             'two equally-close candidates should keep the earlier-listed '
-            'one on a tie -- got %r at the %s call site' % (result.get('identifier'), site)
+            'one -- got %r at the %s call site' % (result.get('identifier'), site)
+        )
+
+
+class TestTheSequelMergesStayUnfixed:
+    """Recorded debt item 1 (spec): the two consecutive-year sequel pairs
+    (Deathly Hallows Part 1/2, Mockingjay Part 1/2) that motivated round
+    one's closest-wins attempt are NOT fixed by reverting to
+    first-within-tolerance. This test documents the known, accepted
+    limitation directly rather than leaving it undiscoverable -- if a
+    future change fixes this case, this test should be UPDATED to expect
+    the correct part, not deleted, since a passing test with the wrong
+    expectation is worse than an honest failing one.
+
+    This is expected behaviour, not a regression: AC-DATA-2's safety
+    property (never fewer identifiers than before) still holds -- the group
+    IS identified, just as the wrong half of the duology, exactly as the
+    pre-BUG-018 code would also have done had it seen Part 1 listed first.
+    """
+
+    def test_deathly_hallows_part_2_is_still_filed_as_part_1_when_listed_first(
+        self, scanner, monkeypatch,
+    ):
+        name_year = {'name': 'Harry Potter Deathly Hallows Part 2', 'year': 2011}
+        candidates = [
+            {'imdb': 'ttHP1', 'year': 2010},  # Part 1, one year off, listed first
+            {'imdb': 'ttHP2', 'year': 2011},  # Part 2, the exact match
+        ]
+        _stub_for_site(monkeypatch, scanner, 'primary', name_year, candidates)
+
+        result = scanner.determineMedia(_group())
+
+        assert result.get('identifier') == 'ttHP1', (
+            'this pins the KNOWN, ACCEPTED limitation recorded in the '
+            'spec\'s debt item 1 -- if this now returns \'ttHP2\', the '
+            'sequel-merge case has been fixed and this test should be '
+            'updated (not deleted) to say so, got %r' % result.get('identifier')
         )
 
 
@@ -492,6 +572,71 @@ class TestAMalformedSearchResultDoesNotAbortIdentification:
         )
 
 
+class TestAMalformedFilenameDuringTheWarningDoesNotStarveIdentification:
+    """FIX 4a (round-two review of 0dc9e9a78). `pickSearchYearMatch`'s
+    mismatched-guess warning calls `os.path.basename(filename)`, which
+    raises TypeError for a `filename` that is not str/bytes/os.PathLike.
+    That call sat OUTSIDE any guard of its own and INSIDE the caller's
+    `except Exception:` (determineMedia's own search try/except, added by
+    FIX 2 of round one specifically to stop a raise here from being fatal)
+    -- so a malformed filename reaching the warning aborted identification
+    for this identifier entirely: the withdrawn design's data-loss
+    behaviour, reintroduced from the one branch built to prevent it.
+    """
+
+    def test_a_non_string_filename_does_not_abort_identification(
+        self, scanner, monkeypatch,
+    ):
+        name_year = {'name': 'Some Movie', 'year': 2020}
+        # No candidate matches the parsed year, so the fallback reaches the
+        # warning branch, which is where `os.path.basename` is called.
+        candidates = [{'imdb': 'ttAAA', 'year': 1999}, {'imdb': 'ttBBB', 'year': 1950}]
+        _stub_for_site(monkeypatch, scanner, 'primary', name_year, candidates)
+
+        group = _group(filename=12345)  # not str/bytes/PathLike
+
+        result = scanner.determineMedia(group)  # must not raise
+
+        assert result.get('identifier') == 'ttAAA', (
+            'a non-string filename reaching the mismatched-guess warning '
+            'aborted identification instead of falling back to the first '
+            'candidate -- got %r' % result.get('identifier')
+        )
+
+
+class TestAHostileCandidateGetIsSkippedNotFatal:
+    """FIX 4b (round-two review of 0dc9e9a78). `_imdb`/`_year` inside
+    `pickSearchYearMatch` used to catch only `AttributeError`. The comment
+    above the function already justifies the guard as covering "the moment
+    a second provider is registered" -- a claim broader than one specific
+    exception type. A candidate whose `.get` raises something else (a
+    malformed provider payload, or any object with a broken `.get`) must
+    be skipped like any other malformed candidate, not propagate out of
+    `pickSearchYearMatch` and starve identification for a group where a
+    perfectly good candidate was sitting right next to it.
+    """
+
+    def test_a_candidate_whose_get_raises_a_non_attributeerror_is_skipped(
+        self, scanner, monkeypatch,
+    ):
+        class _HostileCandidate(dict):
+            def get(self, *args, **kwargs):
+                raise ValueError('malformed provider payload')
+
+        name_year = {'name': 'Some Movie', 'year': 2020}
+        candidates = [_HostileCandidate(imdb='ttBAD', year=2020), {'imdb': 'ttGOOD', 'year': 2020}]
+        _stub_for_site(monkeypatch, scanner, 'primary', name_year, candidates)
+
+        result = scanner.determineMedia(_group())  # must not raise
+
+        assert result.get('identifier') == 'ttGOOD', (
+            'a candidate whose .get() raised ValueError (not AttributeError) '
+            'propagated out of pickSearchYearMatch instead of being '
+            'skipped, starving identification even though a good candidate '
+            'was available -- got %r' % result.get('identifier')
+        )
+
+
 class TestUnknownParsedYearBehaviourIsUnchanged:
     """AC-DATA-3. When `getReleaseNameYear` cannot parse a year at all, the
     fallback's `if name_year.get('name') and name_year.get('year'):` guard
@@ -510,15 +655,27 @@ class TestUnknownParsedYearBehaviourIsUnchanged:
 
 
 class TestSearchTypePinnedRegardlessOfLimit:
-    """FIX 6 (round-one review of 0dc9e9a78). `TheMovieDb.search` flips
-    `search_type` from `phrase` to `ngram` purely as a side effect of
-    `limit > 1` -- and `search_type` is part of the request URL, therefore
-    the cache key, and TMDB's own `ngram` mode fans out into far more
-    per-result detail requests. Raising `SEARCH_YEAR_DISAMBIGUATION_LIMIT`
-    from 1 to 5 (BUG-018's own fix) silently asked the provider a DIFFERENT
-    question. `search_type='phrase'` must reach `fireEvent` on both call
-    sites regardless of the limit, so raising or lowering the limit later
-    can never repeat this."""
+    """FIX 6 (round-one review of 0dc9e9a78). `TheMovieDb.search` derives
+    `search_type` from `limit` unless it is pinned explicitly -- and
+    `search_type` is part of the request URL, therefore the cache key.
+    Raising `SEARCH_YEAR_DISAMBIGUATION_LIMIT` from 1 to 5 (BUG-018's own
+    fix) would otherwise silently key this fallback's cache entries
+    differently to every other `limit=1` caller (see
+    `test_providers.py::TestTheMovieDbProvider` and the round-two-corrected
+    docstring on `TheMovieDb.search` for why this is the ONLY benefit --
+    `search_type` was measured live to have no effect on which results TMDB
+    v3 returns or in what order). `search_type='phrase'` must reach
+    `fireEvent` on both call sites regardless of the limit, so raising or
+    lowering the limit later can never repeat this.
+
+    Round-two review of 0dc9e9a78 (FIX 2): also asserts `limit` itself
+    reaches `fireEvent` as something greater than 1 -- there were
+    previously two tests here asserting `search_type` arrives and NONE
+    asserting `limit` does, which is how setting
+    `SEARCH_YEAR_DISAMBIGUATION_LIMIT` back to 1 (a full revert of the
+    production fix) passed the entire suite: nothing checked that the
+    fallback actually asked the provider for more than one candidate.
+    """
 
     def test_the_primary_search_pins_search_type_to_phrase(self, scanner, monkeypatch):
         name_year = {'name': 'Some Movie', 'year': 2020}
@@ -532,8 +689,14 @@ class TestSearchTypePinnedRegardlessOfLimit:
         assert calls[0].get('search_type') == 'phrase', (
             'the primary movie.search call did not pin search_type to '
             '"phrase" -- got %r. Without this, raising '
-            'SEARCH_YEAR_DISAMBIGUATION_LIMIT above 1 silently flips TMDB '
-            'from an exact to a fuzzy search.' % calls[0].get('search_type')
+            'SEARCH_YEAR_DISAMBIGUATION_LIMIT above 1 silently changes the '
+            'cache key TMDB is queried under.' % calls[0].get('search_type')
+        )
+        assert calls[0].get('limit', 1) > 1, (
+            'the primary movie.search call asked for only %r result(s) -- '
+            'setting SEARCH_YEAR_DISAMBIGUATION_LIMIT back to 1 would make '
+            'this pass too, which is exactly how a full revert of the '
+            'production fix slipped past this suite unnoticed' % calls[0].get('limit')
         )
 
     def test_the_other_search_also_pins_search_type_to_phrase(self, scanner, monkeypatch):
@@ -561,6 +724,11 @@ class TestSearchTypePinnedRegardlessOfLimit:
         assert calls[1].get('search_type') == 'phrase', (
             'the "other" movie.search call did not pin search_type to '
             '"phrase" -- got %r' % calls[1].get('search_type')
+        )
+        assert calls[1].get('limit', 1) > 1, (
+            'the "other" movie.search call asked for only %r result(s) -- '
+            'setting SEARCH_YEAR_DISAMBIGUATION_LIMIT back to 1 would make '
+            'this pass too' % calls[1].get('limit')
         )
 
 
@@ -627,19 +795,6 @@ class TestAMismatchedGuessIsLoggedAtWarning:
             'a matching candidate was found (tt3480796, year 2020) at the '
             '%s call site yet a warning fired anyway: %r' % (site, warnings)
         )
-
-
-def _pre_bug_018_selection(candidates):
-    """Reference implementation of the fallback's selection before
-    BUG-018: `fireEvent('movie.search', ..., limit=1)`, then `movie[0]`,
-    with nothing else read from the result. Kept as a plain function of the
-    candidate list -- not imported from production -- because production is
-    exactly what AC-QA-6 is guarding: importing the (now fixed) selection
-    would compare the fix with itself and could never fail.
-    """
-    if not candidates:
-        return None
-    return candidates[0].get('imdb')
 
 
 class TestTheInvariantNeverFewerIdentifiersThanBefore:

--- a/tests/unit/test_scanner_search_year_disambiguation.py
+++ b/tests/unit/test_scanner_search_year_disambiguation.py
@@ -1,0 +1,434 @@
+"""BUG-018: the scanner's fifth identification fallback files every remake
+under the original.
+
+`determineMedia`'s fifth fallback (`folder_scanner.py`) parses a title and
+year out of a filename, asks `movie.search` for candidates, and today takes
+whichever candidate comes back FIRST -- the search event was called with
+`limit=1`, so nothing else was ever considered. The provider does not rank on
+year, and measured against the live provider the correct film was in second
+place every time:
+
+    "Mulan 2020"      -> 0. Mulan 1998          1. Mulan 2020
+    "Aladdin 2019"    -> 0. Aladdin 1992        1. Aladdin 2019
+    "Mean Girls 2024" -> 0. Mean Girls 2004     1. Mean Girls 2024
+    "Lion King 2019"  -> 0. The Lion King 1994  1. The Lion King 2019
+
+`manage.updateLibrary` deletes any 'done' movie absent from the scan result,
+so filing a remake under the original merges two films into one library
+record and the second is never searched for again.
+
+The invariant this suite exists to protect (BUG-018's own redesign, after a
+first attempt built the wrong fix): the change may only alter WHICH
+identifier the fallback returns, never WHETHER one is returned. A design
+that refuses to guess when no year matches sounds safer in isolation and is
+catastrophic here -- an unidentified file is invisible to
+`manage.updateLibrary`'s "still present" check, so a film owned ONLY as a
+remake would be deleted outright by the next scan. AC-DATA-2 and AC-QA-6
+below exist specifically to keep that door shut.
+
+Stubbing pattern follows `test_identity_provenance.py`: `get_db` is made to
+raise so `determineMedia` falls through to its except branch and returns
+`{'identifier': imdb_id, ...}`, which lets these tests read the chosen id
+straight off the return value rather than reaching into a real database.
+`fireEvent` is replaced outright (not wrapped) for the same reason that file
+gives: production events are never touched, only the two this fallback
+actually calls (`movie.search`, and `movie.info` on the fallback tail).
+"""
+import logging
+
+import pytest
+
+import couchpotato.core.plugins.scanner.folder_scanner as folder_scanner_module
+from couchpotato.core.plugins.scanner.folder_scanner import FolderScannerMixin
+
+DEFAULT_FILENAME = '/dl/Some.Movie.2020.mkv'
+DEFAULT_IDENTIFIER = 'Some Movie 2020'
+
+
+@pytest.fixture
+def scanner(monkeypatch):
+    plugin = FolderScannerMixin()
+
+    # The tail of determineMedia hits the database once an id is chosen.
+    # Every test here is about WHICH id gets chosen, so the lookup is made
+    # to fail and fall through to the info branch, exactly as
+    # test_identity_provenance.py does.
+    monkeypatch.setattr(
+        folder_scanner_module, 'get_db',
+        lambda: (_ for _ in ()).throw(RuntimeError('no db in this test')),
+    )
+    # The four assertion-based routes ahead of the search fallback must all
+    # miss, or these tests would be pinning the wrong code path.
+    monkeypatch.setattr(type(plugin), 'getCPImdb', lambda _s, _f: None, raising=False)
+    monkeypatch.setattr(folder_scanner_module, 'getImdb', lambda path, check_inside=False: None)
+    return plugin
+
+
+def _group(identifiers=None, filename=DEFAULT_FILENAME, is_dvd=False):
+    return {
+        'files': {'movie': [filename], 'nfo': []},
+        'identifiers': identifiers if identifiers is not None else [DEFAULT_IDENTIFIER],
+        'is_dvd': is_dvd,
+    }
+
+
+def _stub_search(monkeypatch, results_by_query):
+    """Replaces `fireEvent` with one that answers `movie.search` calls from
+    `results_by_query` (query string -> candidate list) and returns `[]`
+    for any query not listed, matching a provider that found nothing.
+    Every call is recorded so tests can assert on how many searches fired
+    and with which queries -- needed for the hazard-3 fallback-to-`other`
+    cases below.
+    """
+    calls = []
+
+    def _fire(event, *args, **kwargs):
+        if event == 'movie.search':
+            calls.append(kwargs)
+            return list(results_by_query.get(kwargs.get('q'), []))
+        return None
+
+    monkeypatch.setattr(folder_scanner_module, 'fireEvent', _fire)
+    return calls
+
+
+def _stub_name_year(monkeypatch, scanner_instance, name_year):
+    monkeypatch.setattr(
+        type(scanner_instance), 'getReleaseNameYear',
+        lambda _s, identifier, file_name=None: dict(name_year),
+        raising=False,
+    )
+
+
+# The four production cases from the spec, each as (name_year, candidates,
+# expected_imdb) -- candidates are given in the buggy provider order (wrong
+# film first), so a test asserting `expected_imdb` fails today and passes
+# once the fallback prefers the year match over position.
+MEASURED_CASES = [
+    pytest.param(
+        {'name': 'Mulan', 'year': 2020},
+        [{'imdb': 'tt0120762', 'year': 1998}, {'imdb': 'tt3480796', 'year': 2020}],
+        'tt3480796',
+        id='mulan_2020_over_1998_remake',
+    ),
+    pytest.param(
+        {'name': 'Aladdin', 'year': 2019},
+        [{'imdb': 'tt0103639', 'year': 1992}, {'imdb': 'tt6139732', 'year': 2019}],
+        'tt6139732',
+        id='aladdin_2019_over_1992_remake',
+    ),
+    pytest.param(
+        {'name': 'Mean Girls', 'year': 2024},
+        [{'imdb': 'tt0377092', 'year': 2004}, {'imdb': 'tt6791350', 'year': 2024}],
+        'tt6791350',
+        id='mean_girls_2024_over_2004_remake',
+    ),
+    pytest.param(
+        {'name': 'Lion King', 'year': 2019},
+        [{'imdb': 'tt0110357', 'year': 1994}, {'imdb': 'tt6105098', 'year': 2019}],
+        'tt6105098',
+        id='lion_king_2019_over_1994_remake',
+    ),
+]
+
+
+class TestTheYearMatchWinsOverPosition:
+    """AC-DATA-1 and AC-QA-5 (the same assertion serves both: restoring
+    take-the-first -- i.e. reverting the fix -- makes every case here fail
+    on the Mulan case exactly as AC-QA-5 requires).
+
+    RED today: the production fallback calls `movie.search(..., limit=1)`
+    and takes `movie[0]` unconditionally, so it returns the WRONG (first)
+    candidate for every one of these measured cases.
+    """
+
+    @pytest.mark.parametrize('name_year, candidates, expected_imdb', MEASURED_CASES)
+    def test_candidate_matching_the_parsed_year_wins_even_when_listed_second(
+        self, scanner, monkeypatch, name_year, candidates, expected_imdb,
+    ):
+        search_q = '%(name)s %(year)s' % name_year
+        _stub_search(monkeypatch, {search_q: candidates})
+        _stub_name_year(monkeypatch, scanner, name_year)
+
+        result = scanner.determineMedia(_group())
+
+        assert result.get('identifier') == expected_imdb, (
+            'expected the candidate whose year matches the parsed year %r '
+            'to win regardless of position, got %r from candidates %r -- '
+            'this is the exact merge BUG-018 measured in production' % (
+                name_year['year'], result.get('identifier'), candidates,
+            )
+        )
+
+    def test_a_one_year_provider_discrepancy_still_matches(self, scanner, monkeypatch):
+        """Hazard 1: `getReleaseNameYear` parses a year from the filename,
+        and a provider's release year can legitimately differ from that by
+        one (region release dates, festival vs. wide release). Tolerance
+        of exactly 1 is used -- not 0, which would treat every honestly
+        off-by-one provider year as a non-match and always fall back to
+        the first result; not more than 1, which starts risking exactly
+        the remake collisions this bug is about (the closest two of the
+        four measured remake pairs are still 7 years apart)."""
+        name_year = {'name': 'Some Movie', 'year': 2020}
+        candidates = [
+            {'imdb': 'ttOLD', 'year': 1998},
+            {'imdb': 'ttNEW', 'year': 2019},  # one year off the parsed 2020
+        ]
+        search_q = '%(name)s %(year)s' % name_year
+        _stub_search(monkeypatch, {search_q: candidates})
+        _stub_name_year(monkeypatch, scanner, name_year)
+
+        result = scanner.determineMedia(_group())
+
+        assert result.get('identifier') == 'ttNEW', (
+            'a candidate one year off the parsed year should still count '
+            'as a match ahead of an unrelated candidate decades away; got '
+            '%r' % result.get('identifier')
+        )
+
+    def test_the_second_other_search_gets_the_same_year_preference(
+        self, scanner, monkeypatch,
+    ):
+        """Hazard 3: there are TWO search call sites in this fallback -- the
+        primary query, and a second one built from
+        `name_year['other']` when the primary returns nothing. Both must
+        apply the same year preference or the fix only half-covers the
+        defect."""
+        primary = {'name': 'Mulan', 'year': 2020}
+        other = {'name': 'Mulan the Movie', 'year': 2020}
+        name_year = dict(primary)
+        name_year['other'] = other
+
+        primary_q = '%(name)s %(year)s' % primary
+        other_q = '%(name)s %(year)s' % other
+        candidates = [{'imdb': 'tt0120762', 'year': 1998}, {'imdb': 'tt3480796', 'year': 2020}]
+
+        calls = _stub_search(monkeypatch, {primary_q: [], other_q: candidates})
+        _stub_name_year(monkeypatch, scanner, name_year)
+
+        result = scanner.determineMedia(_group())
+
+        assert [c.get('q') for c in calls] == [primary_q, other_q], (
+            'setup: the primary query must return empty so the fallback '
+            'reaches the "other" query at all, got queries %r' % (
+                [c.get('q') for c in calls],
+            )
+        )
+        assert result.get('identifier') == 'tt3480796', (
+            'the second ("other") search took the wrong candidate too: '
+            'got %r' % result.get('identifier')
+        )
+
+
+class TestNoMatchFallsBackToTheFirstCandidate:
+    """AC-DATA-2, the safety property that replaced the withdrawn refusal
+    design. A candidate list where NOTHING matches the parsed year must
+    still yield the first candidate, exactly as the current code does --
+    never None. This is expected to hold both before and after the fix (the
+    current code already always takes the first result); its job is to
+    catch a FUTURE regression back toward refusal, not to be RED today.
+    """
+
+    def test_takes_the_first_candidate_when_no_year_matches(self, scanner, monkeypatch):
+        name_year = {'name': 'Some Movie', 'year': 2020}
+        candidates = [{'imdb': 'ttAAA', 'year': 1999}, {'imdb': 'ttBBB', 'year': 1950}]
+        search_q = '%(name)s %(year)s' % name_year
+        _stub_search(monkeypatch, {search_q: candidates})
+        _stub_name_year(monkeypatch, scanner, name_year)
+
+        result = scanner.determineMedia(_group())
+
+        assert result.get('identifier') == 'ttAAA', (
+            'must return the FIRST candidate exactly as the pre-BUG-018 '
+            'code did when no candidate matches the parsed year -- '
+            'refusing to guess here is the data-loss design BUG-018 '
+            'withdrew, since a refused file is invisible to '
+            'manage.updateLibrary\'s "still present" check and would be '
+            'deleted on the next scan'
+        )
+
+
+class TestUnknownParsedYearBehaviourIsUnchanged:
+    """AC-DATA-3. When `getReleaseNameYear` cannot parse a year at all, the
+    fallback's `if name_year.get('name') and name_year.get('year'):` guard
+    already stops it from searching -- this is unrelated to the fix and
+    must stay unrelated to it."""
+
+    def test_no_search_fires_and_no_identifier_is_produced(self, scanner, monkeypatch):
+        calls = _stub_search(monkeypatch, {})
+        _stub_name_year(monkeypatch, scanner, {'name': 'Some Movie'})  # no 'year' key
+
+        result = scanner.determineMedia(_group())
+
+        assert calls == [], 'a search fired even though no year was parsed'
+        assert result == {}
+        assert scanner  # keep the fixture referenced for readability
+
+
+class TestAMismatchedGuessIsLoggedAtWarning:
+    """AC-OPS-4. Taking the first candidate when nothing matches must be
+    visible to the operator: a bad guess this way is not destructive (the
+    renamer refuses to replace on a searched identity), but it is silent
+    today. RED today: the current code logs nothing but a debug line with
+    the identifier string, naming neither the parsed year nor the years on
+    offer.
+    """
+
+    def test_warns_with_filename_parsed_year_and_offered_years(
+        self, scanner, monkeypatch, caplog,
+    ):
+        name_year = {'name': 'Some Movie', 'year': 2020}
+        candidates = [{'imdb': 'ttAAA', 'year': 1999}, {'imdb': 'ttBBB', 'year': 1950}]
+        search_q = '%(name)s %(year)s' % name_year
+        _stub_search(monkeypatch, {search_q: candidates})
+        _stub_name_year(monkeypatch, scanner, name_year)
+
+        with caplog.at_level(logging.WARNING):
+            scanner.determineMedia(_group(filename=DEFAULT_FILENAME))
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            DEFAULT_FILENAME in w and '2020' in w and '1999' in w and '1950' in w
+            for w in warnings
+        ), (
+            'expected a warning naming the filename, the parsed year (2020) '
+            'and the years offered (1999, 1950) when a mismatched guess was '
+            'taken; got warnings: %r' % warnings
+        )
+
+    def test_a_matching_candidate_does_not_warn(self, scanner, monkeypatch, caplog):
+        """Negative control: the warning is for bad guesses specifically,
+        not for every successful search -- otherwise AC-OPS-4 would be
+        satisfied by warning unconditionally, which teaches operators to
+        ignore it."""
+        name_year = {'name': 'Mulan', 'year': 2020}
+        candidates = [{'imdb': 'tt0120762', 'year': 1998}, {'imdb': 'tt3480796', 'year': 2020}]
+        search_q = '%(name)s %(year)s' % name_year
+        _stub_search(monkeypatch, {search_q: candidates})
+        _stub_name_year(monkeypatch, scanner, name_year)
+
+        with caplog.at_level(logging.WARNING):
+            scanner.determineMedia(_group())
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings == [], (
+            'a matching candidate was found (tt3480796, year 2020) yet a '
+            'warning fired anyway: %r' % warnings
+        )
+
+
+def _pre_bug_018_selection(candidates):
+    """Reference implementation of the fallback's selection before
+    BUG-018: `fireEvent('movie.search', ..., limit=1)`, then `movie[0]`,
+    with nothing else read from the result. Kept as a plain function of the
+    candidate list -- not imported from production -- because production is
+    exactly what AC-QA-6 is guarding: importing the (now fixed) selection
+    would compare the fix with itself and could never fail.
+    """
+    if not candidates:
+        return None
+    return candidates[0].get('imdb')
+
+
+class TestTheInvariantNeverFewerIdentifiersThanBefore:
+    """AC-QA-6. Drives BOTH the reference pre-BUG-018 selection and the real,
+    changed `determineMedia` against the same candidate lists, and asserts
+    that wherever the old selection found an id, the new code finds one too
+    -- not necessarily the SAME one, which is the entire point of AC-DATA-1.
+
+    Covers the four measured cases plus the three edge shapes the spec
+    names explicitly: a candidate missing its year field, a candidate whose
+    year is explicitly `None`, and an empty result set. A fifth case (the
+    parsed year itself being unknown) is proven separately below, since
+    there the OLD selection is not "call search and take movie[0]" at all
+    -- no search happens on either side of the fix, so there is nothing to
+    drive through `_pre_bug_018_selection`.
+    """
+
+    CANDIDATE_CASES = [
+        pytest.param(
+            [{'imdb': 'tt0120762', 'year': 1998}, {'imdb': 'tt3480796', 'year': 2020}],
+            id='mulan_remake_pair',
+        ),
+        pytest.param(
+            [{'imdb': 'tt0103639', 'year': 1992}, {'imdb': 'tt6139732', 'year': 2019}],
+            id='aladdin_remake_pair',
+        ),
+        pytest.param(
+            [{'imdb': 'tt0377092', 'year': 2004}, {'imdb': 'tt6791350', 'year': 2024}],
+            id='mean_girls_remake_pair',
+        ),
+        pytest.param(
+            [{'imdb': 'tt0110357', 'year': 1994}, {'imdb': 'tt6105098', 'year': 2019}],
+            id='lion_king_remake_pair',
+        ),
+        pytest.param(
+            [{'imdb': 'ttONLY', 'year': 1975}],
+            id='single_candidate_year_does_not_match',
+        ),
+        pytest.param(
+            [{'imdb': 'ttNOYEARFIELD'}],
+            id='no_year_candidate_missing_key_entirely',
+        ),
+        pytest.param(
+            [{'imdb': 'ttNULLYEAR', 'year': None}],
+            id='null_year_candidate_explicit_none',
+        ),
+    ]
+
+    @pytest.mark.parametrize('candidates', CANDIDATE_CASES)
+    def test_an_id_the_old_code_found_is_still_found(self, scanner, monkeypatch, candidates):
+        name_year = {'name': 'Some Movie', 'year': 2020}
+        search_q = '%(name)s %(year)s' % name_year
+        _stub_search(monkeypatch, {search_q: candidates})
+        _stub_name_year(monkeypatch, scanner, name_year)
+
+        pre = _pre_bug_018_selection(candidates)
+        assert pre is not None, (
+            'test setup error: the reference selection found nothing in %r '
+            'to compare against' % candidates
+        )
+
+        result = scanner.determineMedia(_group())
+        post = result.get('identifier')
+
+        assert post is not None, (
+            'the pre-BUG-018 selection returned %r for candidates %r, but '
+            'the changed code returned no identifier at all. This is the '
+            'exact data-loss shape BUG-018\'s withdrawn first design '
+            'built: manage.updateLibrary treats "no identifier" as "movie '
+            'gone" and deletes it on the next scan.' % (pre, candidates)
+        )
+
+    def test_empty_results_produce_no_identifier_on_either_side(self, scanner, monkeypatch):
+        """Not a regression -- included so the parametrized cases above are
+        not vacuously satisfied only because every fixture happens to be
+        non-empty. The pre-BUG-018 selection also returns nothing when the
+        provider returns nothing, so both sides agreeing on None here is
+        correct, not a violation of the invariant."""
+        name_year = {'name': 'Some Movie', 'year': 2020}
+        search_q = '%(name)s %(year)s' % name_year
+        _stub_search(monkeypatch, {search_q: []})
+        _stub_name_year(monkeypatch, scanner, name_year)
+
+        assert _pre_bug_018_selection([]) is None
+
+        result = scanner.determineMedia(_group())
+        assert result == {}
+
+    def test_an_unknown_parsed_year_produces_no_identifier_on_either_side(
+        self, scanner, monkeypatch,
+    ):
+        """The parsed-year-unknown edge case named in AC-QA-6. Neither the
+        old nor the new code ever calls `movie.search` here (the fallback's
+        own `if name_year.get('year'):` guard stops both), so there is
+        nothing for `_pre_bug_018_selection` to be given -- the invariant
+        holds trivially by construction, and this test exists to make that
+        explicit rather than silently uncovered."""
+        calls = _stub_search(monkeypatch, {})
+        _stub_name_year(monkeypatch, scanner, {'name': 'Some Movie'})
+
+        result = scanner.determineMedia(_group())
+
+        assert calls == [], 'a search fired despite no parsed year -- both sides should skip it'
+        assert result == {}


### PR DESCRIPTION
Seven media records in production hold files from two distinct films. The second
film therefore has no record of its own: CouchPotato believes it already owns
it, so it never appears and is never searched for.

    Harry Potter Deathly Hallows Part 1  <- Part 1 (2010) and Part 2 (2011)
    Hunger Games Mockingjay Part 1       <- Part 1 (2014) and Part 2 (2015)
    The Lion King                        <- Lion King (2019) and Lion (2016)
    Beetlejuice                          <- 1988, Beetlejuice 2 (2024), and one more
    Aladdin                              <- 1992 and 2019
    Mulan                                <- 1998 and 2020
    Mean Girls                           <- 2004 and 2024

## Root cause

`determineMedia`'s fifth identification route builds a search query containing
the year, asks for ONE result, and takes it. The provider does not rank on year.
Measured live, and re-measured by an independent reviewer at the end of this
branch:

    "Mulan 2020"      -> 0. Mulan 1998          1. Mulan 2020
    "Aladdin 2019"    -> 0. Aladdin 1992        1. Aladdin 2019
    "Mean Girls 2024" -> 0. Mean Girls 2004     1. Mean Girls 2024
    "Lion King 2019"  -> 0. The Lion King 1994  1. The Lion King 2019

The correct film is position 1 every time. `limit=1` guarantees it is never
seen. The parsed year is already in hand and already in the query; it was simply
never used to choose between results.

## What ships

Raise the result limit, prefer a candidate whose year matches within one, take
the FIRST such candidate, and require that a candidate carry an id before it can
win. When nothing matches, take the first result exactly as before.

## Three defects were produced getting here, and all three are why this took so long

Stated plainly because the failures are the more useful record. Two came from my
own instructions.

**1. The first design refused to identify a file when no year matched.** Correct
in isolation, catastrophic here: `manage.updateLibrary` deletes every terminal
movie absent from the scan result with `delete_from='all'` (media document,
every release, library entry, watch state, tags, profile, review state). A
refused file produces no identifier, so a film owned ONLY as a remake would have
been deleted outright by the next nightly scan. Caught by
`TestFolderScannerIsUntouched`, a blunt freeze over this module that exists
precisely because it feeds that cleanup.

**2. The second design selected on year alone**, so a year-matching candidate
with no imdb id returned nothing. Production-reachable: the provider strips
falsy values, so a record with a null imdb_id arrives with no id key at all, and
this change deliberately steers toward the newer film, which is likelier to be
missing one. The invariant guard PASSED GREEN against it, because all its
fixtures carried an id.

**3. The third design preferred the CLOSEST year match.** Measured live: a film
released in December and ripped in January carries the following year, and the
exact-year decoy then beats the correct film.

    "Wicked 2025"    -> 0. Wicked (2024) CORRECT    1. Wicked: For Good (2025)
    "Nosferatu 2025" -> 0. Nosferatu (2024) CORRECT 1. Nosferatu (2025)
    "Anora 2025"     -> 0. Anora (2024) CORRECT     1. Anora: Stripped Down (2025)

Seven regressions in eleven adversarial cases; first-within-tolerance got all
seven right. Reverted, and recorded in the spec with the measurements so nobody
reaches the same conclusion again.

## The recurring shape, four times

Every defect on this branch was invisible to a green suite because something
below the assertion did not model what mattered:

- the invariant guard's fixtures all carried an id, so it could not see defect 2
- the test doubles ignored `limit`, so reverting it to 1 fully undid the fix
  with 3886 tests passing
- the second stub still ignored `limit` after the first was fixed
- the provider's own truncation was unverified, so breaking it returned one
  result however many were requested, with 3891 tests passing

All four are now closed, each proven by breaking the thing it protects.

## Guards, each proven load-bearing

| Guard | Broken by | Result |
|---|---|---|
| Never fewer identifiers than before | disabling the id filter | 9 fail |
| First-within-tolerance | reintroducing closest-wins | 9 fail |
| The scanner asks for more than one candidate | setting the limit to 1 | 19 fail |
| The provider honours the limit | `if nr == 1` truncation | 1 fail |
| Malformed filename does not abort | removing the guard | 1 fail |
| Hostile candidate is skipped, not fatal | narrowing the except | 1 fail |

## Deliberately not fixed

The two consecutive-year sequel merges. Their cause is only partly established,
and the one attempt to fix them was the measured regression above. Pinned as
`xfail(strict=True)` so the accepted debt appears in every run summary rather
than hiding among the passes, and so the day someone fixes it the suite fails
until the test is updated rather than deleted.

Also recorded: `manage.updateLibrary` inferring "absent means deleted" remains a
single-point data-loss risk, mitigated but not removed.

## Verification

Local gate green. Two `lens-data` passes and two adversarial
`reviewer-verification` passes, plus my own mutation testing of every guard
above. The final review re-measured every documented live claim against the real
provider and all reproduced, including one it expected to be fabricated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
