### PR TITLE
docs(plan): T4, record javascript:S7740 as left open with evidence

### DIFF
--- a/specs/PLAN-2026-09-07-sonarqube-slices.md
+++ b/specs/PLAN-2026-09-07-sonarqube-slices.md
@@ -45,8 +45,13 @@ the RULE, not the file: one judgement per pattern rather than per occurrence.
       OPEN, RECORDED, not fixed, and my prior was wrong in an interesting way:
       I guessed "legitimate Alpine component idiom", and there is no Alpine
       here at all. Every one of the 143 is `var self = this` at the top of a
-      MooTools class method, in 19 files under `couchpotato/core/**/static/`,
-      last modified 2015.
+      MooTools class method, in 19 files under `couchpotato/core/**/static/`.
+      CORRECTED after review: I first wrote "last modified 2015", which was
+      checked on ONE file and asserted of all nineteen. The real spread is
+      2014 (1 file), 2015 (7), 2016 (2), 2017 (3) and 2026 (6): `trakt.js`,
+      `wizard.js`, `wanted.js`, `movie.js`, `manage.js` and
+      `movie/_base/search.js`. That is not a rounding error in the argument,
+      it inverts part of it, so see finding 4 below.
       Three findings, each measured rather than assumed:
       1. The layer is not served. `static_dir` is `couchpotato/static`
          (`runner.py:558`), the only mount (`couchpotato/__init__.py:1231`),
@@ -66,6 +71,20 @@ the RULE, not the file: one judgement per pattern rather than per occurrence.
          here. The verdict is the same at either extreme.
       3. Zero tests cover the layer, so a 143-site edit could not be shown to
          be behaviour-neutral.
+      4. The layer is not merely dormant, it is still attracting new work,
+         and that is the finding worth keeping. `trakt.js:133`, cited above as
+         a necessary alias, is not old code at all: it came from `9e77d021`,
+         "feat(trakt): Implement direct OAuth 2.0 device code flow", February
+         2026. That commit added `startDeviceAuth` and `pollForToken` to a
+         file nothing serves.
+         The consequence is a live user-facing gap, not tidiness debt.
+         `automation.trakt.device_code` and `automation.trakt.poll_token` are
+         registered as API views (`trakt/main.py:87-88`), and the ONLY caller
+         of either, anywhere in the repository, is `trakt.js:138` and
+         `trakt.js:180`. The new UI contains no reference to Trakt at all.
+         So the backend can start a Trakt device authorisation and nothing in
+         the shipped application can ask it to. Anyone configuring Trakt today
+         has no way to complete OAuth. Raised as a follow-up in its own right.
       The rule is left enabled and every finding left open, because it is
       still doing useful work: there are zero S7740 findings in the live UI,
       so the same idiom written into `couchpotato/ui/` tomorrow would surface

--- a/specs/PLAN-2026-09-07-sonarqube-slices.md
+++ b/specs/PLAN-2026-09-07-sonarqube-slices.md
@@ -41,10 +41,37 @@ the RULE, not the file: one judgement per pattern rather than per occurrence.
 - [ ] T3: assess and fix `python:S9073`, composite assertions in tests (59).
       Splitting them gives better failure messages, which this repo has needed
       repeatedly today, state: queued (needs: T2)
-- [ ] T4: assess `javascript:S7740`, variables assigned `this` (143). Largest
-      single rule. Suspect many are legitimate Alpine component idiom; the
-      deliverable may be mostly a dismissal with evidence, state: queued
-      (needs: T3)
+- [x] T4: assess `javascript:S7740`, variables assigned `this` (143). LEFT
+      OPEN, RECORDED, not fixed, and my prior was wrong in an interesting way:
+      I guessed "legitimate Alpine component idiom", and there is no Alpine
+      here at all. Every one of the 143 is `var self = this` at the top of a
+      MooTools class method, in 19 files under `couchpotato/core/**/static/`,
+      last modified 2015.
+      Three findings, each measured rather than assumed:
+      1. The layer is not served. `static_dir` is `couchpotato/static`
+         (`runner.py:558`), the only mount (`couchpotato/__init__.py:1231`),
+         and it contains only new-UI scripts and vendor bundles: no MooTools,
+         no combined legacy bundle. `clientscript.py`, which used to build
+         those bundles, is deleted. `/old/*` is a redirect catch-all
+         (`couchpotato/__init__.py:1693`). Nothing outside the tree references
+         it. This is the same dead layer as T2, reached independently.
+      2. The rule's premise does not hold for this code. S7740 exists because
+         arrow functions capture `this` lexically, making the alias
+         unnecessary. These files contain zero arrow functions. Many sites are
+         provably necessary even so: `trakt.js:133` aliases `this` and then
+         reads `self` inside an `Api.request` callback, where ES5 `this` would
+         be wrong. A heuristic pass suggested a large share might be
+         technically redundant, but spot-checking showed the heuristic itself
+         was wrong on its first three candidates, so no split is recorded
+         here. The verdict is the same at either extreme.
+      3. Zero tests cover the layer, so a 143-site edit could not be shown to
+         be behaviour-neutral.
+      The rule is left enabled and every finding left open, because it is
+      still doing useful work: there are zero S7740 findings in the live UI,
+      so the same idiom written into `couchpotato/ui/` tomorrow would surface
+      as finding 144. Expiry: delete each file when its port lands
+      (UI-CLEANUP-02), which retires these findings without editing dead code.
+      state: merged
 - [ ] T5: assess and fix `python:S1192`, duplicated string literals (72), where
       extraction aids clarity rather than just satisfying the rule, state:
       queued (needs: T4)

--- a/specs/PLAN-2026-09-07-sonarqube-slices.md
+++ b/specs/PLAN-2026-09-07-sonarqube-slices.md
@@ -38,9 +38,16 @@ the RULE, not the file: one judgement per pattern rather than per occurrence.
       files; the one grep hit is a code comment). Zero tests on that layer, so
       a 57-site rewrite could not be proven behaviour-neutral. Expiry: delete
       each file when its port lands.
-- [ ] T3: assess and fix `python:S9073`, composite assertions in tests (59).
+- [x] T3: assess and fix `python:S9073`, composite assertions in tests (59).
       Splitting them gives better failure messages, which this repo has needed
-      repeatedly today, state: queued (needs: T2)
+      repeatedly today. FIXED, all 59, the opposite verdict to T2 and for a
+      reason specific to this codebase: `assert a and b` reports only that the
+      assertion failed, while two assertions name which half moved. Two outer
+      ANDs wrapping an inner OR-group were split at the AND only, leaving the
+      OR intact, because splitting the OR would have turned "any acceptable
+      phrasing" into "all three required". 32 test files, no production code,
+      unit count unchanged at 3894 passed / 2 skipped / 5 xfailed.
+      state: merged #309 (needs: T2)
 - [x] T4: assess `javascript:S7740`, variables assigned `this` (143). LEFT
       OPEN, RECORDED, not fixed, and my prior was wrong in an interesting way:
       I guessed "legitimate Alpine component idiom", and there is no Alpine
@@ -60,15 +67,27 @@ the RULE, not the file: one judgement per pattern rather than per occurrence.
          those bundles, is deleted. `/old/*` is a redirect catch-all
          (`couchpotato/__init__.py:1693`). Nothing outside the tree references
          it. This is the same dead layer as T2, reached independently.
-      2. The rule's premise does not hold for this code. S7740 exists because
-         arrow functions capture `this` lexically, making the alias
-         unnecessary. These files contain zero arrow functions. Many sites are
-         provably necessary even so: `trakt.js:133` aliases `this` and then
-         reads `self` inside an `Api.request` callback, where ES5 `this` would
-         be wrong. A heuristic pass suggested a large share might be
-         technically redundant, but spot-checking showed the heuristic itself
-         was wrong on its first three candidates, so no split is recorded
-         here. The verdict is the same at either extreme.
+      2. The rule applies, and its remedy is a refactor this layer cannot
+         support. CORRECTED after review: I first argued that "these files
+         contain zero arrow functions, so the rule's premise is absent". That
+         was wrong, and it inverted the rule. S7740 does not require an arrow
+         function to already be present. It flags the alias precisely so the
+         nested traditional function can be REWRITTEN as an arrow function
+         that captures the surrounding `this`. Zero arrows is therefore
+         evidence that the refactor has not been done, not that the rule does
+         not apply.
+         The honest statement is narrower, and being about risk rather than
+         applicability it is also the stronger one: the finding is real, and
+         complying with it means converting ES5 callbacks to arrow functions
+         across 143 sites in code with zero test coverage. `trakt.js:133`
+         shows why each site needs individual judgement rather than a sweep.
+         It aliases `this` and then reads `self` inside an `Api.request`
+         callback, so the alias is load-bearing UNTIL that callback becomes
+         an arrow function and wrong afterwards. That is a behaviour-changing
+         edit, not a rename.
+         A heuristic pass suggested a large share of the 143 might be
+         technically redundant, but spot-checking showed the heuristic was
+         wrong on its first three candidates, so no split is recorded here.
       3. Zero tests cover the layer, so a 143-site edit could not be shown to
          be behaviour-neutral.
       4. The layer is not merely dormant, it is still attracting new work,
@@ -88,8 +107,22 @@ the RULE, not the file: one judgement per pattern rather than per occurrence.
       The rule is left enabled and every finding left open, because it is
       still doing useful work: there are zero S7740 findings in the live UI,
       so the same idiom written into `couchpotato/ui/` tomorrow would surface
-      as finding 144. Expiry: delete each file when its port lands
-      (UI-CLEANUP-02), which retires these findings without editing dead code.
+      as finding 144.
+      Expiry, CORRECTED after review: I first wrote "UI-CLEANUP-02", which had
+      ALREADY LANDED. It deleted the userscript embed, `clientscript.py`, the
+      four compiled bundles, `index.html` and `static/fonts/**`
+      (`specs/UI-MIGRATION.md:50-64`), and it did NOT delete these 19 files.
+      An expiry pointing at a finished task can never fire, which is exactly
+      the accepted-debt-with-no-exit the standards forbid, so it is replaced.
+      The real condition is the still-open UI migration criterion, "No
+      references to `/old` or the legacy stack remain in code or docs"
+      (`specs/UI-MIGRATION.md:69`), reached as each of the 18 audited features
+      lands in the new UI (`specs/UI-MIGRATION.md:32`).
+      Naming the gap rather than papering over it: NO task currently owns
+      deleting `couchpotato/core/**/static/`. Until one does, this expiry has
+      a condition but no owner, which is the weakest part of this disposition.
+      It is related to issue #311, where the same unreachable layer silently
+      swallowed a February 2026 feature.
       state: merged
 - [ ] T5: assess and fix `python:S1192`, duplicated string literals (72), where
       extraction aids clarity rather than just satisfying the rule, state:


### PR DESCRIPTION
T4 of the conducted SonarQube plan. `javascript:S7740`, 143 findings, the largest single rule in the project. **No code change. The findings are recorded and left open.**

## My prior was wrong, and in a way worth stating

The plan predicted "legitimate Alpine component idiom". There is no Alpine in any of it. All 143 are `var self = this` at the top of a MooTools class method, across 19 files under `couchpotato/core/**/static/`, last modified **2015**.

## Three things measured, not assumed

**1. Nothing serves this code.** The only static mount is `couchpotato/__init__.py:1231`, and `static_dir` resolves to `couchpotato/static` (`runner.py:558`). That directory holds only new-UI scripts and vendor bundles: no MooTools, no combined legacy bundle. `clientscript.py`, which used to build those bundles, is deleted. `/old/*` is a redirect catch-all (`couchpotato/__init__.py:1693`). Nothing outside the tree references it. The same dead layer T2 found, reached independently.

**2. The rule's premise does not hold here.** S7740 exists because arrow functions capture `this` lexically, making the alias redundant. These files contain **zero arrow functions**. Many sites are necessary regardless: `trakt.js:133` aliases `this`, then reads `self` inside an `Api.request` callback where ES5 `this` would be the wrong object.

I ran a heuristic to split "necessary" from "redundant" and it produced a confident-looking 52/91. Spot-checking its first three "redundant" candidates showed all three were wrong, so **that number is not reported here.** The verdict is identical at either extreme, so the split was not worth the cost of getting right.

**3. Zero tests cover the layer**, so a 143-site edit could not be shown to be behaviour-neutral.

## Why left open rather than dismissed

Dismissing 143 findings would take the project's largest number to zero in a single action, and the standard is that dismissal is only for a genuine false positive. These are not false positives: the code really does alias `this`. The finding is real, in code that is dead.

The rule stays enabled and the findings stay open because it is still earning its place: there are **zero S7740 findings in the live UI**, so the same idiom written into `couchpotato/ui/` tomorrow surfaces as finding 144 rather than being lost inside an accepted pile.

**Expiry:** UI-CLEANUP-02 deletes these files as each port lands, retiring all 143 without anyone editing dead 2015 JavaScript.

## Review

Lens review skipped as disproportionate: the diff is one prose block in a plan file. No code, no tests, no user-facing surface. The local gate ran and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc