### PR TITLE
fix(a11y): three WCAG 2.5.3 label-in-name failures the settings scan could not see

### DIFF
--- a/couchpotato/ui/templates/partials/settings/field_types.html
+++ b/couchpotato/ui/templates/partials/settings/field_types.html
@@ -210,9 +210,8 @@
         </button>
       </div>
     </template>
-    <button @click="addDir()" 
-            class="text-[11px] text-cp-accent hover:text-cp-accentHover transition-colors" 
-            aria-label="Add another folder">+ Add folder</button>
+    <button @click="addDir()"
+            class="text-[11px] text-cp-accent hover:text-cp-accentHover transition-colors">+ Add folder</button>
     <p x-show="buildDescription()" class="text-[10px] text-cp-muted mt-1.5 leading-relaxed" x-html="buildDescription()"></p>
     <template x-if="hasLearnMore()">
       <details class="mt-2 text-[10px]">
@@ -273,9 +272,9 @@
       </div>
     </template>
     
-    <button @click="addRow()" 
+    <button @click="addRow()"
             class="text-[11px] text-cp-accent hover:text-cp-accentHover transition-colors"
-            aria-label="Add another row">+ Add</button>
+            aria-label="Add row">+ Add</button>
     <p x-show="buildDescription()" class="text-[10px] text-cp-muted mt-1.5 leading-relaxed" x-html="buildDescription()"></p>
     <template x-if="hasLearnMore()">
       <details class="mt-2 text-[10px]">

--- a/couchpotato/ui/templates/partials/settings/modals.html
+++ b/couchpotato/ui/templates/partials/settings/modals.html
@@ -79,10 +79,10 @@
     <!-- Path bar -->
     <div class="px-4 py-2 border-b border-white/[0.04] bg-white/[0.02]">
       <div class="flex items-center gap-2 text-xs">
-        <button @click="loadDirectories(browserParent)" 
-                :disabled="browserIsRoot" 
+        <button @click="loadDirectories(browserParent)"
+                :disabled="browserIsRoot"
                 class="px-2 py-1 rounded bg-white/[0.04] text-cp-muted hover:text-cp-text hover:bg-white/[0.06] disabled:opacity-30 disabled:cursor-not-allowed"
-                aria-label="Go up one folder">
+                aria-label="Up one folder">
           ↑ Up
         </button>
         <span class="text-cp-muted font-mono truncate" x-text="browserPath" aria-label="Current path"></span>

--- a/tests/e2e/accessibility.a11y.spec.ts
+++ b/tests/e2e/accessibility.a11y.spec.ts
@@ -295,6 +295,86 @@ test.describe('Accessibility', () => {
   });
 
   /*
+   * WCAG-253: three controls in the settings panels fail (or defeat the
+   * point of) 2.5.3 Label in Name, which requires a control's accessible
+   * name to contain its visible text. None of them are caught by the sweep
+   * above, and that is NOT because axe-core's `label-content-name-mismatch`
+   * rule (enabled, tagged wcag21a/wcag253, selected by the tag list
+   * checkA11y uses) fails to recognise the pattern -- confirmed by scanning
+   * with that rule once each control is actually reached: it flags the
+   * clear failure (the "Add folder" button) the moment the Library tab's
+   * group is open. It never fires above because `currentGroups` -- what
+   * settings.html's x-for actually iterates -- holds only the ACTIVE tab's
+   * groups (scripts.html's `updateCurrentGroups()`); a tab you have not
+   * clicked contributes no DOM at all, not merely a hidden one. The Up
+   * button lives inside a `x-show="browserOpen"` dialog that starts closed,
+   * so it is hidden rather than absent, but axe skips display:none
+   * elements just the same. Either way: unreachable is the whole story for
+   * why these three shipped.
+   *
+   * It is NOT the whole story for whether the axe rule alone would keep
+   * them fixed. Once reached, the rule stays silent on the other two
+   * (measured: scanning the open Newznab row and the open browser dialog
+   * with `label-content-name-mismatch` returns zero violations for either).
+   * That is because the rule's bar is "the accessible name contains the
+   * visible word somewhere", and "Add another row" / "Go up one folder" both
+   * clear it -- "row"'s and "folder"'s case aside, "add" and (for row) "up"
+   * do appear. So this test does not lean on axe for two of the three: it
+   * pins the exact accessible name each control must resolve to, which is
+   * the only assertion that can fail again if a future edit reintroduces
+   * padding that keeps the substring but buries the lead word.
+   */
+  test('settings folder/row "Add" buttons and the folder browser "Up" button lead with their visible text (WCAG 2.5.3)', async ({ page }) => {
+    await page.goto('/settings/');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('tablist', { name: 'Settings categories' })).toBeVisible();
+
+    // --- Control 1: "+ Add folder" in the Movie Library directory list.
+    // Not on the default tab -- switch to it, then open the (enabler-gated,
+    // closed-by-default) group so the button actually renders.
+    await page.getByRole('tab', { name: 'Library' }).click();
+    await page.getByRole('heading', { name: 'Movie Library' }).click();
+
+    const addFolderBtn = page.locator('button', { hasText: '+ Add folder' });
+    await expect(addFolderBtn, 'the "+ Add folder" button never rendered -- Library tab/group did not open as expected').toBeVisible();
+    await expect.soft(addFolderBtn, 'control 1: accessible name for "+ Add folder" must lead with its own visible text, not a different phrase ("Add another folder")')
+      .toHaveAccessibleName('+ Add folder');
+
+    // --- Control 3: "↑ Up" inside the folder browser dialog. Reachable from
+    // control 1's row: adding a folder gives it a "Browse" button.
+    await addFolderBtn.click();
+    await page.getByRole('button', { name: 'Browse for folder 1' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog, 'the folder browser dialog never opened').toBeVisible();
+
+    const upBtn = dialog.locator('button', { hasText: '↑ Up' });
+    await expect.soft(upBtn, 'control 3: accessible name for "↑ Up" must be pinned to the fixed value, not "Go up one folder"')
+      .toHaveAccessibleName('Up one folder');
+    await page.keyboard.press('Escape');
+
+    // --- Control 2: "+ Add" in the Newznab combined host/key rows. Newznab
+    // defaults to enabled, so its group is open without an extra click --
+    // only the tab switch is needed. Scoped to the Newznab card specifically:
+    // torrentpotato's own combined "+ Add" button is also in the DOM on this
+    // tab (collapsed via x-show, not absent, since it defaults disabled), so
+    // an unscoped locator would hit Playwright's strict-mode multiple-match
+    // error rather than a clean pass/fail on the control this test targets.
+    await page.getByRole('tab', { name: 'Searchers' }).click();
+    const newznabCard = page.locator('.bg-cp-card', { has: page.getByRole('heading', { name: 'Newznab', exact: true }) });
+    await expect(newznabCard, 'the Newznab provider card never rendered on the Searchers tab').toBeVisible();
+
+    const addRowBtn = newznabCard.locator('button', { hasText: '+ Add' });
+    await expect(addRowBtn, 'the "+ Add" row button never rendered under Newznab').toBeVisible();
+    // A leading-word check ("starts with Add") is NOT a valid guard here:
+    // "Add another row" already starts with "Add", so it would pass today
+    // even though the padding still buries which control "row" is which
+    // when several look alike. The exact pin is the only assertion that
+    // actually distinguishes the fixed name from the current one.
+    await expect.soft(addRowBtn, 'control 2: accessible name for "+ Add" must be pinned to the fixed value, not "Add another row"')
+      .toHaveAccessibleName('Add row');
+  });
+
+  /*
    * T1.4b/AC-A11Y-10: every page-level checkA11y sweep above runs in the
    * LIGHT theme. With no localStorage seeded, base.html's own init leaves
    * `document.documentElement` without the `light` class removed --


### PR DESCRIPTION
Three controls in the live settings UI violate **WCAG 2.5.3 Label in Name**, which requires a control's accessible name to contain its visible text. This project's floor is WCAG 2.2 AA enforced as tests.

**The three labels are the symptom. The finding is why the scan never saw them, raised separately as #321.**

## The violations

| file | visible | accessible name | verdict |
|---|---|---|---|
| `field_types.html:213` | `+ Add folder` | "Add another folder" | **clear failure**, name does not contain "Add folder" |
| `field_types.html:276` | `+ Add` | "Add another row" | buries the visible word |
| `modals.html:82` | `↑ Up` | "Go up one folder" | buries the visible word |

The practical cost is speech input: a user saying "click Add folder" gets no match, because the name the engine matches against is a different phrase.

## Why an already-enabled axe rule missed all three

axe-core ships `label-content-name-mismatch`, tagged `wcag21a` and `wcag253`. It is **enabled**, and `accessibility.a11y.spec.ts:16` already scans `.withTags([... 'wcag21a' ...])`, which selects it. So the rule that should have caught these was running the whole time. Both explanations turned out to apply, and this was established by measurement rather than reading:

**1. Reachability, the primary cause.** `settings.html` renders groups from an `x-for` over `currentGroups`, which `scripts.html` `updateCurrentGroups()` sets to only the ACTIVE tab's groups. A tab nobody has clicked contributes **no DOM at all**, not hidden markup. The folder browser dialog is `display:none` until opened, which axe also skips. The existing settings accessibility test never switches tabs or opens a modal.

Measured: the rule against the settings page as loaded returns **0 violations**. After clicking through to the Library tab, it immediately flags the clear failure that had been sitting there.

**2. The rule's bar is lower than the criterion, for two of the three.** With the Newznab row and the browser dialog actually open, the same rule returned **zero violations for either**. It accepts the visible word appearing anywhere in the accessible name, so "Add another row" and "Go up one folder" both clear it.

So fixing reachability alone would have caught only control 1. Controls 2 and 3 need an explicit assertion regardless, which is why the new test pins exact accessible names with `toHaveAccessibleName` rather than leaning on axe.

## The fixes

- `field_types.html:213` — redundant `aria-label` removed; `+ Add folder` is already a good accessible name
- `field_types.html:276` — `"Add another row"` to `"Add row"`
- `modals.html:82` — `"Go up one folder"` to `"Up one folder"`

Extra context that helps a screen reader user is kept; only the burying is removed.

## Verification

The new test reaches all three controls, switching to the Library tab, expanding the group and opening the folder browser dialog, then asserts each accessible name with `expect.soft` so all three report independently in one run.

**RED confirmed against the unfixed markup:** all three assertions failed, each naming its control and the wrong string received.

**Mutation, replayed independently by me, not taken from the report:** reverting control 3 to `"Go up one folder"` makes the test fail naming that exact control and string. Restored by file copy, `modals.html` sha256 `a5b7076c...` identical before and after.

`accessibility.a11y.spec.ts` 24 tests green. `filters.spec.ts`, `navigation.spec.ts`, `interactions.e2e.spec.ts`, 61 tests green, and no existing test locates these controls by their old aria-label, checked before changing them. Python unit suite unaffected at 3898 passed. Full local gate green.

## Left alone deliberately

`modals.html:82`'s Up button uses a real `:disabled="browserIsRoot"` attribute on a focusable control, where this project's accessibility floor prefers `aria-disabled` plus a re-entry guard. Out of scope for a label fix; recorded in #321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
