### PR TITLE
fix(net): three bugs in isLocalIP, including a crafted hostname reading as local

### DIFF
--- a/couchpotato/core/helpers/variable.py
+++ b/couchpotato/core/helpers/variable.py
@@ -170,7 +170,37 @@ def sha256(text):
     return hashlib.sha256(ss(text)).hexdigest()
 
 
+# Fully end-anchored so a match has to be the WHOLE candidate address, not
+# just a recognised prefix -- a start-only anchor let '127.0.0.1.evil.com'
+# through, because '^127\.' is satisfied by the first four characters
+# regardless of what follows.
+_IPV4_LOCAL_RE = re.compile(
+    r'^(?:'
+    r'127(?:\.\d{1,3}){3}'
+    r'|192\.168(?:\.\d{1,3}){2}'
+    r'|10(?:\.\d{1,3}){3}'
+    r'|172\.(?:1[6-9]|2[0-9]|3[0-1])(?:\.\d{1,3}){2}'
+    r')$'
+)
+
+# The two forms of IPv6 loopback we recognise: shorthand and its
+# uncompressed equivalent. See the comment in isLocalIP() for why only
+# these two, not general IPv6 canonicalisation.
+_IPV6_LOOPBACK_FORMS = ('::1', '0:0:0:0:0:0:0:1')
+
+
 def isLocalIP(ip):
+    """Return True if ip names a loopback or RFC 1918 private address, or
+    the literal hostname 'localhost'.
+
+    The only caller (http_client.py's failure-tracking logic, which exempts
+    local hosts from being permanently disabled after repeated failures)
+    passes either a bare hostname/address or 'host:port', built from
+    urlparse() as f'{hostname}{":"+port if port else ""}'. urlparse()
+    strips brackets from an IPv6 host, so an IPv6 URL with a port arrives
+    here as e.g. '::1:9117', not '[::1]:9117'. Bracketed forms are also
+    handled in case another caller passes a raw URL-style host string.
+    """
     # Strip a URL scheme prefix if one is present. This used to be
     # ip.lstrip('htps:/'), but str.lstrip() takes a set of characters, not
     # a prefix, so it stripped any leading run of h/t/p/s/:/ -- which ate
@@ -182,21 +212,48 @@ def isLocalIP(ip):
             ip = ip[len(prefix):]
             break
 
-    # This used to be a JAVASCRIPT regex literal (the wrapping '/../'
-    # marks) pasted directly into Python, where the slashes are literal
-    # characters rather than delimiters. That made two alternatives
-    # unmatchable: a literal '/' can never appear immediately before '^'
-    # (start of string) or immediately after '$' (end of string). The
-    # practical effect was that IPv6 loopback ('::1') was never recognised.
-    #
-    # '::1' and its uncompressed equivalent '0:0:0:0:0:0:0:1' are both
-    # matched deliberately, since a client may hand us either form of the
-    # same address. General IPv6 canonicalisation (case folding, partial
-    # zero-compression, mixed forms) is deliberately out of scope here --
-    # this helper only needs to recognise the loopback address, not parse
-    # arbitrary IPv6.
-    regex = r'(^127\.)|(^192\.168\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^0:0:0:0:0:0:0:1$)|(^::1$)'
-    return re.search(regex, ip) is not None or 'localhost' in ip or ip[:4] == '127.'
+    core = ip
+    colon_count = core.count(':')
+
+    if core.startswith('[') and ']' in core:
+        # Bracketed IPv6 ('[addr]' or '[addr]:port'), the standard URL host
+        # form. Unambiguous: the brackets delimit the address, so there is
+        # no need to guess where a port might start.
+        core = core[1:core.index(']')]
+
+    elif colon_count == 1:
+        # Exactly one colon is a hostname/IPv4 'host:port' shape
+        # ('127.0.0.1:9117', 'localhost:9117') -- never a bare IPv6
+        # address, since even the shortest valid IPv6 form ('::1') has two
+        # colons. Only split off the port if what follows really is one.
+        host_part, _, port_part = core.rpartition(':')
+        if port_part.isdigit():
+            core = host_part
+
+    elif colon_count >= 2:
+        # Bare, unbracketed, and IPv6-shaped. 'addr:port' is genuinely
+        # ambiguous here: does '::1:9117' mean loopback address '::1' with
+        # port 9117, or is '::1:9117' the address in its own right? This is
+        # exactly the shape http_client.py's host string produces for an
+        # IPv6 host with a port, since urlparse().hostname strips brackets.
+        #
+        # Deliberate rule: read a trailing ':<digits>' as a port ONLY if
+        # stripping it leaves one of the two recognised loopback forms.
+        # That resolves '::1:9117' to loopback + port (True), while
+        # '2001:db8::1:9117' and '2001:db8::1' -- neither of which is a
+        # loopback address before OR after stripping a trailing number --
+        # are left as-is and correctly stay unmatched (False). Anything
+        # else with two or more colons is used exactly as given: it
+        # matches only if it IS one of the loopback forms.
+        host_part, _, port_part = core.rpartition(':')
+        if port_part.isdigit() and host_part in _IPV6_LOOPBACK_FORMS:
+            core = host_part
+
+    return (
+        _IPV4_LOCAL_RE.match(core) is not None
+        or core in _IPV6_LOOPBACK_FORMS
+        or 'localhost' in core
+    )
 
 
 def getExt(filename):

--- a/couchpotato/core/helpers/variable.py
+++ b/couchpotato/core/helpers/variable.py
@@ -171,8 +171,31 @@ def sha256(text):
 
 
 def isLocalIP(ip):
-    ip = ip.lstrip('htps:/')
-    regex = r'/(^127\.)|(^192\.168\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^::1)$/'
+    # Strip a URL scheme prefix if one is present. This used to be
+    # ip.lstrip('htps:/'), but str.lstrip() takes a set of characters, not
+    # a prefix, so it stripped any leading run of h/t/p/s/:/ -- which ate
+    # the leading '::' off IPv6 loopback ('::1' became '1') and would have
+    # truncated any plain hostname starting with h/t/p/s (e.g. 'host.local'
+    # became 'ost.local'). Only http:// and https:// are stripped now.
+    for prefix in ('https://', 'http://'):
+        if ip.startswith(prefix):
+            ip = ip[len(prefix):]
+            break
+
+    # This used to be a JAVASCRIPT regex literal (the wrapping '/../'
+    # marks) pasted directly into Python, where the slashes are literal
+    # characters rather than delimiters. That made two alternatives
+    # unmatchable: a literal '/' can never appear immediately before '^'
+    # (start of string) or immediately after '$' (end of string). The
+    # practical effect was that IPv6 loopback ('::1') was never recognised.
+    #
+    # '::1' and its uncompressed equivalent '0:0:0:0:0:0:0:1' are both
+    # matched deliberately, since a client may hand us either form of the
+    # same address. General IPv6 canonicalisation (case folding, partial
+    # zero-compression, mixed forms) is deliberately out of scope here --
+    # this helper only needs to recognise the loopback address, not parse
+    # arbitrary IPv6.
+    regex = r'(^127\.)|(^192\.168\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)|(^0:0:0:0:0:0:0:1$)|(^::1$)'
     return re.search(regex, ip) is not None or 'localhost' in ip or ip[:4] == '127.'
 
 

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -8,7 +8,7 @@ import os
 import pytest
 
 from couchpotato.core.helpers.encoding import toUnicode, toSafeString, simplifyString
-from couchpotato.core.helpers.variable import removePyc, tryInt, getImdb
+from couchpotato.core.helpers.variable import removePyc, tryInt, getImdb, isLocalIP
 
 pytestmark = pytest.mark.unit
 
@@ -180,3 +180,88 @@ class TestRemovePyc:
         removePyc(str(tmp_path), show_logs=False)
 
         assert not cache_dir.exists()
+
+
+class TestIsLocalIP:
+    """isLocalIP() used to embed a JAVASCRIPT regex literal (the wrapping
+    '/../' delimiters) directly in a Python re.search() call. In Python
+    those slashes are literal characters, not delimiters, so two of the
+    seven alternatives could never match: one needed a literal '/' before
+    '^' (start of string) and one needed a literal '/' after '$' (end of
+    string). The practical effect was that IPv6 loopback ('::1') was never
+    recognised by the regex -- only the standalone http_client.py caller
+    matters here (couchpotato/core/http_client.py:131, which exempts local
+    hosts from being permanently disabled after repeated failures), so an
+    IPv6-only local service got disabled where the same service on
+    127.0.0.1 would not.
+
+    These tests pin the full table, including the cases that already
+    passed, so the fix cannot regress them.
+    """
+
+    # -- IPv4 loopback and private ranges (already worked before the fix) --
+
+    def test_ipv4_loopback_is_local(self):
+        assert isLocalIP('127.0.0.1') is True
+
+    def test_ipv4_class_c_private_is_local(self):
+        assert isLocalIP('192.168.1.10') is True
+
+    def test_ipv4_class_a_private_is_local(self):
+        assert isLocalIP('10.0.0.5') is True
+
+    def test_hostname_localhost_is_local(self):
+        assert isLocalIP('localhost') is True
+
+    # -- 172.16.0.0/12: the real private range is 172.16.x through 172.31.x --
+
+    def test_172_16_lower_bound_is_local(self):
+        assert isLocalIP('172.16.0.1') is True
+
+    def test_172_20_mid_range_is_local(self):
+        assert isLocalIP('172.20.5.5') is True
+
+    def test_172_31_upper_bound_is_local(self):
+        assert isLocalIP('172.31.255.255') is True
+
+    def test_172_15_just_below_range_is_not_local(self):
+        assert isLocalIP('172.15.0.1') is False
+
+    def test_172_32_just_above_range_is_not_local(self):
+        assert isLocalIP('172.32.0.1') is False
+
+    # -- public addresses stay public --
+
+    def test_public_ip_google_dns_is_not_local(self):
+        assert isLocalIP('8.8.8.8') is False
+
+    def test_arbitrary_public_ip_is_not_local(self):
+        assert isLocalIP('1.2.3.4') is False
+
+    # -- IPv6 loopback: THE BUG. Was False before the fix. --
+
+    def test_ipv6_loopback_shorthand_is_local(self):
+        assert isLocalIP('::1') is True
+
+    def test_ipv6_loopback_full_form_is_local(self):
+        # '0:0:0:0:0:0:0:1' is the same address as '::1' written without
+        # zero-compression. Supported deliberately: a client library is as
+        # likely to hand us one form as the other, and refusing the
+        # uncompressed form would just re-introduce the same class of bug
+        # for a differently-formatted address. Deliberately NOT attempting
+        # general IPv6 canonicalisation (case folding, partial compression
+        # like '0:0:0:0:0:0:0:01', mixed forms) -- that is a much bigger
+        # surface for false positives than this helper's job justifies.
+        assert isLocalIP('0:0:0:0:0:0:0:1') is True
+
+    # -- anchoring: must not match the pattern mid-string --
+
+    def test_public_ip_followed_by_private_looking_text_is_not_local(self):
+        # A careless (unanchored) alternation could match '10.0.0.1'
+        # wherever it appears in the string, not just at the start.
+        assert isLocalIP('8.8.8.8 via 10.0.0.1') is False
+
+    def test_hostname_containing_loopback_looking_text_is_not_local(self):
+        # '127.0.0.1' appears in this string but not at the start, and the
+        # whole thing is a hostname, not a loopback address.
+        assert isLocalIP('not-127.0.0.1.example.com') is False

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -4,6 +4,7 @@ Tests encoding helpers (toUnicode, toSafeString, simplifyString)
 and variable helpers (tryInt, tryFloat, getImdb, etc.).
 """
 import os
+from urllib.parse import urlparse
 
 import pytest
 
@@ -265,3 +266,140 @@ class TestIsLocalIP:
         # '127.0.0.1' appears in this string but not at the start, and the
         # whole thing is a hostname, not a loopback address.
         assert isLocalIP('not-127.0.0.1.example.com') is False
+
+
+class TestIsLocalIPWithPortAndBrackets:
+    """The first round of this fix pinned isLocalIP() against bare
+    addresses only ('::1', '127.0.0.1'). Review found the only real
+    caller never sends a bare address: couchpotato/core/http_client.py:131
+    calls isLocalIP(host) where host is built at http_client.py:203 as
+
+        host = f'{parsed_url.hostname}{(":" + str(parsed_url.port)) if parsed_url.port else ""}'
+
+    urlparse() strips brackets from an IPv6 host, so for a URL like
+    'http://[::1]:9117/api' this produces the string '::1:9117' -- and the
+    end-anchored '::1$' alternative from round one cannot match that,
+    because the port defeats the anchor. So the bug this task exists to
+    fix (IPv6-only local services get permanently disabled where the same
+    service on 127.0.0.1 would not) was still live for essentially every
+    real IPv6 deployment, since a self-hosted service almost always has an
+    explicit port.
+
+    These tests pin the host:port and bracketed shapes directly, plus a
+    set of hostile inputs designed to prove the fix does not widen the
+    match to catch strings that merely *contain* a private-looking prefix
+    or suffix.
+    """
+
+    # -- IPv4 with an explicit port: must still recognise the address --
+
+    def test_ipv4_loopback_with_port_is_local(self):
+        assert isLocalIP('127.0.0.1:9117') is True
+
+    def test_ipv4_private_with_port_is_local(self):
+        assert isLocalIP('192.168.1.5:8080') is True
+
+    def test_public_ipv4_with_port_is_not_local(self):
+        assert isLocalIP('8.8.8.8:443') is False
+
+    # -- bare (unbracketed) IPv6 loopback with a port. THE BUG. --
+    #
+    # Deliberate rule: 'addr:port' is genuinely ambiguous for a bare IPv6
+    # address (unlike IPv4, IPv6 addresses themselves contain colons), so
+    # a trailing ':<digits>' is read as a port ONLY when stripping it
+    # leaves one of the two recognised loopback forms. Anything else is
+    # used exactly as given -- it is not a false "host:port" guess, it is
+    # the address, and it only matches if it IS a loopback address.
+
+    def test_bare_ipv6_loopback_with_port_is_local(self):
+        assert isLocalIP('::1:9117') is True
+
+    def test_bare_ipv6_loopback_full_form_with_port_is_local(self):
+        assert isLocalIP('0:0:0:0:0:0:0:1:9117') is True
+
+    def test_public_ipv6_documentation_address_is_not_local(self):
+        # 2001:db8::/32 is the IPv6 documentation range. It is not a
+        # loopback address before OR after stripping a trailing number, so
+        # the ambiguous-port rule must not touch it.
+        assert isLocalIP('2001:db8::1') is False
+
+    def test_public_ipv6_documentation_address_with_port_is_not_local(self):
+        # Same address as above with a trailing ':9117'. A careless rule
+        # ("if it ends in :digits, strip and treat the rest as the
+        # address") would wrongly read this as address '2001:db8::1',
+        # which is itself not a loopback address either -- but a rule that
+        # instead always keeps the STRIPPED form would need checking too.
+        # Neither the stripped nor the unstripped form is a loopback
+        # address, so this must stay False either way.
+        assert isLocalIP('2001:db8::1:9117') is False
+
+    # -- bracketed IPv6, the standard URL host form: unambiguous --
+
+    def test_bracketed_ipv6_loopback_is_local(self):
+        assert isLocalIP('[::1]') is True
+
+    def test_bracketed_ipv6_loopback_with_port_is_local(self):
+        assert isLocalIP('[::1]:9117') is True
+
+    # -- must not widen: string CONTAINS a private prefix/suffix, isn't one --
+
+    def test_hostname_with_colon_port_that_looks_like_an_ip_suffix_is_not_local(self):
+        # The 'port' half of this host:port split is not digits, so it
+        # must not be treated as a port at all -- and the whole string
+        # must not be mistaken for the address '127.0.0.1' it contains.
+        assert isLocalIP('evil.com:127.0.0.1') is False
+
+    def test_private_ip_followed_by_non_digit_text_after_colon_is_not_local(self):
+        # The single-colon split must only ever be treated as 'address:port'
+        # when what follows the colon really is a port (all digits). If that
+        # check were dropped, a private-looking address with a colon and
+        # arbitrary text after it -- not a real port -- would be quietly
+        # reduced down to just the address and wrongly recognised as local.
+        assert isLocalIP('127.0.0.1:evil') is False
+
+    def test_hostname_with_loopback_looking_prefix_and_real_suffix_is_not_local(self):
+        # Starts with '127.0.0.1' but is not that address -- it is a
+        # hostname with more labels after it. The IPv4 patterns must be
+        # end-anchored, not just start-anchored, or this slips through.
+        assert isLocalIP('127.0.0.1.evil.com') is False
+
+
+class TestIsLocalIPMatchesHttpClientHostShape:
+    """http_client.py:203 builds the host string isLocalIP() actually
+    receives from urlparse(), not by hand. Every isLocalIP test above
+    (and every one from round one) asserts on a hand-written address
+    string, so the suite stayed green while the real call path -- an
+    IPv6 URL with an explicit port -- was still broken. These tests
+    replicate http_client.py:203's own construction from a real URL via
+    urlparse, so a future change to either side that breaks the pairing
+    is caught here rather than only in production.
+    """
+
+    @staticmethod
+    def _host_from_url(url):
+        # Deliberately duplicates http_client.py:203's host construction
+        # rather than importing http_client (which pulls in the wider
+        # client machinery for one two-line expression). Keep this in
+        # sync with that line if it changes.
+        parsed_url = urlparse(url)
+        return f'{parsed_url.hostname}{(":" + str(parsed_url.port)) if parsed_url.port else ""}'
+
+    def test_ipv6_loopback_url_with_port_is_local(self):
+        host = self._host_from_url('http://[::1]:9117/api')
+        assert host == '::1:9117'  # pin the exact shape the bug report measured
+        assert isLocalIP(host) is True
+
+    def test_ipv6_loopback_url_without_port_is_local(self):
+        host = self._host_from_url('http://[::1]/api')
+        assert host == '::1'
+        assert isLocalIP(host) is True
+
+    def test_ipv4_loopback_url_with_port_is_local(self):
+        host = self._host_from_url('http://127.0.0.1:9117/')
+        assert host == '127.0.0.1:9117'
+        assert isLocalIP(host) is True
+
+    def test_public_host_url_with_port_is_not_local(self):
+        host = self._host_from_url('http://example.com:8443/')
+        assert host == 'example.com:8443'
+        assert isLocalIP(host) is False


### PR DESCRIPTION
`isLocalIP()` had **three** separate bugs, each invisible to the others. Only the first was reported by the scanner, and the third is the most serious.

Found while working the MEDIUM-and-above sweep, in the set the earlier volume-ranked pass never reached.

## Why it matters

The only caller is `couchpotato/core/http_client.py:131`:

```python
if count > MAX_FAILURES_BEFORE_DISABLE and not isLocalIP(host):
```

That exempts local hosts from being **permanently disabled** after repeated failures. Getting it wrong in one direction disables your own local services; getting it wrong in the other exempts hosts that should never be exempt.

## Bug 1: a JavaScript regex literal pasted into Python

```python
regex = r'/(^127\.)|(^192\.168\.)|...|(^::1)$/'
```

In JavaScript the wrapping `/.../` delimits the pattern. In Python they are literal characters, so two of the seven alternatives can never match: `/` cannot precede `^`, and cannot follow `$`. `::1` never matched, and `127.` matched only through a fallback.

## Bug 2: `str.lstrip` takes a character set, not a prefix

**This is why fixing bug 1 alone would not have fixed anything.**

```python
ip = ip.lstrip('htps:/')     # ':' is in the set
'::1'.lstrip('htps:/')       # -> '1'
```

The loopback marker was eaten before the regex ever ran. The same line turned `host.local` into `ost.local`.

## Bug 3: start-anchored IPv4, so a crafted hostname read as local

Found only because round two demanded an explicit list of inputs that must stay `False`:

```
isLocalIP('127.0.0.1.evil.com')   ->  True     (before)
```

`^127\.` matches a hostname that merely BEGINS with `127.`, and the redundant `ip[:4] == '127.'` fallback had the identical flaw. **This predates this PR entirely** and had nothing to do with the finding that started it. `127.0.0.1.evil.com` is a registerable domain, and this function decides which hosts skip being disabled. Both are now fully anchored and the redundant fallback is gone.

## Round one was wrong, and a green gate said nothing

The first fix passed 15 tests and a full gate, and **did not fix the bug**. Review caught it.

`http_client.py:203` builds what it passes as `f'{hostname}{":"+port if port else ""}'`, and `urlparse` strips brackets from IPv6 hosts. So `http://[::1]:9117/api` arrives as `'::1:9117'`, and the end-anchored `^::1$` never matched. A self-hosted local service almost always has an explicit port, so that is the common case rather than an edge case.

Every one of those 15 tests used a hand-written bare address. Not one built the string the way the caller does. The suite was green while the real code path stayed broken.

There is now a dedicated test class, `TestIsLocalIPMatchesHttpClientHostShape`, that constructs the host via `urlparse` exactly as the caller does. That is the gap that let it through.

## Behaviour, measured across all shapes

| input | before | after |
|---|---|---|
| `http://[::1]:9117/api` -> `::1:9117` | **False** | **True** |
| `::1` | False | True |
| `0:0:0:0:0:0:0:1` | False | True |
| `[::1]` / `[::1]:9117` | False | True |
| `127.0.0.1` / `127.0.0.1:9117` | True | True |
| `192.168.1.5:8080`, `10.0.0.5`, `172.16.0.1`, `172.31.255.1` | True | True |
| **`127.0.0.1.evil.com`** | **True** | **False** |
| `127.0.0.1:evil` | True | False |
| `172.15.0.1` / `172.32.0.1` | False | False |
| `8.8.8.8` / `8.8.8.8:443` | False | False |
| `2001:db8::1` / `2001:db8::1:9117` | False | False |
| `evil.com:127.0.0.1`, `not-127.0.0.1.example.com` | False | False |

## Deliberate decision on an ambiguous case

`::1:9117` is genuinely ambiguous as a bare string: loopback with a port, or an address in its own right. The rule chosen and documented in the code: a trailing `:<digits>` is read as a port **only if** stripping it leaves an exact recognised loopback form. Otherwise the whole string is treated as the address. That keeps `2001:db8::1:9117` remote.

General IPv6 canonicalisation (case folding, partial zero-compression, mixed forms) is deliberately out of scope. This helper recognises loopback; it does not parse arbitrary IPv6.

## Verification

Suite 3896 to 3927 passed, 2 skipped and 5 xfailed unchanged, so the delta is exactly the 31 new tests. Full local gate green including E2E. Ruff clean.

Four mutations, each confirmed landed by hash, each red for the right reason, each restored by file copy and confirmed byte-identical:

1. IPv4 `$` anchor removed, broke the `127.0.0.1.evil.com` and `127.0.0.1:evil` guards
2. bracket handling disabled, broke `[::1]` and `[::1]:9117`
3. the "recognised form" qualifier dropped from the ambiguous-port rule, broke the bare loopback forms
4. exact match changed to substring containment, broke `2001:db8::1` and `2001:db8::1:9117`

Mutation 3 is worth recording: the prediction of which test would catch it was **wrong**. It was expected to break `2001:db8::1:9117` and instead broke the bare loopback cases. The guard was load bearing either way, but via a different path than predicted, which is the sort of thing worth reporting rather than quietly rewriting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
