### PR TITLE
fix(search): a provider could cost 27s of CPU per search, now 0.0001s

### DIFF
--- a/couchpotato/core/helpers/variable.py
+++ b/couchpotato/core/helpers/variable.py
@@ -441,41 +441,50 @@ def isSubFolder(sub_folder, base_folder):
     return False
 
 
-# A legitimate release name is well under this length (ordinary names
-# measured at 30-60 chars). re.findall retries from every start position,
-# so parsing a run of brackets below is quadratic in input length: measured
-# 124 ms for 8000 unclosed '[' and 496 ms for 16000. A provider controls
-# both the length of a candidate name and how many results one search
-# response contains (sceneScore() in score/main.py runs this per result),
-# so this cap bounds the parse cost regardless of what the provider sends.
-#
-# 1000 rather than something tighter, because the cap is a hard behavioural
-# cliff: a legitimate name whose only bracketed group sits past it silently
-# loses that candidate, and this function decides which releases match, so a
-# false negative is the worse failure. Measured worst case, 200 results of
-# nothing but open brackets: 0.037s at a 300 cap, 0.40s at 1000, 1.59s at
-# 2000. 1000 keeps the attack bounded to well under a second while putting the
-# cliff out of reach of any real release name, which measure 88 to 94 chars in
-# practice and are unusual past 250.
-BRACKETED_NAME_PARSE_LIMIT = 1000
+def _bracketedGroups(name):
+    r"""Every '[...]' group in *name*, left to right, non-overlapping.
+
+    A linear left-to-right scan, not a regex. `re.findall(r'[^[]*\[([^]]*)\]',
+    name)` retries from every start position, which makes it quadratic in
+    the length of a run of brackets (measured: 543 ms for 16000 unclosed
+    '[', 8626 ms for 64000) -- and a provider controls both the length of a
+    candidate name and how many results one search response contains
+    (sceneScore() in score/main.py runs this per result), so that cost was
+    reachable by a hostile response with no single name large enough to look
+    suspicious.
+
+    A capped-length version of the regex was tried first and rejected: the
+    cap does not just drop a candidate past the limit, it can pick the
+    WRONG one. For a name with a short bracket before the cap and the true
+    longest bracket after it, a capped parse returns the short group
+    silently, with no exception -- and that wrong group is what release
+    matching then scores against. This scan has no such failure mode: it
+    is linear regardless of input length, so nothing needs capping.
+    """
+    groups = []
+    i = 0
+    while True:
+        open_at = name.find('[', i)
+        if open_at == -1:
+            break
+        close_at = name.find(']', open_at + 1)
+        if close_at == -1:
+            break
+        groups.append(name[open_at + 1:close_at])
+        i = close_at + 1
+    return groups
 
 
 def longestBracketedName(name):
     """Return the longest '[...]' bracketed group in *name*, stripped.
 
-    Equivalent, for input at or under BRACKETED_NAME_PARSE_LIMIT, to:
+    Equivalent to
         max(re.findall(r'[^[]*\\[([^]]*)\\]', name), key = len).strip()
-    including raising when there is no bracketed group at all -- callers
-    are expected to catch that, same as with the expression this replaces.
-
-    Input longer than the limit is parsed from a capped prefix rather than
-    rejected outright, so a merely long (not pathological) name still
-    scores; only the cost of the parse is bounded, not the acceptance of
-    long input.
+    for every input, including raising when there is no bracketed group at
+    all -- callers are expected to catch that, same as with the expression
+    this replaces.
     """
-    if len(name) > BRACKETED_NAME_PARSE_LIMIT:
-        name = name[:BRACKETED_NAME_PARSE_LIMIT]
-    return max(re.findall(r'[^[]*\[([^]]*)\]', name), key = len).strip()
+    return max(_bracketedGroups(name), key = len).strip()
 
 
 # From SABNZBD

--- a/couchpotato/core/helpers/variable.py
+++ b/couchpotato/core/helpers/variable.py
@@ -448,7 +448,16 @@ def isSubFolder(sub_folder, base_folder):
 # both the length of a candidate name and how many results one search
 # response contains (sceneScore() in score/main.py runs this per result),
 # so this cap bounds the parse cost regardless of what the provider sends.
-BRACKETED_NAME_PARSE_LIMIT = 300
+#
+# 1000 rather than something tighter, because the cap is a hard behavioural
+# cliff: a legitimate name whose only bracketed group sits past it silently
+# loses that candidate, and this function decides which releases match, so a
+# false negative is the worse failure. Measured worst case, 200 results of
+# nothing but open brackets: 0.037s at a 300 cap, 0.40s at 1000, 1.59s at
+# 2000. 1000 keeps the attack bounded to well under a second while putting the
+# cliff out of reach of any real release name, which measure 88 to 94 chars in
+# practice and are unusual past 250.
+BRACKETED_NAME_PARSE_LIMIT = 1000
 
 
 def longestBracketedName(name):

--- a/couchpotato/core/helpers/variable.py
+++ b/couchpotato/core/helpers/variable.py
@@ -441,6 +441,34 @@ def isSubFolder(sub_folder, base_folder):
     return False
 
 
+# A legitimate release name is well under this length (ordinary names
+# measured at 30-60 chars). re.findall retries from every start position,
+# so parsing a run of brackets below is quadratic in input length: measured
+# 124 ms for 8000 unclosed '[' and 496 ms for 16000. A provider controls
+# both the length of a candidate name and how many results one search
+# response contains (sceneScore() in score/main.py runs this per result),
+# so this cap bounds the parse cost regardless of what the provider sends.
+BRACKETED_NAME_PARSE_LIMIT = 300
+
+
+def longestBracketedName(name):
+    """Return the longest '[...]' bracketed group in *name*, stripped.
+
+    Equivalent, for input at or under BRACKETED_NAME_PARSE_LIMIT, to:
+        max(re.findall(r'[^[]*\\[([^]]*)\\]', name), key = len).strip()
+    including raising when there is no bracketed group at all -- callers
+    are expected to catch that, same as with the expression this replaces.
+
+    Input longer than the limit is parsed from a capped prefix rather than
+    rejected outright, so a merely long (not pathological) name still
+    scores; only the cost of the parse is bounded, not the acceptance of
+    long input.
+    """
+    if len(name) > BRACKETED_NAME_PARSE_LIMIT:
+        name = name[:BRACKETED_NAME_PARSE_LIMIT]
+    return max(re.findall(r'[^[]*\[([^]]*)\]', name), key = len).strip()
+
+
 # From SABNZBD
 re_password = [re.compile(r'(.+){{([^{}]+)}}$'), re.compile(r'(.+)\s+password\s*=\s*(.+)$', re.I)]
 

--- a/couchpotato/core/media/_base/searcher/main.py
+++ b/couchpotato/core/media/_base/searcher/main.py
@@ -5,7 +5,7 @@ from couchpotato.api import addApiView
 from couchpotato.core.event import addEvent, fireEvent
 from couchpotato.core.event_names import MEDIA_TYPES, SCANNER_NAME_YEAR, SEARCHER_PROTOCOLS
 from couchpotato.core.helpers.encoding import simplifyString
-from couchpotato.core.helpers.variable import splitString, removeEmpty, removeDuplicate
+from couchpotato.core.helpers.variable import splitString, removeEmpty, removeDuplicate, longestBracketedName
 from couchpotato.core.helpers.protocol import sort_by_protocol_preference
 from couchpotato.core.logger import CPLog
 from couchpotato.core.media._base.searcher.base import SearcherBase
@@ -165,7 +165,7 @@ class Searcher(SearcherBase):
         except Exception: pass
 
         # Match longest name between []
-        try: check_names.append(max(re.findall(r'[^[]*\[([^]]*)\]', check_name), key = len).strip())
+        try: check_names.append(longestBracketedName(check_name))
         except Exception: pass
 
         for check_name in removeDuplicate(check_names):

--- a/couchpotato/core/plugins/score/scores.py
+++ b/couchpotato/core/plugins/score/scores.py
@@ -4,7 +4,7 @@ import traceback
 from couchpotato.core.event import fireEvent
 from couchpotato.core.event_names import SCANNER_NAME_YEAR
 from couchpotato.core.helpers.encoding import simplifyString
-from couchpotato.core.helpers.variable import tryInt
+from couchpotato.core.helpers.variable import longestBracketedName, tryInt
 from couchpotato.core.logger import CPLog
 from couchpotato.environment import Env
 
@@ -205,7 +205,7 @@ def sceneScore(nzb_name):
     except Exception: pass
 
     # Match longest name between []
-    try: check_names.append(max(re.findall(r'[^[]*\[([^]]*)\]', nzb_name), key = len).strip())
+    try: check_names.append(longestBracketedName(nzb_name))
     except Exception: pass
 
     for name in check_names:

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -462,8 +462,8 @@ def _old_bracketed_name_expression(name):
 
 class TestLongestBracketedNameEquivalence:
     """`longestBracketedName` must match the old inline expression exactly
-    for ordinary, at-or-under-the-cap input -- this is the searcher and the
-    scorer, so a behaviour change here changes which releases match.
+    for every input -- this is the searcher and the scorer, so a behaviour
+    change here changes which releases match.
     """
 
     ORDINARY_NAMES = [
@@ -478,6 +478,12 @@ class TestLongestBracketedNameEquivalence:
         'Trailing [ bracket has no closer',
         'Movie [empty][also empty][third]',
         '][][][',
+        # The decoy that broke a length-capped version of this parse: a
+        # short group early, the true longest group nearly 3000 chars in.
+        # A cap that truncates before the second group would silently
+        # return the short one instead of raising or finding the long one
+        # -- pinned here so that regression can never come back unnoticed.
+        '[a]' + 'X' * 1000 + '[' + 'B' * 2000 + ']',
     ]
 
     @pytest.mark.parametrize('name', ORDINARY_NAMES)
@@ -511,26 +517,46 @@ class TestLongestBracketedNameEquivalence:
         name = 'Movie [  padded group  ]'
         assert longestBracketedName(name) == 'padded group'
 
+    def test_a_short_early_group_does_not_hide_a_longer_later_one(self):
+        # The specific defect a length-capped version of this parse had: a
+        # short bracketed group early in the name, and the true longest
+        # group far enough in that a cap would have already truncated the
+        # string. The correct answer is the long group, found and picked
+        # over the short one, not a silent wrong answer and not a raise.
+        name = '[a]' + 'X' * 1000 + '[' + 'B' * 2000 + ']'
+        result = longestBracketedName(name)
+        assert result == 'B' * 2000
+        assert result != 'a'
 
-class TestLongestBracketedNamePerformanceCap:
+
+class TestLongestBracketedNamePerformance:
     """The DoS: re.findall retries from every start position, so a run of
     unclosed '[' is quadratic in length. Measured on this machine against
-    the OLD expression: 8000 unclosed brackets ~124 ms, 16000 ~496 ms, and
-    sceneScore() (score/main.py:66) runs this per search RESULT, so a
-    hostile provider controls both the length of each name and how many
-    results one response contains.
+    the OLD regex-based expression: 16000 unclosed brackets ~543 ms, 64000
+    ~8626 ms. sceneScore() (score/main.py:66) runs this per search RESULT,
+    so a hostile provider controls both the length of each name and how
+    many results one response contains.
+
+    The fix is a linear left-to-right scan (`_bracketedGroups`), not a
+    length cap -- a cap was tried and rejected because it can pick the
+    WRONG group rather than merely miss one (see
+    TestLongestBracketedNameEquivalence.test_a_short_early_group_does_not_hide_a_longer_later_one).
+    There is therefore no cliff to test at: the scan is linear at any
+    length, so this asserts a LARGER pathological input than the old
+    regex-based bound used, to show there is no ceiling being quietly
+    relied on.
     """
 
-    def test_pathological_input_is_bounded(self):
-        pathological = '[' * 16000
+    def test_pathological_input_is_fast_at_a_scale_the_old_code_could_not_finish(self):
+        pathological = '[' * 64000
 
         # Absolute, not relative-to-baseline: the property under test is
-        # "a 16000-char adversarial input does not cost anywhere near its
-        # unbounded ~496 ms", and the cap makes the cost independent of
-        # input length, so there is no meaningful baseline to be relative
-        # to. The margin is wide (50 ms, ~8x a cold/loaded run of the
-        # capped-prefix parse) so this does not flake on a busy machine --
-        # the unpatched code is ~10x slower than even this generous bound.
+        # "a 64000-char adversarial input costs nowhere near the old
+        # regex's ~8626 ms", and a linear scan's cost has no baseline worth
+        # being relative to. The margin is wide (50 ms against a measured
+        # ~0.006 ms) so this does not flake on a busy machine -- the old
+        # regex-based code is roughly a thousand times slower than even
+        # this generous bound.
         started = time.perf_counter()
         try:
             longestBracketedName(pathological)
@@ -539,15 +565,8 @@ class TestLongestBracketedNamePerformanceCap:
         elapsed = time.perf_counter() - started
 
         assert elapsed < 0.05, (
-            'longestBracketedName took %.4f s on a 16000-char adversarial '
-            'input; the input length must be capped before parsing so a '
-            'provider-supplied release name cannot make this quadratic-cost '
-            'regex run against tens of thousands of characters' % elapsed
+            'longestBracketedName took %.4f s on a 64000-char adversarial '
+            'input; the bracket parse must stay linear so a '
+            'provider-supplied release name cannot make it run quadratic '
+            'cost against tens of thousands of characters' % elapsed
         )
-
-    def test_capped_prefix_still_finds_a_bracket_within_the_limit(self):
-        # A merely long (not pathological) name with its bracket inside the
-        # capped prefix must still score -- capping bounds cost, it must not
-        # blanket-reject anything over the limit.
-        name = 'A' * 100 + ' [group] ' + 'B' * 500
-        assert longestBracketedName(name) == 'group'

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -4,12 +4,14 @@ Tests encoding helpers (toUnicode, toSafeString, simplifyString)
 and variable helpers (tryInt, tryFloat, getImdb, etc.).
 """
 import os
+import re
+import time
 from urllib.parse import urlparse
 
 import pytest
 
 from couchpotato.core.helpers.encoding import toUnicode, toSafeString, simplifyString
-from couchpotato.core.helpers.variable import removePyc, tryInt, getImdb, isLocalIP
+from couchpotato.core.helpers.variable import removePyc, tryInt, getImdb, isLocalIP, longestBracketedName
 
 pytestmark = pytest.mark.unit
 
@@ -447,3 +449,105 @@ class TestIsLocalIPMatchesHttpClientHostShape:
         host = self._host_from_url('http://example.com:8443/')
         assert host == 'example.com:8443'
         assert isLocalIP(host) is False
+
+
+def _old_bracketed_name_expression(name):
+    """The exact expression both call sites used before the fix.
+
+    Kept here, not imported, so the test pins the ORIGINAL behaviour rather
+    than whatever the two call sites happen to say today.
+    """
+    return max(re.findall(r'[^[]*\[([^]]*)\]', name), key = len).strip()
+
+
+class TestLongestBracketedNameEquivalence:
+    """`longestBracketedName` must match the old inline expression exactly
+    for ordinary, at-or-under-the-cap input -- this is the searcher and the
+    scorer, so a behaviour change here changes which releases match.
+    """
+
+    ORDINARY_NAMES = [
+        'Some.Movie.2024.1080p.BluRay.x264-GROUP',
+        'Some.Movie.2024.1080p.BluRay.x264-GROUP [PublicHD]',
+        'Movie [Nested [inner] outer] Name',
+        'Movie [first] and [a much longer second bracket group]',
+        'No brackets at all here',
+        '',
+        '[]',
+        'Leading ] bracket has no opener',
+        'Trailing [ bracket has no closer',
+        'Movie [empty][also empty][third]',
+        '][][][',
+    ]
+
+    @pytest.mark.parametrize('name', ORDINARY_NAMES)
+    def test_matches_old_expression_when_old_expression_succeeds(self, name):
+        try:
+            expected = _old_bracketed_name_expression(name)
+        except Exception:
+            pytest.skip('old expression raises for %r, covered separately' % name)
+
+        assert longestBracketedName(name) == expected
+
+    @pytest.mark.parametrize('name', ORDINARY_NAMES)
+    def test_raises_exactly_when_old_expression_raises(self, name):
+        old_raised = False
+        try:
+            _old_bracketed_name_expression(name)
+        except Exception:
+            old_raised = True
+
+        if not old_raised:
+            pytest.skip('old expression succeeds for %r, covered separately' % name)
+
+        with pytest.raises(Exception):
+            longestBracketedName(name)
+
+    def test_picks_the_longest_group_not_the_first_or_last(self):
+        name = 'Movie [x] middle [a much longer bracketed group here] end [y]'
+        assert longestBracketedName(name) == 'a much longer bracketed group here'
+
+    def test_strips_the_result(self):
+        name = 'Movie [  padded group  ]'
+        assert longestBracketedName(name) == 'padded group'
+
+
+class TestLongestBracketedNamePerformanceCap:
+    """The DoS: re.findall retries from every start position, so a run of
+    unclosed '[' is quadratic in length. Measured on this machine against
+    the OLD expression: 8000 unclosed brackets ~124 ms, 16000 ~496 ms, and
+    sceneScore() (score/main.py:66) runs this per search RESULT, so a
+    hostile provider controls both the length of each name and how many
+    results one response contains.
+    """
+
+    def test_pathological_input_is_bounded(self):
+        pathological = '[' * 16000
+
+        # Absolute, not relative-to-baseline: the property under test is
+        # "a 16000-char adversarial input does not cost anywhere near its
+        # unbounded ~496 ms", and the cap makes the cost independent of
+        # input length, so there is no meaningful baseline to be relative
+        # to. The margin is wide (50 ms, ~8x a cold/loaded run of the
+        # capped-prefix parse) so this does not flake on a busy machine --
+        # the unpatched code is ~10x slower than even this generous bound.
+        started = time.perf_counter()
+        try:
+            longestBracketedName(pathological)
+        except Exception:
+            pass
+        elapsed = time.perf_counter() - started
+
+        assert elapsed < 0.05, (
+            'longestBracketedName took %.4f s on a 16000-char adversarial '
+            'input; the input length must be capped before parsing so a '
+            'provider-supplied release name cannot make this quadratic-cost '
+            'regex run against tens of thousands of characters' % elapsed
+        )
+
+    def test_capped_prefix_still_finds_a_bracket_within_the_limit(self):
+        # A merely long (not pathological) name with its bracket inside the
+        # capped prefix must still score -- capping bounds cost, it must not
+        # blanket-reject anything over the limit.
+        name = 'A' * 100 + ' [group] ' + 'B' * 500
+        assert longestBracketedName(name) == 'group'


### PR DESCRIPTION
A hostile or compromised provider can burn tens of seconds of CPU per search using release names that look unremarkable individually.

## The problem, measured

Two files carry an identical block extracting candidate names from a provider-supplied release name:

```python
try: check_names.append(max(re.findall(r'[^[]*\[([^]]*)\]', name), key = len).strip())
except Exception: pass
```

`re.findall` retries from every start position, so on a run of open brackets the cost is quadratic. And `sceneScore()` runs **per candidate** (`score/main.py:66`), so a provider controls both the number of results and the length of each name.

| one search response | before |
|---|---|
| 100 results x 8000-char names | **13.95 s** |
| 200 results x 8000-char names | **27.50 s** |
| 100 results, ordinary names | 0.0000 s |

You do not need one enormous name. A hundred 8KB ones is more plausible and far less conspicuous.

## What was tried and rejected, because the rejected version is the interesting part

**First attempt: rewrite the pattern.** `r'\[([^]]*)\]'` is exactly equivalent, zero mismatches across 4013 strings, and **not faster**. The quadratic cost is findall's start-position retries, not the leading `[^[]*`.

**Second attempt: cap the input length.** This shipped in an earlier revision of this PR and **was wrong**. Review caught it. A cap does not merely lose a candidate past the limit, which is what both the implementer's caveat and my own analysis claimed. With a short bracket before the cap and the true longest bracket after it, it silently returns the **wrong, shorter** group:

```python
name = '[a]' + 'X'*1000 + '[' + 'B'*2000 + ']'
old(name)                   # -> 'B'*2000   the actual longest group
capped_version(name)        # -> 'a'        wrong, and no exception
```

I had already raised the cap from 300 to 1000 reasoning that its failure mode was a benign false negative. That reasoning was wrong, and a wrong candidate name feeds bad data into release matching, which is silent and worse at any cap value.

## The fix that shipped

No cap. A linear left-to-right scan, `_bracketedGroups()`, replacing the regex inside a single shared helper `longestBracketedName()` in `couchpotato/core/helpers/variable.py`, called from both sites so the duplicated expression cannot drift.

| | original | capped (rejected) | linear scan |
|---|---|---|---|
| 100 results x 8KB names | 13.95 s | 0.198 s | **0.0001 s** |
| 200 results x 64KB names | (untested, worse) | (capped) | **0.0003 s** |
| correctness | exact | **silently wrong** | exact |

Roughly 140,000x faster than the original **and** exactly correct, with no cliff to reason about.

## Verification

**Equivalence, independently by me as well as the implementer:** 20,000 fuzzed strings against the old expression, zero mismatches, comparing raises-vs-raises as well as values. The implementer separately fuzzed 30,000 including 5,000 decoy-shaped inputs with varying gap and tail lengths.

**The decoy case is pinned permanently**, both in the equivalence parametrisation and as an explicitly named test, since it is the specific defect the cap introduced.

**Mutation:** reverting to the capped regex fails the decoy tests, asserting `'a' == 'B'*2000` and naming the wrong short group. Restored by file copy, byte-identical by shasum, **with `__pycache__` cleared before re-running**, because a stale bytecode cache survived a byte-identical restore on this repo earlier today and produced a false green.

3957 passed, 14 skipped, 5 xfailed. Ruff clean. Full local gate green.

The cap commit is kept in history rather than amended away, so the record reads "tried and superseded" rather than pretending it never happened.

## Out of scope, found in the same block

`re.search(r'([\'"])[^\1]*\1', name)` is genuinely broken: inside a character class `\1` is the octal escape for `\x01`, not a backreference, so it spans from the first quote to the LAST matching one. `Movie "Title" 2024 "GROUP"` yields `"Title" 2024 "GROUP"` as a candidate title. Raised as #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
