### PR TITLE
test: split composite assertions so a failure names which half broke

### DIFF
--- a/tests/integration/test_migration.py
+++ b/tests/integration/test_migration.py
@@ -472,7 +472,8 @@ class TestMigrationFailureModes:
         )
         # The reassurance is load-bearing: an operator who thinks the source
         # was damaged may go looking for a backup they do not need.
-        assert 'source is' in message and 'untouched' in message, message
+        assert 'source is' in message, message
+        assert 'untouched' in message, message
 
     def test_the_remedy_differs_by_where_the_clash_actually_is(self, tmp_path):
         """Three states, and each issues a DIFFERENT destructive instruction.
@@ -502,7 +503,9 @@ class TestMigrationFailureModes:
 
         found, text = _describe_identifier_collision(source_clash)
         assert found is True
-        assert 'imdb=tt1' in text and 'a' in text and 'b' in text
+        assert 'imdb=tt1' in text, text
+        assert 'a' in text, text
+        assert 'b' in text, text
 
         found, _text = _describe_identifier_collision(no_clash)
         assert found is False

--- a/tests/unit/test_auth_required_lockout_guard.py
+++ b/tests/unit/test_auth_required_lockout_guard.py
@@ -393,8 +393,11 @@ class TestASavedPasswordIsNeverEchoedBack:
                                     '$2b$12$abcdefghijklmnopqrstuv', 'password')
 
         assert stored == '$2b$12$abcdefghijklmnopqrstuv', 'the hash was not stored'
-        assert 'value' not in result and 'submitted' not in result, (
-            'the save response echoed a password-typed option: %r' % (result,)
+        assert 'value' not in result, (
+            'the save response echoed a password-typed option value: %r' % (result,)
+        )
+        assert 'submitted' not in result, (
+            'the save response echoed a password-typed option submission: %r' % (result,)
         )
         assert not any(str(v).startswith('$2b$') for v in result.values()), (
             'a bcrypt hash reached the response body: %r' % (result,)
@@ -530,7 +533,8 @@ class TestTheMaskWithholdsForAnUnregisteredOption:
             'an UNREGISTERED password option echoed its value: %r' % (result,)
         )
         blob = repr(result)
-        assert 'hunter2' not in blob and '$2b$' not in blob
+        assert 'hunter2' not in blob, blob
+        assert '$2b$' not in blob, blob
 
     def test_a_registered_ordinary_string_still_echoes(self):
         """Anti-vacuity: withholding must not become "withhold everything"."""

--- a/tests/unit/test_check_snatched_resilience.py
+++ b/tests/unit/test_check_snatched_resilience.py
@@ -139,7 +139,8 @@ class TestCreateNzbName:
         with patch.object(type(plugin), 'cpTag', return_value='', create=True):
             name = plugin.createNzbName({}, {'identifiers': {'imdb': 'tt1234567'}})
 
-        assert name and 'None' not in name
+        assert name, 'expected a fallback name to be produced'
+        assert 'None' not in name, name
 
 
 class TestCheckSnatchedIsolatesBadReleases:

--- a/tests/unit/test_check_test_traps.py
+++ b/tests/unit/test_check_test_traps.py
@@ -2452,7 +2452,8 @@ def test_a_hyphenated_custom_element_is_not_a_script_block(tmp_path):
         '<script>\nconst a = "</script-loader>";\nconst broken = (;\n</script>\n'
     )
     findings = findings_for(early_close)
-    assert findings and findings[0][0] == 3, (
+    assert findings, "expected the early-closed script block to be flagged at all"
+    assert findings[0][0] == 3, (
         "expected the real error at line 3, got %r -- the block was closed early "
         "by a string" % findings
     )
@@ -2494,7 +2495,8 @@ def test_a_commented_out_script_element_is_not_parsed(tmp_path):
         "<!--\n<script>\nignored (;\n</script>\n-->\n<script>\nconst broken = (;\n</script>\n"
     )
     findings = findings_for(both)
-    assert findings and findings[0][0] == 7, (
+    assert findings, "expected the real block after the comment to be flagged at all"
+    assert findings[0][0] == 7, (
         "the real block after a comment must still be checked, at its own line; got %r"
         % findings
     )
@@ -2742,7 +2744,8 @@ def test_a_killed_parser_is_reported_as_could_not_run(tmp_path, monkeypatch):
     path = tmp_path / "x.html"
     path.write_text("<script>\nconst x = 1;\n</script>\n")
     findings = findings_for(path)
-    assert findings and "could not run" in findings[0][1], findings
+    assert findings, "expected the killed parser to be reported as a finding"
+    assert "could not run" in findings[0][1], findings
 
 
 @requires_node

--- a/tests/unit/test_claude_review_skip_is_visible.py
+++ b/tests/unit/test_claude_review_skip_is_visible.py
@@ -404,7 +404,11 @@ class TestTheStepBehavesWhenRun:
             'the notice never says the review did not happen, so it reads like '
             'any other automated comment. Body:\n%s' % body
         )
-        assert 'green' in low and ('not' in low or 'does not' in low), (
+        assert 'green' in low, (
+            'the notice never mentions the green check it is warning about. '
+            'Body:\n%s' % body
+        )
+        assert 'not' in low or 'does not' in low, (
             'the notice does not tell the reader that the green check is not a '
             'passed review, which is the single thing it exists to say. '
             'Body:\n%s' % body

--- a/tests/unit/test_corrupted_document_reporting.py
+++ b/tests/unit/test_corrupted_document_reporting.py
@@ -133,8 +133,11 @@ class TestItLogsAtErrorNamingTheDocument:
             database.reportCorrupted('doc-123', traceback_error='ValueError: bad json')
 
         message = _error_records(caplog)[0].getMessage().lower()
-        assert 'not' in message and 'delet' in message, (
+        assert 'not' in message, (
             'the message must say plainly the document was NOT deleted: %r' % message
+        )
+        assert 'delet' in message, (
+            'the message must say plainly the document was not DELETED: %r' % message
         )
 
     def test_the_traceback_error_is_included(self, database, caplog):

--- a/tests/unit/test_downloaders.py
+++ b/tests/unit/test_downloaders.py
@@ -674,7 +674,10 @@ class TestPutIO:
         # delete_after_download=...)` (bound off the `_File` resource class in
         # 8.8.0) must still accept `dest` and `delete_after_download`.
         file_cls = getattr(putiopy, '_File', None) or getattr(putiopy, 'File', None)
-        assert file_cls is not None and hasattr(file_cls, 'download'), (
+        assert file_cls is not None, (
+            'putiopy no longer exposes a File resource class at all'
+        )
+        assert hasattr(file_cls, 'download'), (
             'putiopy no longer exposes a File resource class with a download() '
             'method'
         )
@@ -688,7 +691,10 @@ class TestPutIO:
         # Transfer.add_url, called as
         # `client.Transfer.add_url(url, callback_url=..., parent_id=...)`.
         transfer_cls = getattr(putiopy, '_Transfer', None) or getattr(putiopy, 'Transfer', None)
-        assert transfer_cls is not None and hasattr(transfer_cls, 'add_url'), (
+        assert transfer_cls is not None, (
+            'putiopy no longer exposes a Transfer resource class at all'
+        )
+        assert hasattr(transfer_cls, 'add_url'), (
             'putiopy no longer exposes a Transfer resource class with an '
             'add_url() method'
         )
@@ -2216,7 +2222,12 @@ class TestRTorrentDownload:
         # info_hash (2nd positional arg) is now passed to load_torrent
         # directly, instead of load_torrent re-deriving it internally.
         assert call_args[1] == expected_hash
-        assert isinstance(call_args[1], str) and len(call_args[1]) == 40
+        assert isinstance(call_args[1], str), (
+            f'info_hash must be passed as a str, got {type(call_args[1])!r}'
+        )
+        assert len(call_args[1]) == 40, (
+            f'info_hash must be a 40-char sha1 hex digest, got {call_args[1]!r}'
+        )
         mock_torrent.set_custom.assert_called_once_with(1, 'movies')
         mock_torrent.start.assert_called_once()
         assert result['id'] == expected_hash

--- a/tests/unit/test_extractor.py
+++ b/tests/unit/test_extractor.py
@@ -1075,7 +1075,8 @@ class TestCollisionWarningIsAlsoBounded:
             'unbounded collision warnings: %d lines from one archive' % len(per_entry)
         )
         summary = [m for m in messages if 'collided on the same destination' in m]
-        assert summary and '1000' in summary[0], (
+        assert summary, 'no collision-total summary line was logged at all'
+        assert '1000' in summary[0], (
             'the collision total was not reported, so the cap hides the scale'
         )
 
@@ -1255,7 +1256,8 @@ class TestUnreadableEntryLoggingIsAlsoBounded:
             'archive' % len(per_entry)
         )
         summary = [m for m in messages if 'could not be read in total' in m]
-        assert summary and '1000' in summary[0], (
+        assert summary, 'no unreadable-total summary line was logged at all'
+        assert '1000' in summary[0], (
             'the unreadable total was not reported, so the cap hides the scale'
         )
         assert extracted == [], 'nothing was extractable, so the list must be empty'
@@ -1355,7 +1357,8 @@ class TestOverlongNameLoggingIsAlsoBounded:
         )
         summary = [m for m in messages if 'could not be written' in m
                    and 'in total' in m]
-        assert summary and '1000' in summary[0], (
+        assert summary, 'no unwritable-total summary line was logged at all'
+        assert '1000' in summary[0], (
             'the unwritable total was not reported, so the cap hides the scale'
         )
         assert extracted == []
@@ -1463,7 +1466,8 @@ class TestTheSummarySurvivesAnAbortedArchive:
 
         summary = [r.getMessage() for r in caplog.records
                    if 'refused in total' in r.getMessage()]
-        assert summary and '6' in summary[0], (
+        assert summary, 'no refused-in-total summary line was logged at all'
+        assert '6' in summary[0], (
             'the archive aborted and took its own diagnostic counts with it, '
             'which is the case the summary exists for'
         )
@@ -1726,7 +1730,8 @@ class TestEntryHardCapLoggingIsAlsoBounded:
         )
         summary = [m for m in messages
                    if 'per-entry size ceiling' in m and 'in total' in m]
-        assert summary and '1000' in summary[0], (
+        assert summary, 'no oversized-entry-total summary line was logged at all'
+        assert '1000' in summary[0], (
             'the oversized-entry total was not reported, so the cap hides '
             'the scale'
         )

--- a/tests/unit/test_fastapi_web.py
+++ b/tests/unit/test_fastapi_web.py
@@ -840,11 +840,19 @@ class TestTemplateRendering:
         done_window = html[max(0, pos_done - 400):pos_done + 100]
         failed_window = html[max(0, pos_failed - 400):pos_failed + 100]
 
-        assert 'bg-cp-success/10' in done_window and 'text-cp-success' in done_window, (
-            'Mark Done must use the success token'
+        assert 'bg-cp-success/10' in done_window, (
+            'Mark Done must use the success background token'
         )
-        assert 'bg-cp-danger/10' in failed_window and 'text-cp-danger' in failed_window, (
-            'Mark Failed must use the danger token, matching movie_detail.html:283'
+        assert 'text-cp-success' in done_window, (
+            'Mark Done must use the success text token'
+        )
+        assert 'bg-cp-danger/10' in failed_window, (
+            'Mark Failed must use the danger background token, matching '
+            'movie_detail.html:283'
+        )
+        assert 'text-cp-danger' in failed_window, (
+            'Mark Failed must use the danger text token, matching '
+            'movie_detail.html:283'
         )
         assert 'bg-cp-danger' not in done_window, (
             'Mark Done must not also carry the danger token'

--- a/tests/unit/test_git_env_namespace_scrub.py
+++ b/tests/unit/test_git_env_namespace_scrub.py
@@ -186,7 +186,8 @@ class TestNonGitVariablesAreUntouched:
         # function -- the strongest available check that the strip has not
         # eaten something load-bearing well outside the GIT_* namespace.
         env = sanitized_git_env()
-        assert 'PATH' in env and env['PATH']
+        assert 'PATH' in env, 'PATH was stripped entirely'
+        assert env['PATH'], 'PATH survived but was emptied'
 
 
 class TestTheTemplateDirEscapeIsClosed:
@@ -239,7 +240,11 @@ class TestTheTemplateDirEscapeIsClosed:
             'hook either way: %s' % commit.stderr
         )
         head = git('rev-parse', 'HEAD')
-        assert head.returncode == 0 and head.stdout.strip(), (
+        assert head.returncode == 0, (
+            'rev-parse itself failed -- the test setup is broken, '
+            'not just the assertion under test: %s' % head.stderr
+        )
+        assert head.stdout.strip(), (
             'no commit was actually created -- the test setup is broken, '
             'not just the assertion under test'
         )

--- a/tests/unit/test_login_page.py
+++ b/tests/unit/test_login_page.py
@@ -111,7 +111,8 @@ class TestLoginPageRendersDesignSystem:
     def test_login_page_has_submit_button(self, client):
         resp = client.get('/login/')
         text = resp.text.lower()
-        assert '<button' in text and 'type="submit"' in text
+        assert '<button' in text, 'no button element on the login page'
+        assert 'type="submit"' in text, 'the login page button is not type="submit"'
 
     def test_login_page_form_posts_to_same_url(self, client):
         resp = client.get('/login/')

--- a/tests/unit/test_login_page_a11y.py
+++ b/tests/unit/test_login_page_a11y.py
@@ -191,7 +191,8 @@ class TestTheSubmitButtonLabel:
 
         fg, _ = _resolve(classes, 'text', palette)
         bg, _ = _resolve(classes, 'bg', palette)
-        assert fg and bg, (classes, sorted(palette))
+        assert fg, ('no foreground colour resolved', classes, sorted(palette))
+        assert bg, ('no background colour resolved', classes, sorted(palette))
         ratio = contrast_ratio(fg, bg)
 
         assert ratio >= MIN_TEXT_RATIO, (
@@ -267,8 +268,11 @@ class TestTheStatusMessage:
 
         fg, _ = _resolve(classes, 'text', palette)
         tint, alpha = _resolve(classes, 'bg', palette)
-        assert fg and tint, (classes, sorted(palette))
-        assert alpha is not None and alpha < 1.0, (
+        assert fg, ('no foreground colour resolved', classes, sorted(palette))
+        assert tint, ('no background tint resolved', classes, sorted(palette))
+        assert alpha is not None, (
+            'the panel background carries no alpha channel at all: %s' % classes)
+        assert alpha < 1.0, (
             'the panel is an opaque fill rather than a tint of an existing '
             'token: %s' % classes)
 

--- a/tests/unit/test_login_page_messages.py
+++ b/tests/unit/test_login_page_messages.py
@@ -552,8 +552,8 @@ class TestTheSignOutFailurePage:
         role, text = region
         assert role == 'alert', role
         lowered = text.lower()
-        assert 'still' in lowered and ('signed in' in lowered or 'valid' in lowered
-                                       or 'active' in lowered), text
+        assert 'still' in lowered, text
+        assert 'signed in' in lowered or 'valid' in lowered or 'active' in lowered, text
         for banned in FORBIDDEN_IN_COPY:
             assert banned not in lowered, (banned, text)
 
@@ -691,7 +691,8 @@ class TestACorrectPasswordThatCannotStartASessionSaysSo:
         response = self._login_with_a_broken_store(client, monkeypatch, settings)
 
         body = response.text.lower()
-        assert 'incorrect' not in body and 'not recognised' not in body, body[:400]
+        assert 'incorrect' not in body, body[:400]
+        assert 'not recognised' not in body, body[:400]
 
     def test_it_sets_no_cookie(self, client, monkeypatch, settings):
         """Fail closed is unchanged: no secret, no session."""

--- a/tests/unit/test_mark_done.py
+++ b/tests/unit/test_mark_done.py
@@ -69,7 +69,10 @@ def test_mark_done_conflict_error_after_retries_returns_failure_and_logs_warning
         result = plugin.markDone(id='movie-1')
 
     assert result['success'] is False
-    assert isinstance(result['error'], str) and result['error']
+    assert isinstance(result['error'], str), (
+        f"result['error'] must be a string, got {type(result['error'])!r}"
+    )
+    assert result['error'], "result['error'] must not be empty"
 
     warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
     error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]

--- a/tests/unit/test_no_forked_workflow_copies.py
+++ b/tests/unit/test_no_forked_workflow_copies.py
@@ -163,8 +163,12 @@ def test_the_trigger_override_is_present_and_readable():
         % (sorted(set(rules.keys()) - set(TRIGGER_KEYS)), sorted(TRIGGER_KEYS))
     )
     for key in TRIGGER_KEYS:
-        assert isinstance(rules.get(key), list) and rules[key], (
-            'harness-triggers.json is missing a non-empty "%s" glob list; the '
+        assert isinstance(rules.get(key), list), (
+            'harness-triggers.json["%s"] is missing or not a list; the '
+            'installed workflow reads exactly these keys.' % key
+        )
+        assert rules[key], (
+            'harness-triggers.json["%s"] is an empty glob list; the '
             'installed workflow reads exactly these keys.' % key
         )
 
@@ -202,14 +206,21 @@ def test_harness_triggers_json_matches_the_agents_md_table():
         table_globs = table.get(key, set())
         only_in_json = json_globs - table_globs
         only_in_table = table_globs - json_globs
-        assert not only_in_json and not only_in_table, (
+        assert not only_in_json, (
             'harness-triggers.json["%s"] and the AGENTS.md trigger table have '
             'drifted.\n'
             'In harness-triggers.json but not in the AGENTS.md table: %s\n'
+            'Change both together; see AGENTS.md, "Multi-lens harness: path '
+            'triggers and precedence".'
+            % (key, sorted(only_in_json))
+        )
+        assert not only_in_table, (
+            'harness-triggers.json["%s"] and the AGENTS.md trigger table have '
+            'drifted.\n'
             'In the AGENTS.md table but not in harness-triggers.json: %s\n'
             'Change both together; see AGENTS.md, "Multi-lens harness: path '
             'triggers and precedence".'
-            % (key, sorted(only_in_json), sorted(only_in_table))
+            % (key, sorted(only_in_table))
         )
 
     assert 'couchpotato/api.py' in rules['architecture']

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -410,8 +410,11 @@ class TestFanartTVProvider:
         p = self._make_provider()
         assert getattr(p, 'ak', None), 'the shipped fanart.tv key is gone'
         decoded = b64decode(p.ak).decode()
-        assert len(decoded) == 32 and all(c in '0123456789abcdef' for c in decoded), (
-            f'shipped key is not a 32-char hex API key: {decoded!r}'
+        assert len(decoded) == 32, (
+            f'shipped key is not 32 characters long: {decoded!r}'
+        )
+        assert all(c in '0123456789abcdef' for c in decoded), (
+            f'shipped key is not hex-encoded: {decoded!r}'
         )
 
     def test_trimDiscs_bluray_only(self):

--- a/tests/unit/test_rate_limit_auth_routes.py
+++ b/tests/unit/test_rate_limit_auth_routes.py
@@ -267,7 +267,8 @@ class TestTheRateLimitedResponseIsUsable:
         message = ' '.join(re.sub(r'<[^>]+>', ' ', match.group(1)).split()).lower()
 
         assert 'username' not in message, message
-        assert 'was wrong' not in message and 'incorrect' not in message, message
+        assert 'was wrong' not in message, message
+        assert 'incorrect' not in message, message
         assert 'not accepted' not in message, message
 
     def test_it_leaks_no_mechanism(self, client):

--- a/tests/unit/test_release_for_media_real_backend.py
+++ b/tests/unit/test_release_for_media_real_backend.py
@@ -271,9 +271,11 @@ class TestDetachFileDoesNotLogTheLibraryPath:
         assert secret not in messages, (
             'the library path reached the log through the exception: %s' % messages
         )
-        assert '/mnt/nas' not in messages and 'Some Movie' not in messages
+        assert '/mnt/nas' not in messages, messages
+        assert 'Some Movie' not in messages, messages
         # The bound must not cost the diagnosis.
-        assert 'Permission denied' in messages and '13' in messages
+        assert 'Permission denied' in messages, messages
+        assert '13' in messages, messages
         assert rel['_id'] in messages
 
 
@@ -322,7 +324,8 @@ class TestDetachFileActuallyDetaches:
         rel = self._with_files(db, 'm-1', {'movie': [str(a), str(b)]})
         # Read it back rather than trusting insert()'s return value.
         before = db.get('id', rel['_id']).get('copy_id')
-        assert before and ',' in before, (
+        assert before, 'the fixture stored no copy_id at all'
+        assert ',' in before, (
             'the fixture did not store a two-file identity: %r' % before
         )
 
@@ -414,7 +417,8 @@ class TestWithoutPathsNeverStringifiesAnOSError:
         from couchpotato.core.logger import without_paths
 
         rendered = without_paths(PermissionError(13, 'Permission denied', '/x/y.mkv'))
-        assert '13' in rendered and 'Permission denied' in rendered
+        assert '13' in rendered, rendered
+        assert 'Permission denied' in rendered, rendered
         assert '/x/y.mkv' not in rendered
 
     def test_a_non_OSError_keeps_its_message(self):

--- a/tests/unit/test_renamer_decision_memory.py
+++ b/tests/unit/test_renamer_decision_memory.py
@@ -201,7 +201,8 @@ class TestAnUnchangedDeclinedGroupIsNotRescanned:
         # "Already decided" must never become "already done" (AC-QA-12):
         # both the library file and the download must survive, byte for
         # byte, no matter how many times an unchanged scan runs.
-        assert world['dst'] and open(world['dst'], 'rb').read() == world['original_dst_bytes'], (
+        assert world['dst'], 'the collided scan reported no destination path at all'
+        assert open(world['dst'], 'rb').read() == world['original_dst_bytes'], (
             'the collided library file was modified by a scan that should '
             'only ever have refused'
         )

--- a/tests/unit/test_renamer_mover.py
+++ b/tests/unit/test_renamer_mover.py
@@ -457,7 +457,8 @@ class TestLinkFallback:
         result = _move(plugin, tmp_path, str(old), str(dest))
 
         assert result is True
-        assert os.path.exists(old) and not os.path.islink(old), 'old must remain a real file'
+        assert os.path.exists(old), 'old must still exist'
+        assert not os.path.islink(old), 'old must remain a real file, not a symlink'
         assert Path(old).read_bytes() == DOWNLOAD
         assert dest.read_bytes() == DOWNLOAD
         assert not os.path.islink(dest)
@@ -587,7 +588,8 @@ class TestT18DataLossFixes:
         result = _move(plugin, tmp_path, str(old), str(dest))
 
         assert result is True, 'this branch still degrades to a plain copy and reports success'
-        assert os.path.exists(old) and not os.path.islink(old), (
+        assert os.path.exists(old), 'old must still exist'
+        assert not os.path.islink(old), (
             'old must remain the real file -- never unlinked ahead of the replace'
         )
         assert Path(old).read_bytes() == DOWNLOAD
@@ -949,7 +951,8 @@ class TestCallerLevelDataLossGuards:
         )
 
         assert deleted == [], 'source folder must not be cleaned up when nothing moved'
-        assert old.exists() and old.read_bytes() == DOWNLOAD, 'the download must survive'
+        assert old.exists(), 'the download must survive'
+        assert old.read_bytes() == DOWNLOAD, 'the download must survive unmodified'
 
     def test_fix_b_a_failed_hardlink_fallback_replace_leaves_no_stray_link_via_the_real_caller(self, tmp_path, monkeypatch):
         """AC-DATA-12 / AC-QA-15 / AC-QA-17 at the caller level. Unlike (a) and
