### PR TITLE
test(e2e): replace fixed waits with real assertions

### DIFF
--- a/tests/e2e/accessibility.a11y.spec.ts
+++ b/tests/e2e/accessibility.a11y.spec.ts
@@ -246,16 +246,21 @@ test.describe('Accessibility', () => {
   test('Wanted page should be accessible', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000); // Wait for htmx to load content
-    
+    // #movie-count starts empty and is only populated once the grid's htmx
+    // load has swapped in and filterMovies() has run on it (wanted.html) --
+    // real content-loaded signal rather than a guessed duration.
+    await expect(page.locator('#movie-count')).not.toBeEmpty();
+
     await checkA11y(page, 'Wanted');
   });
 
   test('Available page should be accessible', async ({ page }) => {
     await page.goto('/available/');
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
-    
+    // /available/ redirects to /wanted?filter=available and renders the
+    // same wanted.html grid, so the same readiness signal applies.
+    await expect(page.locator('#movie-count')).not.toBeEmpty();
+
     await checkA11y(page, 'Available');
   });
 
@@ -270,15 +275,21 @@ test.describe('Accessibility', () => {
   test('Add Movie page should be accessible', async ({ page }) => {
     await page.goto('/add/');
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
-    
+    // Nothing loads via htmx on this page until a search is typed, so the
+    // real readiness signal is the search field the test's own scan
+    // depends on being there.
+    await expect(page.locator('#movie-search')).toBeVisible();
+
     await checkA11y(page, 'Add Movie');
   });
 
   test('Settings page should be accessible', async ({ page }) => {
     await page.goto('/settings/');
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(2000); // Settings takes longer to load
+    // Settings loads via Alpine's own `loading` flag, not htmx -- the tabs
+    // are gated behind `x-show="!loading"`, so waiting for them is the real
+    // signal settings finished loading.
+    await expect(page.getByRole('tablist', { name: 'Settings categories' })).toBeVisible();
 
     await checkA11y(page, 'Settings');
   });
@@ -302,7 +313,7 @@ test.describe('Accessibility', () => {
 
     await page.goto('/');
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000); // Wait for htmx to load content
+    await expect(page.locator('#movie-count')).not.toBeEmpty();
 
     // Pin that dark theme really took effect -- load-bearing, not decorative:
     // a broken theme pipeline must red this test loudly rather than silently
@@ -315,7 +326,7 @@ test.describe('Accessibility', () => {
 
     await page.goto('/settings/');
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(2000); // Settings takes longer to load
+    await expect(page.getByRole('tablist', { name: 'Settings categories' })).toBeVisible();
 
     await expect
       .poll(() => page.evaluate(() => document.documentElement.classList.contains('light')))
@@ -386,27 +397,27 @@ test.describe('Accessibility', () => {
   async function navigateWizardToProviders(page: any, searchType: 'Usenet' | 'Torrents' | 'Both' = 'Both') {
     await page.goto('/wizard/');
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(500);
+    await expect(page.getByRole('button', { name: 'Continue' })).toBeVisible();
 
     // Step 1: Welcome -> Continue
     await page.getByRole('button', { name: 'Continue' }).click();
-    await page.waitForTimeout(300);
+    await expect(page.getByRole('heading', { name: 'Server Security' })).toBeVisible();
 
     // Step 2: Security -> Skip (no credentials needed for this check)
     await page.getByRole('button', { name: 'Skip' }).click();
-    await page.waitForTimeout(300);
+    await expect(page.getByRole('heading', { name: 'Where to Search' })).toBeVisible();
 
     // Step 3: Providers -> choose a search type so the provider toggles render.
     // Each source button's accessible name is "<Type> <hint>" (e.g. "Both
     // Maximum coverage"), so match on a name starting with the type.
     await page.getByRole('button', { name: new RegExp('^' + searchType) }).click();
-    await page.waitForTimeout(300);
+    await expect(page.locator('button[role="switch"]:visible').first()).toBeVisible();
   }
 
   test('Setup Wizard page should be accessible', async ({ page }) => {
     await page.goto('/wizard/');
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
+    await expect(page.getByRole('heading', { name: 'Welcome to CouchPotato' })).toBeVisible();
 
     // Regression guard for UI-CONFORM-01: the wizard used to render its 8
     // toggle switches at a non-canonical size (w-10 h-5) and without
@@ -430,7 +441,6 @@ test.describe('Accessibility', () => {
 
     // Step 2: Security -- username/password.
     await page.getByRole('button', { name: 'Continue' }).click();
-    await page.waitForTimeout(300);
     // A3: assert the wizard actually reached this step before scanning it --
     // demonstrated to matter: blocking `nextStep()` from advancing left the
     // Welcome step showing while this scan ran unaware, and reported clean.
@@ -441,25 +451,33 @@ test.describe('Accessibility', () => {
 
     // Security -> Providers (Skip, no credentials needed for this scan).
     await page.getByRole('button', { name: 'Skip' }).click();
-    await page.waitForTimeout(300);
+    await expect(page.getByRole('heading', { name: 'Where to Search' })).toBeVisible();
 
     // Step 3: Providers -- "Both" renders usenet and torrent sections
     // together; enabling Newznab and Jackett reveals their credential
     // fields, and expanding + enabling one private tracker reveals the
     // `x-for` field loop (AC-A11Y-2's bound-id case).
     await page.getByRole('button', { name: /^Both/ }).click();
-    await page.waitForTimeout(300);
+    await expect(page.getByRole('switch', { name: 'Enable Newznab Indexers' })).toBeVisible();
     await page.getByRole('switch', { name: 'Enable Newznab Indexers' }).click();
     await page.getByRole('switch', { name: 'Enable Jackett / TorrentPotato' }).click();
     await page.getByRole('button', { name: /Private Trackers/ }).click();
-    await page.waitForTimeout(300);
+    await expect(page.getByRole('switch', { name: 'Enable PassThePopcorn' })).toBeVisible();
     // TWO trackers enabled, not one: a single enabled tracker cannot prove
     // B2's fix, because a static id/for pair inside the field loop would
     // never collide with itself -- it only collides once a second tracker's
     // identically-named "Username"/"Passkey" fields are ALSO visible.
     await page.getByRole('switch', { name: 'Enable PassThePopcorn' }).click();
     await page.getByRole('switch', { name: 'Enable HDBits' }).click();
-    await page.waitForTimeout(300);
+    // Both trackers' field groups must be rendered before the scan below
+    // counts fields against them -- assertFieldNamesAreReal reads the DOM
+    // once, with no retry, so this has to be a real wait, not a guess.
+    await expect(
+      page.getByRole('group', { name: 'PassThePopcorn' }).getByLabel('Username'),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('group', { name: 'HDBits' }).getByLabel('Username'),
+    ).toBeVisible();
     await assertWizardStepShowing(page, 'Where to Search', '#wizard-jackett-url');
     // A5: floor measured directly -- 9 fields (2 Newznab entry, 2 Jackett,
     // 3 PassThePopcorn, 2 HDBits), before B1's second indexer entry below
@@ -485,7 +503,6 @@ test.describe('Accessibility', () => {
     // checks presence, not uniqueness -- so only a direct read of the two
     // names can catch the static-aria-label regression B1 fixed.
     await page.getByRole('button', { name: '+ Add another indexer' }).click();
-    await page.waitForTimeout(300);
     const indexerUrlInputs = page.getByLabel(/Newznab indexer URL \d+/);
     await expect(indexerUrlInputs).toHaveCount(2);
     const firstName = await indexerUrlInputs.nth(0).getAttribute('aria-label');
@@ -502,11 +519,13 @@ test.describe('Accessibility', () => {
     // getDownloaderFields()'s x-html-injected markup actually renders, and
     // enable Black Hole for its own folder fields.
     await page.getByRole('button', { name: 'Continue' }).click();
-    await page.waitForTimeout(500);
+    await expect(page.getByRole('heading', { name: 'Download Clients' })).toBeVisible();
     await page.getByRole('button', { name: 'SABnzbd' }).click();
     await page.getByRole('button', { name: 'qBittorrent' }).click();
     await page.getByRole('switch', { name: 'Enable Black Hole' }).click();
-    await page.waitForTimeout(300);
+    // Black Hole's own folder fields render behind `x-show="blackholeEnabled"`
+    // -- wait for the field the scan below counts before it runs.
+    await expect(page.locator('#wizard-blackhole-nzb-dir')).toBeVisible();
     await assertWizardStepShowing(page, 'Download Clients', '#wizard-dl-sabnzbd-host');
     // A5: floor measured directly -- 8 fields (3 SABnzbd, 3 qBittorrent, 2
     // Black Hole).
@@ -527,7 +546,6 @@ test.describe('Accessibility', () => {
 
     // Step 5: Library -- renamer fields, on by default.
     await page.getByRole('button', { name: 'Continue' }).click();
-    await page.waitForTimeout(500);
     await assertWizardStepShowing(page, 'Movie Library', '#wizard-renamer-from');
     // A5: floor measured directly -- 4 fields (download folder, movie
     // library, folder naming, file naming).
@@ -588,7 +606,6 @@ test.describe('Accessibility', () => {
     // Step 3: Providers -> Continue to Downloader (saves the providers step
     // for real against the local test server).
     await page.getByRole('button', { name: 'Continue' }).click();
-    await page.waitForTimeout(500);
 
     // Black Hole toggle is always visible on the Downloader step.
     const blackholeToggle = page.getByRole('switch', { name: 'Enable Black Hole' });
@@ -600,7 +617,6 @@ test.describe('Accessibility', () => {
 
     // Step 4: Downloader -> Continue to Library
     await page.getByRole('button', { name: 'Continue' }).click();
-    await page.waitForTimeout(500);
 
     // Renamer toggle is always visible on the Library step.
     const renamerToggle = page.getByRole('switch', { name: 'Enable Automatic Renaming' });
@@ -758,7 +774,7 @@ test.describe('Accessibility', () => {
   test('Interactive elements should be keyboard accessible', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
+    await expect(page.locator('#movie-count')).not.toBeEmpty();
 
     // Tab through the page
     await page.keyboard.press('Tab');
@@ -838,7 +854,7 @@ test.describe('Accessibility', () => {
 
       await page.goto('/wizard/');
       await page.waitForLoadState('networkidle');
-      await page.waitForTimeout(1000);
+      await expect(page.getByRole('heading', { name: 'Welcome to CouchPotato' })).toBeVisible();
 
       // Pin the theme really took effect, same guard the toast contrast test
       // uses, so a broken theme pipeline reds this loudly rather than
@@ -850,7 +866,6 @@ test.describe('Accessibility', () => {
       // Welcome -> Server Security, the same step-advance
       // navigateWizardToProviders/the wizard a11y test above use.
       await page.getByRole('button', { name: 'Continue' }).click();
-      await page.waitForTimeout(300);
       await assertWizardStepShowing(page, 'Server Security', '#wizard-username');
 
       const input = page.locator('#wizard-username');
@@ -992,7 +1007,8 @@ test.describe('Accessibility', () => {
   test('Images should have alt text', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
+    // Poster <img>s only exist once the grid's htmx load has swapped in.
+    await expect(page.locator('#movie-count')).not.toBeEmpty();
 
     // Get all images
     const images = page.locator('img');
@@ -1266,8 +1282,8 @@ test.describe('Accessibility', () => {
   test('Color contrast should be sufficient', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
-    await page.waitForTimeout(1000);
-    
+    await expect(page.locator('#movie-count')).not.toBeEmpty();
+
     // Run axe specifically for color contrast
     const results = await new AxeBuilder({ page })
       .withRules(['color-contrast'])

--- a/tests/e2e/wizard.spec.ts
+++ b/tests/e2e/wizard.spec.ts
@@ -58,6 +58,34 @@ test.describe('Wizard: a refused save must not read as success', () => {
     await expect(SECURITY_USERNAME(page)).toBeVisible({ timeout: 5000 });
   }
 
+  /**
+   * Settle point for the wizard's Continue/Finish Setup button after a
+   * click, used by the "walk forward N steps" loops below.
+   *
+   * The button carries `:disabled="saving"`, so waiting for it to become
+   * enabled again is normally the right signal that nextStep()'s save (or
+   * its absence) has resolved. But on the LAST step (Library), that same
+   * click also advances currentStep to 5, which hides the whole footer via
+   * `x-show="currentStep < 5"` -- and a role-based locator like
+   * `getByRole('button', ...)` excludes a `display:none` element from
+   * matching at all. `toBeEnabled()` alone therefore hangs for the full
+   * timeout on exactly that transition: not a real race in the app, but a
+   * mismatch between the assertion and a button that is SUPPOSED to
+   * disappear. Both outcomes -- re-enabled, or gone -- are the real end of
+   * the async work, so both count as settled here.
+   */
+  async function waitForWizardButtonSettled(next: any): Promise<void> {
+    await expect
+      .poll(
+        async () => {
+          if (!(await next.isVisible().catch(() => false))) return 'gone';
+          return (await next.isEnabled()) ? 'enabled' : 'disabled';
+        },
+        { timeout: 5000 },
+      )
+      .not.toBe('disabled');
+  }
+
   test('a refused password save is reported to the operator', async ({ page }) => {
     await refuseEverySave(page);
     await gotoSecurityStep(page);
@@ -84,8 +112,8 @@ test.describe('Wizard: a refused save must not read as success', () => {
      * on a NON-event, so it succeeded at its first poll, at t~0, before the
      * async advance had happened. The locator was groping at the right idea --
      * `useInnerText` to dodge hidden steps' markup -- but the missing piece
-     * was a bounded settle, which asserting that something must NOT happen
-     * always needs.
+     * was a settle point that actually corresponds to the async work
+     * finishing, which asserting that something must NOT happen always needs.
      *
      * `[x-text="steps[currentStep]"]` is unique in the template and unaffected
      * by hidden markup, so it discriminates where `body` could not.
@@ -93,6 +121,13 @@ test.describe('Wizard: a refused save must not read as success', () => {
      * This is the security-relevant half of the task: does a refused PASSWORD
      * save leave the operator on the Security step, or strand them further in
      * with no credential stored.
+     *
+     * The settle point is the failure toast, not a fixed sleep. `toast()` in
+     * `nextStep()`'s catch block is written by the exact branch that skips
+     * `this.currentStep++` -- `saveCurrentStep()` throws before that line is
+     * reached, in the same synchronous try block, so observing the toast
+     * PROVES currentStep was never incremented on this cycle, rather than
+     * hoping a guessed duration was long enough.
      */
     await refuseEverySave(page);
     await gotoSecurityStep(page);
@@ -101,9 +136,7 @@ test.describe('Wizard: a refused save must not read as success', () => {
     await SECURITY_PASSWORD(page).fill('hunter2');
     await page.getByRole('button', { name: /Continue/i }).click();
 
-    // Bounded settle: this asserts a non-event, so it must outlive the advance
-    // it is claiming did not happen.
-    await page.waitForTimeout(1500);
+    await expect(page.locator('[x-text="message"]')).toBeVisible({ timeout: 5000 });
 
     await expect(
       page.locator('[x-text="steps[currentStep]"]'),
@@ -201,12 +234,13 @@ test.describe('Wizard: a refused save must not read as success', () => {
     await SECURITY_PASSWORD(page).fill('hunter2');
     await page.getByRole('button', { name: /^Skip$/i }).click();
 
-    // Walk to the summary step.
+    // Walk to the summary step. See waitForWizardButtonSettled above for why
+    // this is not a plain toBeEnabled().
     for (let i = 0; i < 4; i++) {
       const next = page.getByRole('button', { name: /Continue|Finish Setup/i });
       if (!(await next.isVisible().catch(() => false))) break;
       await next.click();
-      await page.waitForTimeout(300);
+      await waitForWizardButtonSettled(next);
     }
 
     // Scoped to the Authentication row itself. Asserting on `body` was too
@@ -249,16 +283,17 @@ test.describe('Wizard: a refused save must not read as success', () => {
 
     await SECURITY_PASSWORD(page).fill('hunter2');
     await page.getByRole('button', { name: /Continue/i }).click();   // really saves
-    await page.waitForTimeout(500);
+    await expect(page.getByRole('button', { name: /Continue/i })).toBeEnabled();
     await page.getByRole('button', { name: /Back/i }).click();
     await expect(SECURITY_PASSWORD(page)).toBeVisible({ timeout: 5000 });
     await page.getByRole('button', { name: /^Skip$/i }).click();
 
+    // Same settle point as the loop above.
     for (let i = 0; i < 4; i++) {
       const next = page.getByRole('button', { name: /Continue|Finish Setup/i });
       if (!(await next.isVisible().catch(() => false))) break;
       await next.click();
-      await page.waitForTimeout(300);
+      await waitForWizardButtonSettled(next);
     }
 
     await expect(
@@ -295,12 +330,13 @@ test.describe('Wizard: a refused save must not read as success', () => {
     });
     await gotoSecurityStep(page);
 
-    // Walk forward until the renamer save is attempted and refused.
+    // Walk forward until the renamer save is attempted and refused. Same
+    // settle point as the loops above.
     for (let i = 0; i < 5; i++) {
       const next = page.getByRole('button', { name: /Continue|Finish Setup/i });
       if (!(await next.isVisible().catch(() => false))) break;
       await next.click();
-      await page.waitForTimeout(400);
+      await waitForWizardButtonSettled(next);
       const msg = await page.locator('[x-text="message"]').textContent().catch(() => '');
       if (msg && /fail|refus|error/i.test(msg)) break;
     }

--- a/tests/e2e/wizard.spec.ts
+++ b/tests/e2e/wizard.spec.ts
@@ -58,32 +58,53 @@ test.describe('Wizard: a refused save must not read as success', () => {
     await expect(SECURITY_USERNAME(page)).toBeVisible({ timeout: 5000 });
   }
 
+  /** The header's current-step label, e.g. "Providers" or "Done". */
+  const stepLabel = (page: any) => page.locator('[x-text="steps[currentStep]"]');
+
   /**
-   * Settle point for the wizard's Continue/Finish Setup button after a
+   * Outcome point for the wizard's Continue/Finish Setup button after a
    * click, used by the "walk forward N steps" loops below.
    *
-   * The button carries `:disabled="saving"`, so waiting for it to become
-   * enabled again is normally the right signal that nextStep()'s save (or
-   * its absence) has resolved. But on the LAST step (Library), that same
-   * click also advances currentStep to 5, which hides the whole footer via
-   * `x-show="currentStep < 5"` -- and a role-based locator like
-   * `getByRole('button', ...)` excludes a `display:none` element from
-   * matching at all. `toBeEnabled()` alone therefore hangs for the full
-   * timeout on exactly that transition: not a real race in the app, but a
-   * mismatch between the assertion and a button that is SUPPOSED to
-   * disappear. Both outcomes -- re-enabled, or gone -- are the real end of
-   * the async work, so both count as settled here.
+   * This used to poll the button for "enabled or gone" -- a proxy for
+   * `nextStep()`'s async save having resolved. Under load that proxy went
+   * stale before the thing it stood in for: five isolated runs of this file
+   * passed and it still timed out under the full suite, because a slower
+   * machine can leave the button visible-and-enabled for a moment that
+   * outlasts the poll's budget even though the save itself is done. The
+   * fix is to stop watching the button and watch the state `nextStep()`
+   * itself changes.
+   *
+   * `nextStep()` has exactly two outcomes (see its try/catch at
+   * wizard.html:1148 onward): the save resolves and `currentStep++` runs,
+   * or it throws and `toast()` writes the failure message -- `saving` is
+   * reset to false on both paths, which is why the old button-based signal
+   * could not tell them apart. Waiting on `steps[currentStep]` and the
+   * toast directly discriminates the two real outcomes instead of a shared
+   * side effect of both.
+   *
+   * `steps[currentStep]` lives in the progress header (wizard.html:28),
+   * outside the `x-show="currentStep < 5"` footer that hides the button --
+   * so, unlike the button, it keeps reporting correctly on the final
+   * Library -> summary transition without any step-specific branch: the
+   * label simply reads "Done" there the same way it reads "Providers" or
+   * "Library" on every earlier step. One signal, no special case.
    */
-  async function waitForWizardButtonSettled(next: any): Promise<void> {
+  async function waitForWizardStepOutcome(page: any, beforeStepName: string | null): Promise<void> {
+    const toast = page.locator('[x-text="message"]');
     await expect
       .poll(
         async () => {
-          if (!(await next.isVisible().catch(() => false))) return 'gone';
-          return (await next.isEnabled()) ? 'enabled' : 'disabled';
+          const [stepText, toastVisible] = await Promise.all([
+            stepLabel(page).textContent().catch(() => null),
+            toast.isVisible().catch(() => false),
+          ]);
+          if (stepText !== beforeStepName) return 'advanced';
+          if (toastVisible) return 'refused';
+          return 'pending';
         },
         { timeout: 5000 },
       )
-      .not.toBe('disabled');
+      .not.toBe('pending');
   }
 
   test('a refused password save is reported to the operator', async ({ page }) => {
@@ -234,13 +255,14 @@ test.describe('Wizard: a refused save must not read as success', () => {
     await SECURITY_PASSWORD(page).fill('hunter2');
     await page.getByRole('button', { name: /^Skip$/i }).click();
 
-    // Walk to the summary step. See waitForWizardButtonSettled above for why
-    // this is not a plain toBeEnabled().
+    // Walk to the summary step. See waitForWizardStepOutcome above for why
+    // this waits on the step label rather than the button.
     for (let i = 0; i < 4; i++) {
       const next = page.getByRole('button', { name: /Continue|Finish Setup/i });
       if (!(await next.isVisible().catch(() => false))) break;
+      const beforeStep = await stepLabel(page).textContent();
       await next.click();
-      await waitForWizardButtonSettled(next);
+      await waitForWizardStepOutcome(page, beforeStep);
     }
 
     // Scoped to the Authentication row itself. Asserting on `body` was too
@@ -288,12 +310,13 @@ test.describe('Wizard: a refused save must not read as success', () => {
     await expect(SECURITY_PASSWORD(page)).toBeVisible({ timeout: 5000 });
     await page.getByRole('button', { name: /^Skip$/i }).click();
 
-    // Same settle point as the loop above.
+    // Same outcome point as the loop above.
     for (let i = 0; i < 4; i++) {
       const next = page.getByRole('button', { name: /Continue|Finish Setup/i });
       if (!(await next.isVisible().catch(() => false))) break;
+      const beforeStep = await stepLabel(page).textContent();
       await next.click();
-      await waitForWizardButtonSettled(next);
+      await waitForWizardStepOutcome(page, beforeStep);
     }
 
     await expect(
@@ -331,12 +354,13 @@ test.describe('Wizard: a refused save must not read as success', () => {
     await gotoSecurityStep(page);
 
     // Walk forward until the renamer save is attempted and refused. Same
-    // settle point as the loops above.
+    // outcome point as the loops above.
     for (let i = 0; i < 5; i++) {
       const next = page.getByRole('button', { name: /Continue|Finish Setup/i });
       if (!(await next.isVisible().catch(() => false))) break;
+      const beforeStep = await stepLabel(page).textContent();
       await next.click();
-      await waitForWizardButtonSettled(next);
+      await waitForWizardStepOutcome(page, beforeStep);
       const msg = await page.locator('[x-text="message"]').textContent().catch(() => '');
       if (msg && /fail|refus|error/i.test(msg)) break;
     }


### PR DESCRIPTION
SonarQube `typescript:S2925`, "Fixed waits should not be used in tests", stood
at 80 findings and had risen from 60 that day because I added eleven while doing
other work. This clears the two files I had touched.

    tests/e2e/accessibility.a11y.spec.ts   27 waits -> 0
    tests/e2e/wizard.spec.ts                5 waits -> 0

Every one was waiting for something the test could simply assert on: a page's
content after `goto`, or a wizard step after a click. None was the legitimate
case, which is a transition with no observable end state.

## Measured effect

| File | Before | After |
|---|---|---|
| `wizard.spec.ts` | 29.3s | 18.2s |
| `accessibility.a11y.spec.ts` | 69.6s | 47.0s |

33 seconds per run, and the tests now wait for events rather than guessing at
durations.

## The replacement was wrong first, in an instructive way

The initial replacement for the wizard's walk-forward loops polled the Continue
button for "enabled or gone". That passed five isolated runs and then failed
under full-suite load:

    Error: Timeout 5000ms exceeded while waiting on the predicate

Not an app race: `nextStep()` sets `saving = true`, wraps the save in
try/catch, and clears it on both paths. And not a number to raise: the
hardcoded 5000 is identical to `playwright.config.ts`'s project-wide
`expect.timeout`.

The helper watched the wrong thing. `nextStep()` has exactly two outcomes,
advance or toast, and `saving` is cleared on both, so a button-based signal
cannot discriminate them. `waitForWizardStepOutcome` now polls
`steps[currentStep]` and the toast together. It also removes a special case:
that label lives outside the `x-show="currentStep < 5"` footer, so the final
transition needs no separate branch.

The shape is worth recording: a change removing tests that waited on a clock
rather than a condition, whose own replacement waited on a proxy rather than
the condition. Same family, one level up.

## Verification

Two full-load passes, run in the foreground rather than through a backgrounded
gate:

- `--project=chromium --fail-on-flaky-tests`: 168/168
- `--project=isolation --workers=2`: 2/2
- `--project=mobile-chrome`: 10/10
- `--project=accessibility`: 85/85
- `./scripts/verify.sh --no-e2e`: 3894 unit, 42 integration, 214 UI unit
- plus one complete `make verify` run, clean

The known-flaky Navigation tests did not flake in either pass.

## Two operational findings, recorded in the session notes

A crashed worker leaves `.e2e-w0-data` behind and every later test then fails
at 0ms. That is not contention, though it looks like it; the log names the
cause and the fix (`python scripts/e2e_worker_data.py cleanup 0`). I
misdiagnosed it once and discarded two runs over it.

And a backgrounded `make verify` is not trustworthy here: it was SIGTERM'd
twice at the same point despite `nohup` and `disown`, because disowning drops
job tracking but not process-group membership.

The remaining 48 findings of this rule are in files this change did not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
