### PR TITLE
fix(a11y): the folder browser claimed a listbox it never implemented

### DIFF
--- a/couchpotato/ui/templates/partials/settings/modals.html
+++ b/couchpotato/ui/templates/partials/settings/modals.html
@@ -90,7 +90,15 @@
     </div>
     
     <!-- Directory list -->
-    <div class="flex-1 overflow-y-auto min-h-[200px] max-h-[400px]" role="listbox" aria-label="Folders">
+    {#- No role="listbox" here, deliberately. It used to claim one and kept
+        none of the promise: no arrow-key navigation, no aria-selected, no
+        aria-activedescendant, and every folder its own tab stop. A screen
+        reader announced a listbox and a position within it while none of the
+        implied interaction worked, which is worse than plain buttons.
+        The entries below are ordinary buttons and already work with Tab and
+        Enter. If a real listbox is ever wanted, it needs the whole pattern,
+        not the role. See issue #314. -#}
+    <div class="flex-1 overflow-y-auto min-h-[200px] max-h-[400px]" aria-label="Folders">
       <!-- Loading -->
       <div x-show="browserLoading" class="flex items-center justify-center py-8" role="status">
         <svg aria-hidden="true" class="w-4 h-4 animate-spin text-cp-muted" viewBox="0 0 24 24" fill="none">
@@ -107,8 +115,7 @@
       
       <!-- Directory items -->
       <template x-for="dir in browserDirs" :key="dir">
-        <button @click="selectDirectory(dir)" 
-                role="option"
+        <button @click="selectDirectory(dir)"
                 class="w-full px-4 py-2 text-left text-xs hover:bg-white/[0.04] flex items-center gap-2 border-b border-white/[0.02]">
           <svg aria-hidden="true" class="w-4 h-4 text-cp-accent shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z"/>

--- a/couchpotato/ui/templates/partials/settings/modals.html
+++ b/couchpotato/ui/templates/partials/settings/modals.html
@@ -97,8 +97,14 @@
         implied interaction worked, which is worse than plain buttons.
         The entries below are ordinary buttons and already work with Tab and
         Enter. If a real listbox is ever wanted, it needs the whole pattern,
-        not the role. See issue #314. -#}
-    <div class="flex-1 overflow-y-auto min-h-[200px] max-h-[400px]" aria-label="Folders">
+        not the role. See issue #314.
+
+        No aria-label here either. With the role gone this div has generic
+        semantics, and aria-label is PROHIBITED on a generic element, so the
+        label was invalid ARIA that assistive technology may ignore. It was
+        also redundant: the dialog is already labelled by its own heading via
+        aria-labelledby="browser-title" at :52, which reads "Browse Folders". -#}
+    <div class="flex-1 overflow-y-auto min-h-[200px] max-h-[400px]">
       <!-- Loading -->
       <div x-show="browserLoading" class="flex items-center justify-center py-8" role="status">
         <svg aria-hidden="true" class="w-4 h-4 animate-spin text-cp-muted" viewBox="0 0 24 24" fill="none">

--- a/tests/e2e/accessibility.a11y.spec.ts
+++ b/tests/e2e/accessibility.a11y.spec.ts
@@ -324,6 +324,51 @@ test.describe('Accessibility', () => {
    * the only assertion that can fail again if a future edit reintroduces
    * padding that keeps the substring but buries the lead word.
    */
+  /**
+   * The folder browser announced itself as a listbox and kept none of the
+   * promise: no arrow-key navigation, no aria-selected, no
+   * aria-activedescendant, and every folder its own tab stop. A screen reader
+   * read out "listbox" and a position within it, and none of the interaction
+   * that implies worked.
+   *
+   * The fix was to REMOVE the ARIA rather than build the full listbox pattern.
+   * The entries are ordinary buttons and already work with Tab and Enter; no
+   * ARIA is better than ARIA that lies. See issue #314.
+   *
+   * This asserts the absence, because the defect was a promise the widget did
+   * not keep, and the only way that regresses is someone adding the roles back
+   * without the keyboard behaviour.
+   */
+  test('the folder browser does not claim to be a listbox it has not implemented (#314)', async ({ page }) => {
+    await page.goto('/settings/');
+    await expect(page.getByRole('tablist', { name: 'Settings categories' })).toBeVisible();
+    await page.getByRole('tab', { name: 'Library' }).click();
+    await page.getByRole('heading', { name: 'Movie Library' }).click();
+
+    const addFolderBtn = page.locator('button', { hasText: '+ Add folder' });
+    await expect(addFolderBtn, 'the "+ Add folder" button never rendered').toBeVisible();
+    await addFolderBtn.click();
+    await page.getByRole('button', { name: 'Browse for folder 1' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog, 'the folder browser dialog never opened').toBeVisible();
+
+    // If either role comes back, it must come back WITH arrow keys,
+    // aria-selected and a single tab stop. Until then, absence is correct.
+    await expect(dialog.locator('[role="listbox"]'),
+      'the directory list claims role="listbox" without implementing one: no arrow keys, no aria-selected, no aria-activedescendant, every entry its own tab stop')
+      .toHaveCount(0);
+    await expect(dialog.locator('[role="option"]'),
+      'directory entries claim role="option" without aria-selected, which tells a screen reader they are options of which none is ever selected')
+      .toHaveCount(0);
+
+    // And the entries must still be reachable as ordinary buttons, so the
+    // removal has not taken the keyboard path away with the false promise.
+    await expect(dialog.locator('button').first(),
+      'the dialog has no buttons at all, so removing the ARIA has broken the control rather than corrected it')
+      .toBeVisible();
+  });
+
   test('settings folder/row "Add" buttons and the folder browser "Up" button lead with their visible text (WCAG 2.5.3)', async ({ page }) => {
     await page.goto('/settings/');
     await page.waitForLoadState('networkidle');

--- a/tests/e2e/accessibility.a11y.spec.ts
+++ b/tests/e2e/accessibility.a11y.spec.ts
@@ -362,11 +362,23 @@ test.describe('Accessibility', () => {
       'directory entries claim role="option" without aria-selected, which tells a screen reader they are options of which none is ever selected')
       .toHaveCount(0);
 
-    // And the entries must still be reachable as ordinary buttons, so the
-    // removal has not taken the keyboard path away with the false promise.
-    await expect(dialog.locator('button').first(),
-      'the dialog has no buttons at all, so removing the ARIA has broken the control rather than corrected it')
+    // The DIRECTORY ENTRIES specifically must still be ordinary, reachable
+    // buttons, so removing the ARIA has not taken the keyboard path away along
+    // with the false promise.
+    //
+    // Scoped deliberately. An earlier version asserted on
+    // dialog.locator('button').first(), which resolves to the header's "Close
+    // folder browser" control. That button, and Up, Cancel and Select This
+    // Folder, all render unconditionally, so the assertion passed even if every
+    // directory entry vanished or stopped being a button. It could not fail for
+    // the thing it claimed to guard.
+    const entries = dialog.locator('button.w-full.px-4.py-2.text-left');
+    await expect(entries.first(),
+      'no directory ENTRY button is present, so the folder list is either empty or its entries are no longer buttons; removing the ARIA has broken the control rather than corrected it')
       .toBeVisible();
+    await expect(entries.first(),
+      'a directory entry is not keyboard focusable, so the keyboard path was removed along with the false listbox promise')
+      .toBeEnabled();
   });
 
   test('settings folder/row "Add" buttons and the folder browser "Up" button lead with their visible text (WCAG 2.5.3)', async ({ page }) => {


### PR DESCRIPTION
The folder browser told screen readers it was a listbox and implemented none of one. Closes the substantive half of #314.

## The defect

`partials/settings/modals.html` declared the directory list `role="listbox"` with `role="option"` on each entry, and kept none of that promise:

- no arrow-key navigation, in the markup or in any JS
- no `aria-selected` on the options
- no `aria-activedescendant`
- every folder its own tab stop

So a screen reader announced a listbox and a position within it, and none of the interaction that announcement implies worked. That is worse than plain buttons, because the announcement sets an expectation the widget cannot meet.

It was an oversight rather than a trade-off: `movie_detail.html:482` implements the equivalent pattern correctly a few files away, with real arrow-key handling and bound `aria-checked`.

## The fix: remove the ARIA, do not build the listbox

The scanner suggested `<datalist>` or `<select>`, which cannot work here: the entries carry an icon and are populated dynamically as the user walks the tree.

The entries are ordinary buttons and already work correctly with Tab and Enter. **No ARIA beats ARIA that lies.** If a real listbox is ever wanted it needs the whole pattern, and that should be justified by the interaction rather than by the role name already being present. A comment in the template says so, so the next person does not re-add the role alone.

## The test asserts an absence, deliberately

The defect was a promise the widget did not keep, so the guard is that the promise is not made. It also asserts the entries remain reachable as buttons, so removing the ARIA cannot silently take the keyboard path away along with the false claim.

**RED confirmed for the right reason, on the second attempt.** The first run failed with `ReferenceError: BASE is not defined`, a variable I had invented rather than the file's own navigation idiom. That is a false red: it proves nothing about the defect, and implementing against it would have produced a test that passed afterwards for the same irrelevant reason. Fixed, re-run, and the real failure is `Expected: 0, Received: 1` with the diagnostic message.

**Mutation:** restoring `role="listbox"` fails the test with the message explaining why the role is wrong, not merely a count mismatch. Restored by file copy, byte-identical by shasum.

25 of 25 accessibility tests pass. Full local gate green.

## Correction to #314's scope, carried here for the record

That issue also claimed this modal has no keyboard escape and no focus trap. **It has both**: `modals.html:53` closes on Escape, and `:55-66` is a working focus trap that cycles and handles shift-tab at the first element.

That claim came from a summary carried into the session and was repeated three times, including into two GitHub issues, without ever opening the file. Corrected on #314 and #321. Worth stating plainly because it is a different failure from the others in this session: not checking badly, but not checking at all, because the claim arrived already written down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc
