### PR TITLE
deps: correct the stevedore note, whose reason expired a month ago

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,9 @@ bencodepy==0.9.5
 subliminal==2.7.1
 babelfish==0.6.1
 dogpile.cache==1.5.0
-stevedore==5.9.1  # 5.9.0 dropped Python 3.10 (CP supports 3.10+)
+stevedore==5.9.1  # was held at 5.8.0 because 5.9.0 requires >=3.11; that
+                  # hold expired when the 3.10-3.13 CI legs were dropped
+                  # on 2026-08-09 and prod moved to python:3.14-alpine
 pysubs2==1.9.0
 pymediainfo==7.0.1
 knowit==0.5.11


### PR DESCRIPTION
The stevedore pin carried `# 5.9.0 dropped Python 3.10 (CP supports 3.10+)`, and Dependabot's bump (#339) carried that comment through unchanged. So master briefly said 5.9.1 is acceptable because we support a Python version it does not.

That stopped being true on 2026-08-09, when the 3.10 to 3.13 CI legs were dropped on measurement and the matrix was pinned to exactly the Dockerfile version, enforced by `test_ci_matrix_tests_exactly_the_dockerfile_version`. stevedore 5.9.1 requires `>=3.11`; prod runs `python:3.14-alpine`. The hold had already expired, which is why #339 was correct to merge.

The point of recording why a dependency is held is that someone can tell when the reason stops applying. That only works if the note gets corrected when it does, and a bot bumping the version will not do it.

`pip check`: `No broken requirements found.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ss6TA5seR8ykyJfe3itaSc