@@ -1033,7 +1036,8 @@ class TestCallerLevelDataLossGuards:
         )
 
         assert deleted == [], 'the source folder must not be cleaned up when the move never happened'
-        assert old.exists() and old.read_bytes() == DOWNLOAD, 'the download must survive'
+        assert old.exists(), 'the download must survive'
+        assert old.read_bytes() == DOWNLOAD, 'the download must survive unmodified'
         assert not os.path.exists(dest), 'nothing reached the destination either'
 
 

--- a/tests/unit/test_replacement_end_to_end.py
+++ b/tests/unit/test_replacement_end_to_end.py
@@ -272,7 +272,8 @@ class TestTheRecordNamesTheMediaNotThePath:
         assert replaced, 'the replacement was not recorded at all'
         assert world['dst'] not in replaced[0]
         assert 'media-1' in replaced[0]
-        assert '720p' in replaced[0] and '2160p' in replaced[0]
+        assert '720p' in replaced[0], replaced[0]
+        assert '2160p' in replaced[0], replaced[0]
 
 
 class TestAFailedSupersedeDoesNotUndoASuccessfulSwap:
@@ -641,7 +642,8 @@ class TestNoFilesystemPathReachesTheLogDuringAReplacement:
         ]
         assert announced
         assert 'media-1' in announced[0]
