### PR TITLE
fix(docker): pin libuuid for the new util-linux CVEs blocking every PR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,17 @@ ENV PYTHONUNBUFFERED=1 \
 #   here serves QUIC, so the practical exposure is low, but the fix is a
 #   version bump that is already published and costs nothing to take.
 #   Drop this explicit pin once the base image ships openssl >= 3.5.8-r0.
+#
+#   libuuid is pinned for the same reason, and the package name is the trap.
+#   Trivy reports CVE-2026-78408, CVE-2026-78409 and CVE-2026-78410 against
+#   "util-linux", which is the SOURCE package. util-linux is not installed
+#   here; the only artefact from that source in the runtime image is
+#   libuuid, at 2.42.1-r0. Pinning "util-linux" would have installed a
+#   package that was not previously present and left libuuid untouched, so
+#   the scan would have kept failing while the change looked correct.
+#   Measured in a python:3.14-alpine container: installed libuuid 2.42.1-r0,
+#   available 2.42.3-r1 in Alpine v3.24 main, and the pin resolves.
+#   Drop this explicit pin once the base image ships libuuid >= 2.42.3-r1.
 RUN apk add --no-cache \
         ca-certificates \
         su-exec \
@@ -66,7 +77,8 @@ RUN apk add --no-cache \
         7zip \
         "c-ares>=1.34.8-r0" \
         "libcrypto3>=3.5.8-r0" \
-        "libssl3>=3.5.8-r0"
+        "libssl3>=3.5.8-r0" \
+        "libuuid>=2.42.3-r1"
 
 # Create app user
 ARG PUID=1000


### PR DESCRIPTION
Three new HIGH CVEs in util-linux started failing the Trivy gate on 2026-09-05
and are blocking every PR in the repo. Master is failing the same way, so this
is a base-image change rather than anything a branch introduced.

    CVE-2026-78408  util-linux: SUID mount(8) allows nosuid bypass
    CVE-2026-78409  util-linux: nsenter --join-cgroup leak
    CVE-2026-78410  util-linux: TOCTOU in the mount program

## The package name is the trap

Trivy reports these against `util-linux`, which is the SOURCE package.
**`util-linux` is not installed in the runtime image.** The only artefact from
that source present is `libuuid`, at 2.42.1-r0.

Pinning `util-linux`, which is the obvious reading of the scanner output, would
have installed a package that was not previously there and left the vulnerable
`libuuid` exactly where it was. The scan would have kept failing while the
change read as entirely correct, and the next person would reasonably conclude
the pin does not work rather than that it is the wrong name.

Measured in a `python:3.14-alpine` container before writing the pin:

    installed : libuuid 2.42.1-r0
    available : libuuid 2.42.3-r1   (alpine v3.24 main)
    the pin resolves

## Verified end to end, not pushed and hoped

A Dockerfile change that looks right and does nothing is exactly what this
situation invites, so:

- built the image, and the built image carries `libuuid 2.42.3-r1`
- ran the exact scan CI runs against it: trivy 0.70.0, `--scanners vuln`,
  `--severity CRITICAL,HIGH`, `--ignore-unfixed`, the repo's `.trivyignore`
- result: **exit 0, zero findings on the alpine layer**

## Style

Follows the `openssl` and `c-ares` pins already in this file, including their
convention of recording why the pin exists and the condition for dropping it:
once the base image ships `libuuid >= 2.42.3-r1`.

Unblocks #303 and every other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
