### PR TITLE
test(logger): pin PrivacyFilter.filter() to always return truthy, so the BLOCKER can be dismissed safely

### DIFF
--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -144,6 +144,53 @@ class TestPrivacyFilter:
         filt.filter(record)
         assert 'secret' not in record.msg
 
+    def test_filter_returns_truthy_on_the_dev_early_return(self):
+        """S3516: filter() must always return truthy, per the stdlib
+        logging.Filter contract (truthy keeps the record, falsy drops it).
+        A future "fix" of the SonarQube false positive that turns this
+        branch into `return False` would silently delete every log line
+        while Env.get('dev') is true, and none of the nine existing
+        PrivacyFilter test files would notice, because none of them look
+        at the return value. This pins the early return at the top of
+        filter() (logger.py, the `if self._is_develop: return True` line).
+        """
+        filt = PrivacyFilter()
+        filt._is_develop = True
+        filt._api_key = 'mykey123'
+        record = logging.LogRecord('test', logging.INFO, '', 0,
+                                   'accessing mykey123 endpoint', None, None)
+
+        result = filt.filter(record)
+
+        assert result, (
+            'PrivacyFilter.filter() returned falsy on the dev early-return '
+            'path -- this would silently drop the log record'
+        )
+
+    def test_filter_returns_truthy_after_redacting(self):
+        """S3516, the normal (non-dev) redacting path. The message carries
+        a real secret so the redaction code actually runs rather than being
+        skipped, then pins the return at the end of filter() (logger.py,
+        `record.msg = msg; return True`). Same failure mode as the dev-path
+        test above: a falsy return here would silently drop every redacted
+        log line, which is most of production traffic.
+        """
+        filt = PrivacyFilter()
+        filt._is_develop = False
+        filt._api_key = 'mykey123'
+        record = logging.LogRecord('test', logging.INFO, '', 0,
+                                   'url?api_key=secret123&token=mykey123', None, None)
+
+        result = filt.filter(record)
+
+        assert result, (
+            'PrivacyFilter.filter() returned falsy on the redacting path -- '
+            'this would silently drop the log record'
+        )
+        # Confirms the redacting path was genuinely exercised, not skipped.
+        assert 'secret123' not in record.msg
+        assert 'mykey123' not in record.msg
+
 
 class TestSetupLogging:
     """Test setup_logging function."""


### PR DESCRIPTION
The project's only BLOCKER, `python:S3516`, is a **false positive**. This PR adds the guard that makes dismissing it safe, and changes no production code.

## The finding

`python:S3516` against `PrivacyFilter.filter()` in `couchpotato/core/logger.py:245`: "refactor this method to not always return the same value".

`PrivacyFilter` is what keeps API keys, credentials and private filesystem paths out of the log files. It is a `logging.Filter`, and that contract is explicit: `filter(record)` returns truthy to KEEP the record and falsy to DROP it. A redacting filter must keep every record. The code says so itself, a few lines below the finding:

> A filter that swallows the line removes the reason the line was logged, and the operator turns it off.

Both return paths correctly return `True`. The rule is right in general and wrong here.

## Why a guard rather than just a dismissal

The danger is not the current code, it is the next person who takes the finding at face value and "fixes" it by returning `False` on some branch. That would silently stop log output.

**Corrected claim, because I measured instead of asserting.** I first recorded that no test would catch this and the suite would stay green. That is wrong. Mutating the final `return True` to `return False` fails **two** tests, and the second is pre-existing: `test_privacy_filter_applied_via_child_logger` asserts a redacted message reaches the log, and a falsy return means no record reaches the log at all.

So the danger was overstated. The guard is still worth having, for two reasons that survive the correction:

1. An incidental failure inside a redaction test does not tell the next person that **the return value** is the contract they broke. It points at redaction, which is not what changed.
2. That incidental test covers only ONE of the two return paths.

I found this only by re-running the mutation myself rather than accepting the implementer's reported table, which was otherwise exact. Its evidence was correct; it simply ran the mutation against a narrower test selection and never saw the second failure.

## What this adds

`tests/unit/test_logging.py`, two tests in the existing `TestPrivacyFilter` class:

- `test_filter_returns_truthy_on_the_dev_early_return` covers the `if self._is_develop: return True` path at `:255`
- `test_filter_returns_truthy_after_redacting` covers the end-of-method `return True` at `:367`, using a message that genuinely contains a secret so the redaction path is actually exercised rather than skipped

## Verification

`couchpotato/core/logger.py` is byte-identical, sha256 `2fd58907...` before and after.

Both return paths mutated to `return False` one at a time, each confirmed landed by `git diff` before running, each restored by file copy and confirmed byte-identical by sha256:

| mutation | result |
|---|---|
| `:255` True to False | the dev-path test failed naming that path; the redacting-path test stayed green |
| `:367` True to False | the redacting-path test failed naming that path; the dev-path test stayed green |

I independently replayed the `:367` mutation and reproduced the same hash `eaa1ef3b...`, the same failure, and a byte-identical restore.

Unit suite 3896 to 3898 passed, 2 skipped and 5 xfailed unchanged, so the delta is exactly the two new tests. Full local gate green including E2E. Ruff clean.

## Follow-up

Once this lands, `python:S3516` gets marked false positive with a comment naming these tests, so the dismissal cites something enforceable rather than an argument.

## Scope note

This is T1 of the corrected plan in #318. The original scan pass ranked work by rule volume, which put 143 findings in dead JavaScript ahead of this blocker. Ranking by severity, as the owner asked, surfaced it immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