-        assert '720p' in announced[0] and '2160p' in announced[0]
+        assert '720p' in announced[0], announced[0]
+        assert '2160p' in announced[0], announced[0]
 
 
 class TestAGuessedMovieIdentityNeverAuthorisesDestruction:
@@ -1307,7 +1309,8 @@ class TestRedactingAnExceptionKeepsItsDiagnosis:
         error = PermissionError(13, 'Permission denied', '/mnt/nas/Some Movie.mkv')
         rendered = plugin._withoutPaths(error)
 
-        assert '13' in rendered and 'Permission denied' in rendered
+        assert '13' in rendered, rendered
+        assert 'Permission denied' in rendered, rendered
         assert '/mnt/nas' not in rendered
         assert 'Some Movie' not in rendered
 

--- a/tests/unit/test_replacement_operator_decision.py
+++ b/tests/unit/test_replacement_operator_decision.py
@@ -133,4 +133,5 @@ class TestTwoCandidatesRefuseRatherThanPickingOne:
         outcome_ab, existing_ab = decide_operator_replacement([a, b])
         outcome_ba, existing_ba = decide_operator_replacement([b, a])
         assert outcome_ab == outcome_ba == OPERATOR_DECLINED_AMBIGUOUS_FILE
-        assert existing_ab is None and existing_ba is None
+        assert existing_ab is None, 'a-then-b order left a stray existing release'
+        assert existing_ba is None, 'b-then-a order left a stray existing release'

--- a/tests/unit/test_replacement_wiring.py
+++ b/tests/unit/test_replacement_wiring.py
@@ -508,8 +508,9 @@ class TestForMediaHonoursRequireComplete:
         monkeypatch.setattr(release_main, 'get_db', lambda: db)
 
         result = plugin.forMedia('m', require_complete=True)
-        assert result is not None and len(result) == 1, (
-            'a deleted row made the whole set look unreadable'
+        assert result is not None, 'a deleted row made the whole set look unreadable'
+        assert len(result) == 1, (
+            'a deleted row changed the size of the readable set'
         )
         from couchpotato.core.plugins.release.main import INCOMPLETE_RELEASE_SET
         assert result is not INCOMPLETE_RELEASE_SET
@@ -527,7 +528,10 @@ class TestForMediaHonoursRequireComplete:
         monkeypatch.setattr(release_main, 'get_db', lambda: db)
 
         result = plugin.forMedia('m', require_complete=True)
-        assert result is not None and len(result) == 1
+        assert result is not None, 'a deleted document made the whole set look unreadable'
+        assert len(result) == 1, (
+            'a deleted document changed the size of the readable set'
+        )
 
     def test_a_corrupt_document_counts_as_incomplete(self, monkeypatch):
         import couchpotato.core.plugins.release.main as release_main

--- a/tests/unit/test_restore_to_wanted.py
+++ b/tests/unit/test_restore_to_wanted.py
@@ -199,7 +199,10 @@ class TestRestoreToWantedProfileResolution:
             result = plugin.restoreToWanted('movie-1')
 
         assert result['success'] is False
-        assert isinstance(result.get('error'), str) and result['error']
+        assert isinstance(result.get('error'), str), (
+            f"result['error'] must be a string, got {type(result.get('error'))!r}"
+        )
+        assert result['error'], "result['error'] must not be empty"
         assert movie['status'] == 'done', 'a refused restore must not touch the movie at all'
         assert not db.update_with_retry.called, (
             'a refused restore must never write to the movie -- that would '

--- a/tests/unit/test_scanner_search_year_disambiguation.py
+++ b/tests/unit/test_scanner_search_year_disambiguation.py
@@ -666,7 +666,11 @@ class TestAMalformedFilenameDuringTheWarningDoesNotStarveIdentification:
         warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
         assert warnings, 'setup: expected the mismatched-guess warning to fire'
         for message in warnings:
-            assert 'realuser' not in message and 'private' not in message, (
+            assert 'realuser' not in message, (
+                'the raw non-string filename value leaked into a WARNING log '
+                'line -- got %r' % message
+            )
+            assert 'private' not in message, (
                 'the raw non-string filename value leaked into a WARNING log '
                 'line -- got %r' % message
             )

--- a/tests/unit/test_search_releases_list_only.py
+++ b/tests/unit/test_search_releases_list_only.py
@@ -775,7 +775,10 @@ class TestSearchReleasesThreeWayOutcome:
         assert result['success'] is False
         assert result['searched'] is False
         assert result['found'] == 0
-        assert isinstance(result.get('reason'), str) and result['reason'], (
+        assert isinstance(result.get('reason'), str), (
+            f"result['reason'] must be a string, got {type(result.get('reason'))!r}"
+        )
+        assert result['reason'], (
             'a could-not-search outcome must name a reason the UI can show'
         )
 
@@ -1223,7 +1226,11 @@ class TestADatabaseFaultIsNotReportedAsAMissingProfile:
         assert result['searched'] is False
         assert single.called is False
         reason = result.get('reason', '').lower()
-        assert 'read' in reason and 'profile' in reason, (
+        assert 'read' in reason, (
+            'a database fault must not be reported as a configuration problem: %r'
+            % result.get('reason')
+        )
+        assert 'profile' in reason, (
             'a database fault must not be reported as a configuration problem: %r'
             % result.get('reason')
         )

--- a/tests/unit/test_searcher_correct_release.py
+++ b/tests/unit/test_searcher_correct_release.py
@@ -269,7 +269,8 @@ class TestSizeBoundsGuardedAgainstAPartialDoc:
         QualityPlugin.fill() writes has both) must not KeyError. It is
         rejected rather than silently accepted: 0MB is never a real file."""
         quality = _real_quality_missing_size(tmp_path, 'qpartial', 'dvdrip')
-        assert 'size_min' not in quality and 'size_max' not in quality
+        assert 'size_min' not in quality, quality
+        assert 'size_max' not in quality, quality
 
         nzb = _nzb(size=1500)
         media = _media()

--- a/tests/unit/test_seed_e2e_data_guard.py
+++ b/tests/unit/test_seed_e2e_data_guard.py
@@ -677,7 +677,8 @@ class TestEnablingAuthenticationRefusesARealDataDirectory:
 
         assert parser.get('core', 'auth_required') == '1'
         stored = parser.get('core', 'password')
-        assert stored and stored != 'hunter2', 'the plaintext was stored'
+        assert stored, 'no password was stored at all'
+        assert stored != 'hunter2', 'the plaintext was stored'
         assert check_password(md5('hunter2'), stored), (
             'the stored password is not the form login_post compares against '
             '(bcrypt over md5 of the plaintext), so the seeded instance would '

--- a/tests/unit/test_session_secret_recovery.py
+++ b/tests/unit/test_session_secret_recovery.py
@@ -293,7 +293,8 @@ class TestTheRegenerationIsAnnounced:
             % log_text(env)
         )
         joined = '\n'.join(warnings).lower()
-        assert 'session' in joined and 'secret' in joined, warnings
+        assert 'session' in joined, warnings
+        assert 'secret' in joined, warnings
         # The TRIGGER, not just the fact. "A new secret was created" is what
         # the INFO on a first boot already says.
         assert 'no longer in the database' in joined, warnings

--- a/tests/unit/test_sign_out_control.py
+++ b/tests/unit/test_sign_out_control.py
@@ -270,9 +270,14 @@ class TestTheLabelMatchesWhatTheButtonDoes:
         assert laptop.get('/').status_code == 200
         assert phone.post('/logout/').status_code in (302, 303)
         after = laptop.get('/')
-        assert after.status_code == 302 and 'login' in after.headers.get('location', ''), (
+        assert after.status_code == 302, (
             'the second client kept its session, so this test would happily '
             'accept a label promising "all devices" from a route that ends one'
+        )
+        assert 'login' in after.headers.get('location', ''), (
+            'the second client was redirected but not to the login page, so '
+            'this test would happily accept a label promising "all devices" '
+            'from a route that ends one'
         )
 
         lowered = label.lower()

--- a/tests/unit/test_suggestion_ignore_concurrency.py
+++ b/tests/unit/test_suggestion_ignore_concurrency.py
@@ -85,7 +85,8 @@ def test_stale_ignore_snapshot_cannot_be_persisted_last(monkeypatch):
     thread_b.start()
     thread_a.join(timeout=5)
     thread_b.join(timeout=5)
-    assert not thread_a.is_alive() and not thread_b.is_alive()
+    assert not thread_a.is_alive(), 'thread A did not finish within the join timeout'
+    assert not thread_b.is_alive(), 'thread B did not finish within the join timeout'
 
     persisted = set(stored['suggestion.ignored'].split(','))
     assert persisted == {'aaa', 'bbb'}, (

--- a/tests/unit/test_watch_history.py
+++ b/tests/unit/test_watch_history.py
@@ -113,7 +113,10 @@ def test_mark_watched_conflict_error_after_retries_returns_failure_and_logs_warn
         result = plugin.markWatched(id='movie-1', watched_by='Scott')
 
     assert result['success'] is False
-    assert isinstance(result['error'], str) and result['error']
+    assert isinstance(result['error'], str), (
+        f"result['error'] must be a string, got {type(result['error'])!r}"
+    )
+    assert result['error'], "result['error'] must not be empty"
     fire_event.assert_not_called()
 
     warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
@@ -136,7 +139,10 @@ def test_mark_unwatched_conflict_error_after_retries_returns_failure_and_logs_wa
         result = plugin.markUnwatched(id='movie-1')
 
     assert result['success'] is False
-    assert isinstance(result['error'], str) and result['error']
+    assert isinstance(result['error'], str), (
+        f"result['error'] must be a string, got {type(result['error'])!r}"
+    )
+    assert result['error'], "result['error'] must not be empty"
     fire_event.assert_not_called()
 
     warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]


### PR DESCRIPTION
T3 of the conducted SonarQube plan. `python:S9073`, 59 findings, **all in tests, zero in production code.**

## Disposition: fix, all 59

The opposite verdict to T2, and for a reason specific to this repository's week rather than tidiness. `assert a and b` reports only "assertion failed". Two assertions name which half moved. This session has repeatedly been misled by guards that were green for the wrong reason or failed for the wrong reason, and a composite assertion actively hides which condition changed.

| Shape | Count | Why |
|---|---|---|
| Independent facts joined by `and` | ~35 | Each half is a separate way the code could be wrong |
| Truthy or type guard, then the real check | ~19 | pytest halts on the first failure exactly as `and` short-circuits, so splitting is behaviour-neutral and the guard failure now reads differently from the real one |
| Outer AND wrapping an inner OR-group | 2 | **Only the outer AND was split.** The OR-group was deliberately left whole |
| Length plus charset pairs | ~3 | Wrong length and wrong encoding are distinct failures |

None of the 59 was the single-idea range check (`0 <= x <= 100`) that would have been worse split. All decomposed cleanly.

## The one that mattered

```python
-  assert 'still' in lowered and ('signed in' in lowered or 'valid' in lowered
-                                 or 'active' in lowered), text
+  assert 'still' in lowered, text
+  assert 'signed in' in lowered or 'valid' in lowered or 'active' in lowered, text
```

Splitting the inner OR would have turned "any acceptable phrasing" into "all three required" and broken a passing test. The brief said that if splitting changes what is asserted, that is a finding rather than a silent edit. It was found and left intact.

Where a guard half previously had no message, relying on the second half's, it was given one, so a guard failure is now legible too.

## Verification

3894 unit tests passing, identical pass/skip/xfail counts to before, confirming nothing was weakened or dropped. Four representative mutations across every distinct shape, including the data-loss-critical "old must remain a real file, not a symlink" assertion in the renamer: each inverted, watched fail for the real reason, restored byte-identical.

Scope confirmed against the merge base: 32 test files, no production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc