### PR TITLE
ci(review): pin claude-code-action, which @v1 moved out from under us

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -54,7 +54,24 @@ jobs:
         # CLAUDE_CODE_OAUTH_TOKEN as a separate Dependabot secret isn't wanted.
         # Moved here from the job's `if:` -- see the note above `steps:`.
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
-        uses: anthropics/claude-code-action@v1
+        # PINNED, deliberately, not tracking @v1.
+        #
+        # v1.0.218 (published 2026-09-08T20:39Z) broke this job: the SDK
+        # aborts with "Claude Code native binary not found at
+        # /home/runner/.local/bin/claude", so the action fails before it
+        # reviews anything. Nothing in this repository changed; @v1 simply
+        # moved under us.
+        #
+        # Evidence for 217 being the last good one: five runs between 02:14
+        # and 06:25 on 2026-09-08 succeeded, all against v1.0.217 (published
+        # 09-06). The first run after 218 landed, at 22:24, failed, and
+        # failed again on a re-run.
+        #
+        # This job is a REQUIRED check on master, so an upstream release can
+        # block every merge in the repository with no warning and no change
+        # here. That is the real reason for the pin rather than this one
+        # regression. Bump it deliberately, when someone can watch the run.
+        uses: anthropics/claude-code-action@v1.0.217
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Keep one updating summary comment per PR (visible verdict even when


### PR DESCRIPTION
## What broke

`claude-review` fails on every PR with:

```
ReferenceError: Claude Code native binary not found at /home/runner/.local/bin/claude
```

The action aborts before reviewing anything. Nothing in this repository changed.

## Evidence

| Event | Time (UTC) |
|---|---|
| Five `claude-review` runs, all successful, all on v1.0.217 | 2026-09-08 02:14 to 06:25 |
| `claude-code-action` **v1.0.218** published | 2026-09-08 20:39 |
| First run after that, failed | 2026-09-08 22:24 |
| Re-run, failed identically | 2026-09-08 22:34 |

v1.0.217 was published 09-06, so every one of those five successes ran against it. The workflow tracked the floating `@v1` tag and picked up 218 automatically.

## Why pin rather than wait

The regression is the trigger, not the reason.

`claude-review` is a **required** check on master, and it is the only required check that reads semantics rather than running a fixed command. Tracking a floating tag means an upstream release can block every merge in the repository, with no warning and no change on our side. That is exactly what happened, and it will happen again.

Bump it deliberately, when someone can watch the run.

## Why this one needs `--admin`

The action refuses to act when this workflow file differs from the copy on the default branch. That is a good rule, and it makes it structurally impossible for the reviewer to review its own repair. The workflow already anticipates this and posts a message saying the reviewer never executed.

Every other check on this PR is green. This is a one-line change to a version string, with the evidence above recorded in the file itself.

The owner agreed to the admin merge for this PR specifically, on the basis that it unblocks the reviewer so #334 can then go through it normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc